### PR TITLE
Commenting out methods on ITypeComp and ITypeInfo since they are blocking the .NET Native Compiler

### DIFF
--- a/sources/Interop/Windows/um/oaidl/ITypeComp.cs
+++ b/sources/Interop/Windows/um/oaidl/ITypeComp.cs
@@ -109,49 +109,49 @@ namespace TerraFX.Interop
         #endregion
 
         #region Methods
-        [return: NativeTypeName("HRESULT")]
-        public int Bind(
-            [In, NativeTypeName("LPOLESTR")] char* szName,
-            [In, NativeTypeName("ULONG")] uint lHashVal,
-            [In, NativeTypeName("WORD")] ushort wFlags,
-            [Out] ITypeInfo** ppTInfo,
-            [Out] DESCKIND* pDescKind,
-            [Out] BINDPTR* pBindPtr
-        )
-        {
-            fixed (ITypeComp* This = &this)
-            {
-                return MarshalFunction<_Bind>(lpVtbl->Bind)(
-                    This,
-                    szName,
-                    lHashVal,
-                    wFlags,
-                    ppTInfo,
-                    pDescKind,
-                    pBindPtr
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int Bind(
+        //     [In, NativeTypeName("LPOLESTR")] char* szName,
+        //     [In, NativeTypeName("ULONG")] uint lHashVal,
+        //     [In, NativeTypeName("WORD")] ushort wFlags,
+        //     [Out] ITypeInfo** ppTInfo,
+        //     [Out] DESCKIND* pDescKind,
+        //     [Out] BINDPTR* pBindPtr
+        // )
+        // {
+        //     fixed (ITypeComp* This = &this)
+        //     {
+        //         return MarshalFunction<_Bind>(lpVtbl->Bind)(
+        //             This,
+        //             szName,
+        //             lHashVal,
+        //             wFlags,
+        //             ppTInfo,
+        //             pDescKind,
+        //             pBindPtr
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int BindType(
-            [In, NativeTypeName("LPOLESTR")] char* szName,
-            [In, NativeTypeName("ULONG")] uint lHashVal,
-            [Out] ITypeInfo** ppTInfo,
-            [Out] ITypeComp** ppTComp
-        )
-        {
-            fixed (ITypeComp* This = &this)
-            {
-                return MarshalFunction<_BindType>(lpVtbl->BindType)(
-                    This,
-                    szName,
-                    lHashVal,
-                    ppTInfo,
-                    ppTComp
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int BindType(
+        //     [In, NativeTypeName("LPOLESTR")] char* szName,
+        //     [In, NativeTypeName("ULONG")] uint lHashVal,
+        //     [Out] ITypeInfo** ppTInfo,
+        //     [Out] ITypeComp** ppTComp
+        // )
+        // {
+        //     fixed (ITypeComp* This = &this)
+        //     {
+        //         return MarshalFunction<_BindType>(lpVtbl->BindType)(
+        //             This,
+        //             szName,
+        //             lHashVal,
+        //             ppTInfo,
+        //             ppTComp
+        //         );
+        //     }
+        // }
         #endregion
 
         #region Structs

--- a/sources/Interop/Windows/um/oaidl/ITypeInfo.cs
+++ b/sources/Interop/Windows/um/oaidl/ITypeInfo.cs
@@ -264,328 +264,328 @@ namespace TerraFX.Interop
         #endregion
 
         #region Methods
-        [return: NativeTypeName("HRESULT")]
-        public int GetTypeAttr(
-            [Out] TYPEATTR** ppTypeAttr
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetTypeAttr>(lpVtbl->GetTypeAttr)(
-                    This,
-                    ppTypeAttr
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetTypeAttr(
+        //     [Out] TYPEATTR** ppTypeAttr
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetTypeAttr>(lpVtbl->GetTypeAttr)(
+        //             This,
+        //             ppTypeAttr
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetTypeComp(
-            [Out] ITypeComp** ppTComp = null
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetTypeComp>(lpVtbl->GetTypeComp)(
-                    This,
-                    ppTComp
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetTypeComp(
+        //     [Out] ITypeComp** ppTComp = null
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetTypeComp>(lpVtbl->GetTypeComp)(
+        //             This,
+        //             ppTComp
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetFuncDesc(
-            [In, NativeTypeName("UINT")] uint index,
-            [Out] FUNCDESC** ppFuncDesc
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetFuncDesc>(lpVtbl->GetFuncDesc)(
-                    This,
-                    index,
-                    ppFuncDesc
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetFuncDesc(
+        //     [In, NativeTypeName("UINT")] uint index,
+        //     [Out] FUNCDESC** ppFuncDesc
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetFuncDesc>(lpVtbl->GetFuncDesc)(
+        //             This,
+        //             index,
+        //             ppFuncDesc
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetVarDesc(
-            [In, NativeTypeName("UINT")] uint index,
-            [Out] VARDESC** ppVarDesc
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetVarDesc>(lpVtbl->GetVarDesc)(
-                    This,
-                    index,
-                    ppVarDesc
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetVarDesc(
+        //     [In, NativeTypeName("UINT")] uint index,
+        //     [Out] VARDESC** ppVarDesc
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetVarDesc>(lpVtbl->GetVarDesc)(
+        //             This,
+        //             index,
+        //             ppVarDesc
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetNames(
-            [In, NativeTypeName("MEMBERID")] int memid,
-            [Out, NativeTypeName("BSTR[]")] char** rgBstrNames,
-            [In, NativeTypeName("UINT")] uint cMaxNames,
-            [Out, NativeTypeName("UINT")] uint* pcNames
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetNames>(lpVtbl->GetNames)(
-                    This,
-                    memid,
-                    rgBstrNames,
-                    cMaxNames,
-                    pcNames
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetNames(
+        //     [In, NativeTypeName("MEMBERID")] int memid,
+        //     [Out, NativeTypeName("BSTR[]")] char** rgBstrNames,
+        //     [In, NativeTypeName("UINT")] uint cMaxNames,
+        //     [Out, NativeTypeName("UINT")] uint* pcNames
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetNames>(lpVtbl->GetNames)(
+        //             This,
+        //             memid,
+        //             rgBstrNames,
+        //             cMaxNames,
+        //             pcNames
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetRefTypeOfImplType(
-            [In, NativeTypeName("UINT")] uint index,
-            [Out, NativeTypeName("HREFTYPE")] uint* pRefType
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetRefTypeOfImplType>(lpVtbl->GetRefTypeOfImplType)(
-                    This,
-                    index,
-                    pRefType
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetRefTypeOfImplType(
+        //     [In, NativeTypeName("UINT")] uint index,
+        //     [Out, NativeTypeName("HREFTYPE")] uint* pRefType
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetRefTypeOfImplType>(lpVtbl->GetRefTypeOfImplType)(
+        //             This,
+        //             index,
+        //             pRefType
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetImplTypeFlags(
-            [In, NativeTypeName("UINT")] uint index,
-            [Out, NativeTypeName("INT")] int* pImplTypeFlags
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetImplTypeFlags>(lpVtbl->GetImplTypeFlags)(
-                    This,
-                    index,
-                    pImplTypeFlags
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetImplTypeFlags(
+        //     [In, NativeTypeName("UINT")] uint index,
+        //     [Out, NativeTypeName("INT")] int* pImplTypeFlags
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetImplTypeFlags>(lpVtbl->GetImplTypeFlags)(
+        //             This,
+        //             index,
+        //             pImplTypeFlags
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetIDsOfNames(
-            [In, NativeTypeName("LPOLESTR[]")] char** rgszNames,
-            [In, NativeTypeName("UINT")] uint cNames,
-            [Out, NativeTypeName("MEMBERID")] int* pMemId
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetIDsOfNames>(lpVtbl->GetIDsOfNames)(
-                    This,
-                    rgszNames,
-                    cNames,
-                    pMemId
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetIDsOfNames(
+        //     [In, NativeTypeName("LPOLESTR[]")] char** rgszNames,
+        //     [In, NativeTypeName("UINT")] uint cNames,
+        //     [Out, NativeTypeName("MEMBERID")] int* pMemId
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetIDsOfNames>(lpVtbl->GetIDsOfNames)(
+        //             This,
+        //             rgszNames,
+        //             cNames,
+        //             pMemId
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int Invoke(
-            [In, NativeTypeName("PVOID")] void* pvInstance,
-            [In, NativeTypeName("MEMBERID")] int memid,
-            [In, NativeTypeName("WORD")] ushort wFlags,
-            [In, Out] DISPPARAMS* pDispParams,
-            [Out] VARIANT* pVarResult,
-            [Out] EXCEPINFO* pExcepInfo,
-            [Out, NativeTypeName("UINT")] uint* puArgErr
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_Invoke>(lpVtbl->Invoke)(
-                    This,
-                    pvInstance,
-                    memid,
-                    wFlags,
-                    pDispParams,
-                    pVarResult,
-                    pExcepInfo,
-                    puArgErr
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int Invoke(
+        //     [In, NativeTypeName("PVOID")] void* pvInstance,
+        //     [In, NativeTypeName("MEMBERID")] int memid,
+        //     [In, NativeTypeName("WORD")] ushort wFlags,
+        //     [In, Out] DISPPARAMS* pDispParams,
+        //     [Out] VARIANT* pVarResult,
+        //     [Out] EXCEPINFO* pExcepInfo,
+        //     [Out, NativeTypeName("UINT")] uint* puArgErr
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_Invoke>(lpVtbl->Invoke)(
+        //             This,
+        //             pvInstance,
+        //             memid,
+        //             wFlags,
+        //             pDispParams,
+        //             pVarResult,
+        //             pExcepInfo,
+        //             puArgErr
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetDocumentation(
-            [In, NativeTypeName("MEMBERID")] int memid,
-            [Out, Optional, NativeTypeName("BSTR")] char** pBstrName,
-            [Out, Optional, NativeTypeName("BSTR")] char** pBstrDocString,
-            [Out, NativeTypeName("DWORD")] uint* pdwHelpContext,
-            [Out, NativeTypeName("BSTR")] char** pBstrHelpFile = null
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetDocumentation>(lpVtbl->GetDocumentation)(
-                    This,
-                    memid,
-                    pBstrName,
-                    pBstrDocString,
-                    pdwHelpContext,
-                    pBstrHelpFile
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetDocumentation(
+        //     [In, NativeTypeName("MEMBERID")] int memid,
+        //     [Out, Optional, NativeTypeName("BSTR")] char** pBstrName,
+        //     [Out, Optional, NativeTypeName("BSTR")] char** pBstrDocString,
+        //     [Out, NativeTypeName("DWORD")] uint* pdwHelpContext,
+        //     [Out, NativeTypeName("BSTR")] char** pBstrHelpFile = null
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetDocumentation>(lpVtbl->GetDocumentation)(
+        //             This,
+        //             memid,
+        //             pBstrName,
+        //             pBstrDocString,
+        //             pdwHelpContext,
+        //             pBstrHelpFile
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetDllEntry(
-            [In, NativeTypeName("MEMBERID")] int memid,
-            [In] INVOKEKIND invKind,
-            [Out, Optional, NativeTypeName("BSTR")] char** pBstrDllName,
-            [Out, Optional, NativeTypeName("BSTR")] char** pBstrName,
-            [Out, NativeTypeName("WORD")] ushort* pwOrdinal
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetDllEntry>(lpVtbl->GetDllEntry)(
-                    This,
-                    memid,
-                    invKind,
-                    pBstrDllName,
-                    pBstrName,
-                    pwOrdinal
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetDllEntry(
+        //     [In, NativeTypeName("MEMBERID")] int memid,
+        //     [In] INVOKEKIND invKind,
+        //     [Out, Optional, NativeTypeName("BSTR")] char** pBstrDllName,
+        //     [Out, Optional, NativeTypeName("BSTR")] char** pBstrName,
+        //     [Out, NativeTypeName("WORD")] ushort* pwOrdinal
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetDllEntry>(lpVtbl->GetDllEntry)(
+        //             This,
+        //             memid,
+        //             invKind,
+        //             pBstrDllName,
+        //             pBstrName,
+        //             pwOrdinal
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetRefTypeInfo(
-            [In, NativeTypeName("HREFTYPE")] uint hRefType,
-            [Out] ITypeInfo** ppTInfo = null
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetRefTypeInfo>(lpVtbl->GetRefTypeInfo)(
-                    This,
-                    hRefType,
-                    ppTInfo
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetRefTypeInfo(
+        //     [In, NativeTypeName("HREFTYPE")] uint hRefType,
+        //     [Out] ITypeInfo** ppTInfo = null
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetRefTypeInfo>(lpVtbl->GetRefTypeInfo)(
+        //             This,
+        //             hRefType,
+        //             ppTInfo
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int AddressOfMember(
-            [In, NativeTypeName("MEMBERID")] int memid,
-            [In] INVOKEKIND invKind,
-            [Out, NativeTypeName("PVOID")] void** ppv
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_AddressOfMember>(lpVtbl->AddressOfMember)(
-                    This,
-                    memid,
-                    invKind,
-                    ppv
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int AddressOfMember(
+        //     [In, NativeTypeName("MEMBERID")] int memid,
+        //     [In] INVOKEKIND invKind,
+        //     [Out, NativeTypeName("PVOID")] void** ppv
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_AddressOfMember>(lpVtbl->AddressOfMember)(
+        //             This,
+        //             memid,
+        //             invKind,
+        //             ppv
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int CreateInstance(
-            [In] IUnknown* pUnkOuter,
-            [In, NativeTypeName("REFIID")] Guid* riid,
-            [Out, NativeTypeName("PVOID")] void** ppvObj
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_CreateInstance>(lpVtbl->CreateInstance)(
-                    This,
-                    pUnkOuter,
-                    riid,
-                    ppvObj
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int CreateInstance(
+        //     [In] IUnknown* pUnkOuter,
+        //     [In, NativeTypeName("REFIID")] Guid* riid,
+        //     [Out, NativeTypeName("PVOID")] void** ppvObj
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_CreateInstance>(lpVtbl->CreateInstance)(
+        //             This,
+        //             pUnkOuter,
+        //             riid,
+        //             ppvObj
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetMops(
-            [In, NativeTypeName("MEMBERID")] int memid,
-            [Out, NativeTypeName("BSTR")] char** pBstrMops = null
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetMops>(lpVtbl->GetMops)(
-                    This,
-                    memid,
-                    pBstrMops
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetMops(
+        //     [In, NativeTypeName("MEMBERID")] int memid,
+        //     [Out, NativeTypeName("BSTR")] char** pBstrMops = null
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetMops>(lpVtbl->GetMops)(
+        //             This,
+        //             memid,
+        //             pBstrMops
+        //         );
+        //     }
+        // }
 
-        [return: NativeTypeName("HRESULT")]
-        public int GetContainingTypeLib(
-            [Out] ITypeLib** ppTLib,
-            [Out, NativeTypeName("UINT")] uint* pIndex
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                return MarshalFunction<_GetContainingTypeLib>(lpVtbl->GetContainingTypeLib)(
-                    This,
-                    ppTLib,
-                    pIndex
-                );
-            }
-        }
+        // [return: NativeTypeName("HRESULT")]
+        // public int GetContainingTypeLib(
+        //     [Out] ITypeLib** ppTLib,
+        //     [Out, NativeTypeName("UINT")] uint* pIndex
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         return MarshalFunction<_GetContainingTypeLib>(lpVtbl->GetContainingTypeLib)(
+        //             This,
+        //             ppTLib,
+        //             pIndex
+        //         );
+        //     }
+        // }
 
-        public void ReleaseTypeAttr(
-            [In] TYPEATTR* pTypeAttr
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                MarshalFunction<_ReleaseTypeAttr>(lpVtbl->ReleaseTypeAttr)(
-                    This,
-                    pTypeAttr
-                );
-            }
-        }
+        // public void ReleaseTypeAttr(
+        //     [In] TYPEATTR* pTypeAttr
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         MarshalFunction<_ReleaseTypeAttr>(lpVtbl->ReleaseTypeAttr)(
+        //             This,
+        //             pTypeAttr
+        //         );
+        //     }
+        // }
 
-        public void ReleaseFuncDesc(
-            [In] FUNCDESC* pFuncDesc
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                MarshalFunction<_ReleaseFuncDesc>(lpVtbl->ReleaseFuncDesc)(
-                    This,
-                    pFuncDesc
-                );
-            }
-        }
+        // public void ReleaseFuncDesc(
+        //     [In] FUNCDESC* pFuncDesc
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         MarshalFunction<_ReleaseFuncDesc>(lpVtbl->ReleaseFuncDesc)(
+        //             This,
+        //             pFuncDesc
+        //         );
+        //     }
+        // }
 
-        public void ReleaseVarDesc(
-            [In] VARDESC* pVarDesc
-        )
-        {
-            fixed (ITypeInfo* This = &this)
-            {
-                MarshalFunction<_ReleaseVarDesc>(lpVtbl->ReleaseVarDesc)(
-                    This,
-                    pVarDesc
-                );
-            }
-        }
+        // public void ReleaseVarDesc(
+        //     [In] VARDESC* pVarDesc
+        // )
+        // {
+        //     fixed (ITypeInfo* This = &this)
+        //     {
+        //         MarshalFunction<_ReleaseVarDesc>(lpVtbl->ReleaseVarDesc)(
+        //             This,
+        //             pVarDesc
+        //         );
+        //     }
+        // }
         #endregion
 
         #region Structs


### PR DESCRIPTION
These methods are highly unlikely to be used and are currently just blocking .NET Native from working. The issue should still be investigated and fixed later.