### PR TITLE
Upgrading projects to netcoreapp3.1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,9 +19,9 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.3.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190828-03" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.4.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>

--- a/samples/DirectX/TerraFX.Samples.DirectX.csproj
+++ b/samples/DirectX/TerraFX.Samples.DirectX.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -120,7 +120,7 @@ try {
     $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
     Create-Directory -Path $DotNetInstallDirectory
 
-    & $DotNetInstallScript -Channel 3.0 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
+    & $DotNetInstallScript -Channel 3.1 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
     & $DotNetInstallScript -Channel 2.1 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture -Runtime dotnet
 
     $env:PATH="$DotNetInstallDirectory;$env:PATH"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,7 +204,7 @@ if [[ ! -z "$architecture" ]]; then
   DotNetInstallDirectory="$ArtifactsDir/dotnet"
   CreateDirectory "$DotNetInstallDirectory"
 
-  . "$DotNetInstallScript" --channel 3.0 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
+  . "$DotNetInstallScript" --channel 3.1 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
   . "$DotNetInstallScript" --channel 2.1 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture" --runtime dotnet
 
   PATH="$DotNetInstallDirectory:$PATH:"

--- a/sources/Interop/D2D1/TerraFX.Interop.D2D1.csproj
+++ b/sources/Interop/D2D1/TerraFX.Interop.D2D1.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/D3D11/TerraFX.Interop.D3D11.csproj
+++ b/sources/Interop/D3D11/TerraFX.Interop.D3D11.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/D3D12/TerraFX.Interop.D3D12.csproj
+++ b/sources/Interop/D3D12/TerraFX.Interop.D3D12.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/D3DCommon/TerraFX.Interop.D3DCommon.csproj
+++ b/sources/Interop/D3DCommon/TerraFX.Interop.D3DCommon.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/sources/Interop/D3DCompiler/TerraFX.Interop.D3DCompiler.csproj
+++ b/sources/Interop/D3DCompiler/TerraFX.Interop.D3DCompiler.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DCommon/TerraFX.Interop.DCommon.csproj
+++ b/sources/Interop/DCommon/TerraFX.Interop.DCommon.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DWrite/TerraFX.Interop.DWrite.csproj
+++ b/sources/Interop/DWrite/TerraFX.Interop.DWrite.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DXGI/TerraFX.Interop.DXGI.csproj
+++ b/sources/Interop/DXGI/TerraFX.Interop.DXGI.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.csproj
+++ b/sources/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/sources/Interop/Gdi32/TerraFX.Interop.Gdi32.csproj
+++ b/sources/Interop/Gdi32/TerraFX.Interop.Gdi32.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/Kernel32/TerraFX.Interop.Kernel32.csproj
+++ b/sources/Interop/Kernel32/TerraFX.Interop.Kernel32.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/User32/TerraFX.Interop.User32.csproj
+++ b/sources/Interop/User32/TerraFX.Interop.User32.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/WinCodec/TerraFX.Interop.WinCodec.csproj
+++ b/sources/Interop/WinCodec/TerraFX.Interop.WinCodec.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/Windows/TerraFX.Interop.Windows.csproj
+++ b/sources/Interop/Windows/TerraFX.Interop.Windows.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tests/Interop/D2D1/TerraFX.Interop.D2D1.UnitTests.csproj
+++ b/tests/Interop/D2D1/TerraFX.Interop.D2D1.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/D3D12/TerraFX.Interop.D3D12.UnitTests.csproj
+++ b/tests/Interop/D3D12/TerraFX.Interop.D3D12.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/D3DCommon/TerraFX.Interop.D3DCommon.UnitTests.csproj
+++ b/tests/Interop/D3DCommon/TerraFX.Interop.D3DCommon.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DCommon/TerraFX.Interop.DCommon.UnitTests.csproj
+++ b/tests/Interop/DCommon/TerraFX.Interop.DCommon.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DWrite/TerraFX.Interop.DWrite.UnitTests.csproj
+++ b/tests/Interop/DWrite/TerraFX.Interop.DWrite.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DXGI/TerraFX.Interop.DXGI.UnitTests.csproj
+++ b/tests/Interop/DXGI/TerraFX.Interop.DXGI.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.UnitTests.csproj
+++ b/tests/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/Gdi32/TerraFX.Interop.Gdi32.UnitTests.csproj
+++ b/tests/Interop/Gdi32/TerraFX.Interop.Gdi32.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/User32/TerraFX.Interop.User32.UnitTests.csproj
+++ b/tests/Interop/User32/TerraFX.Interop.User32.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/WinCodec/TerraFX.Interop.WinCodec.UnitTests.csproj
+++ b/tests/Interop/WinCodec/TerraFX.Interop.WinCodec.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/Windows/TerraFX.Interop.Windows.UnitTests.csproj
+++ b/tests/Interop/Windows/TerraFX.Interop.Windows.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This upgrades dependencies to their latest stable version and moves the projects to the new .NET Core LTS (3.1).