### PR TITLE
Generation file and wrapper type cleanup

### DIFF
--- a/generation/shared/dxgi/generate.rsp
+++ b/generation/shared/dxgi/generate.rsp
@@ -43,8 +43,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgi1_2/generate.rsp
+++ b/generation/shared/dxgi1_2/generate.rsp
@@ -34,8 +34,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgi1_3/generate.rsp
+++ b/generation/shared/dxgi1_3/generate.rsp
@@ -31,8 +31,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgi1_4/generate.rsp
+++ b/generation/shared/dxgi1_4/generate.rsp
@@ -23,8 +23,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgi1_5/generate.rsp
+++ b/generation/shared/dxgi1_5/generate.rsp
@@ -25,8 +25,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgi1_6/generate.rsp
+++ b/generation/shared/dxgi1_6/generate.rsp
@@ -30,8 +30,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgicommon/generate.rsp
+++ b/generation/shared/dxgicommon/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgiformat/generate.rsp
+++ b/generation/shared/dxgiformat/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/shared/dxgitype/generate.rsp
+++ b/generation/shared/dxgitype/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-DXGI
 --methodClassName
 DXGI
 --namespace

--- a/generation/um/d2d1/generate.rsp
+++ b/generation/um/d2d1/generate.rsp
@@ -113,8 +113,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1_1/generate.rsp
+++ b/generation/um/d2d1_1/generate.rsp
@@ -116,8 +116,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1_2/generate.rsp
+++ b/generation/um/d2d1_2/generate.rsp
@@ -59,8 +59,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1_3/generate.rsp
+++ b/generation/um/d2d1_3/generate.rsp
@@ -107,8 +107,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1effectauthor/generate.rsp
+++ b/generation/um/d2d1effectauthor/generate.rsp
@@ -37,8 +37,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1effectauthor_1/generate.rsp
+++ b/generation/um/d2d1effectauthor_1/generate.rsp
@@ -13,8 +13,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1effects/generate.rsp
+++ b/generation/um/d2d1effects/generate.rsp
@@ -52,8 +52,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1effects_1/generate.rsp
+++ b/generation/um/d2d1effects_1/generate.rsp
@@ -12,8 +12,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1effects_2/generate.rsp
+++ b/generation/um/d2d1effects_2/generate.rsp
@@ -34,8 +34,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d2d1svg/generate.rsp
+++ b/generation/um/d2d1svg/generate.rsp
@@ -51,8 +51,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D2D1
 --methodClassName
 D2D1
 --namespace

--- a/generation/um/d3d11/generate.rsp
+++ b/generation/um/d3d11/generate.rsp
@@ -192,8 +192,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11_1/generate.rsp
+++ b/generation/um/d3d11_1/generate.rsp
@@ -32,8 +32,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11_2/generate.rsp
+++ b/generation/um/d3d11_2/generate.rsp
@@ -17,8 +17,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11_3/generate.rsp
+++ b/generation/um/d3d11_3/generate.rsp
@@ -54,8 +54,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11_4/generate.rsp
+++ b/generation/um/d3d11_4/generate.rsp
@@ -32,8 +32,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11on12/generate.rsp
+++ b/generation/um/d3d11on12/generate.rsp
@@ -17,8 +17,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11sdklayers/generate.rsp
+++ b/generation/um/d3d11sdklayers/generate.rsp
@@ -35,8 +35,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11shader/generate.rsp
+++ b/generation/um/d3d11shader/generate.rsp
@@ -23,8 +23,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/d3d11shadertracing/generate.rsp
+++ b/generation/um/d3d11shadertracing/generate.rsp
@@ -18,8 +18,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-D3D11
 --methodClassName
 D3D11
 --namespace

--- a/generation/um/handleapi/generate.rsp
+++ b/generation/um/handleapi/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-Kernel32
 --methodClassName
 Kernel32
 --namespace

--- a/generation/um/heapapi/generate.rsp
+++ b/generation/um/heapapi/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-Kernel32
 --methodClassName
 Kernel32
 --namespace

--- a/generation/um/libloaderapi/generate.rsp
+++ b/generation/um/libloaderapi/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-Kernel32
 --methodClassName
 Kernel32
 --namespace

--- a/generation/um/profileapi/generate.rsp
+++ b/generation/um/profileapi/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-Kernel32
 --methodClassName
 Kernel32
 --namespace

--- a/generation/um/synchapi/generate.rsp
+++ b/generation/um/synchapi/generate.rsp
@@ -10,8 +10,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-Kernel32
 --methodClassName
 Kernel32
 --namespace

--- a/generation/um/wincodec/generate.rsp
+++ b/generation/um/wincodec/generate.rsp
@@ -232,8 +232,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-WinCodec
 --methodClassName
 WinCodec
 --namespace

--- a/generation/um/wincodecsdk/generate.rsp
+++ b/generation/um/wincodecsdk/generate.rsp
@@ -172,8 +172,6 @@ header.txt
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/shared
 --include-directory
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um
---libraryPath
-WinCodec
 --methodClassName
 WinCodec
 --namespace

--- a/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext3.cs
+++ b/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext3.cs
@@ -573,6 +573,7 @@ namespace TerraFX.Interop
         public void DrawSpriteBatch([NativeTypeName("ID2D1SpriteBatch *")] ID2D1SpriteBatch* spriteBatch, [NativeTypeName("ID2D1Bitmap *")] ID2D1Bitmap* bitmap, D2D1_BITMAP_INTERPOLATION_MODE interpolationMode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, D2D1_SPRITE_OPTIONS spriteOptions = D2D1_SPRITE_OPTIONS_NONE)
         {
             DrawSpriteBatch(spriteBatch, 0, spriteBatch->GetSpriteCount(), bitmap, interpolationMode, spriteOptions);
+            return;
         }
 
         [return: NativeTypeName("HRESULT")]

--- a/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext4.cs
+++ b/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext4.cs
@@ -598,6 +598,7 @@ namespace TerraFX.Interop
         public void DrawSpriteBatch([NativeTypeName("ID2D1SpriteBatch *")] ID2D1SpriteBatch* spriteBatch, [NativeTypeName("ID2D1Bitmap *")] ID2D1Bitmap* bitmap, D2D1_BITMAP_INTERPOLATION_MODE interpolationMode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, D2D1_SPRITE_OPTIONS spriteOptions = D2D1_SPRITE_OPTIONS_NONE)
         {
             DrawSpriteBatch(spriteBatch, 0, spriteBatch->GetSpriteCount(), bitmap, interpolationMode, spriteOptions);
+            return;
         }
 
         [return: NativeTypeName("HRESULT")]

--- a/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext5.cs
+++ b/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext5.cs
@@ -613,6 +613,7 @@ namespace TerraFX.Interop
         public void DrawSpriteBatch([NativeTypeName("ID2D1SpriteBatch *")] ID2D1SpriteBatch* spriteBatch, [NativeTypeName("ID2D1Bitmap *")] ID2D1Bitmap* bitmap, D2D1_BITMAP_INTERPOLATION_MODE interpolationMode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, D2D1_SPRITE_OPTIONS spriteOptions = D2D1_SPRITE_OPTIONS_NONE)
         {
             DrawSpriteBatch(spriteBatch, 0, spriteBatch->GetSpriteCount(), bitmap, interpolationMode, spriteOptions);
+            return;
         }
 
         [return: NativeTypeName("HRESULT")]

--- a/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext6.cs
+++ b/sources/Interop/D2D1/um/d2d1_3/ID2D1DeviceContext6.cs
@@ -616,6 +616,7 @@ namespace TerraFX.Interop
         public void DrawSpriteBatch([NativeTypeName("ID2D1SpriteBatch *")] ID2D1SpriteBatch* spriteBatch, [NativeTypeName("ID2D1Bitmap *")] ID2D1Bitmap* bitmap, D2D1_BITMAP_INTERPOLATION_MODE interpolationMode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, D2D1_SPRITE_OPTIONS spriteOptions = D2D1_SPRITE_OPTIONS_NONE)
         {
             DrawSpriteBatch(spriteBatch, 0, spriteBatch->GetSpriteCount(), bitmap, interpolationMode, spriteOptions);
+            return;
         }
 
         [return: NativeTypeName("HRESULT")]

--- a/sources/Interop/Kernel32/um/libloaderapi/ENUMRESLANGPROCA.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/ENUMRESLANGPROCA.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int ENUMRESLANGPROCA([NativeTypeName("HMODULE")] IntPtr hModule, [NativeTypeName("LPCSTR")] sbyte* lpType, [NativeTypeName("LPCSTR")] sbyte* lpName, [NativeTypeName("WORD")] ushort wLanguage, [NativeTypeName("LONG_PTR")] IntPtr lParam);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/ENUMRESLANGPROCW.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/ENUMRESLANGPROCW.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int ENUMRESLANGPROCW([NativeTypeName("HMODULE")] IntPtr hModule, [NativeTypeName("LPCWSTR")] ushort* lpType, [NativeTypeName("LPCWSTR")] ushort* lpName, [NativeTypeName("WORD")] ushort wLanguage, [NativeTypeName("LONG_PTR")] IntPtr lParam);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/ENUMRESNAMEPROCA.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/ENUMRESNAMEPROCA.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int ENUMRESNAMEPROCA([NativeTypeName("HMODULE")] IntPtr hModule, [NativeTypeName("LPCSTR")] sbyte* lpType, [NativeTypeName("LPSTR")] sbyte* lpName, [NativeTypeName("LONG_PTR")] IntPtr lParam);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/ENUMRESNAMEPROCW.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/ENUMRESNAMEPROCW.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int ENUMRESNAMEPROCW([NativeTypeName("HMODULE")] IntPtr hModule, [NativeTypeName("LPCWSTR")] ushort* lpType, [NativeTypeName("LPWSTR")] ushort* lpName, [NativeTypeName("LONG_PTR")] IntPtr lParam);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/ENUMRESTYPEPROCA.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/ENUMRESTYPEPROCA.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int ENUMRESTYPEPROCA([NativeTypeName("HMODULE")] IntPtr hModule, [NativeTypeName("LPSTR")] sbyte* lpType, [NativeTypeName("LONG_PTR")] IntPtr lParam);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/ENUMRESTYPEPROCW.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/ENUMRESTYPEPROCW.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int ENUMRESTYPEPROCW([NativeTypeName("HMODULE")] IntPtr hModule, [NativeTypeName("LPWSTR")] ushort* lpType, [NativeTypeName("LONG_PTR")] IntPtr lParam);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/PGET_MODULE_HANDLE_EXA.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/PGET_MODULE_HANDLE_EXA.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int PGET_MODULE_HANDLE_EXA([NativeTypeName("DWORD")] uint dwFlags, [NativeTypeName("LPCSTR")] sbyte* lpModuleName, [NativeTypeName("HMODULE *")] IntPtr* phModule);
 }

--- a/sources/Interop/Kernel32/um/libloaderapi/PGET_MODULE_HANDLE_EXW.cs
+++ b/sources/Interop/Kernel32/um/libloaderapi/PGET_MODULE_HANDLE_EXW.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int PGET_MODULE_HANDLE_EXW([NativeTypeName("DWORD")] uint dwFlags, [NativeTypeName("LPCWSTR")] ushort* lpModuleName, [NativeTypeName("HMODULE *")] IntPtr* phModule);
 }

--- a/sources/Interop/Kernel32/um/synchapi/PINIT_ONCE_FN.cs
+++ b/sources/Interop/Kernel32/um/synchapi/PINIT_ONCE_FN.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     [return: NativeTypeName("BOOL")]
     public unsafe delegate int PINIT_ONCE_FN([NativeTypeName("PINIT_ONCE")] RTL_RUN_ONCE* InitOnce, [NativeTypeName("PVOID")] void* Parameter, [NativeTypeName("PVOID *")] void** Context);
 }

--- a/sources/Interop/Kernel32/um/synchapi/PTIMERAPCROUTINE.cs
+++ b/sources/Interop/Kernel32/um/synchapi/PTIMERAPCROUTINE.cs
@@ -7,6 +7,6 @@ using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     public unsafe delegate void PTIMERAPCROUTINE([NativeTypeName("LPVOID")] void* lpArgToCompletionRoutine, [NativeTypeName("DWORD")] uint dwTimerLowValue, [NativeTypeName("DWORD")] uint dwTimerHighValue);
 }

--- a/sources/Interop/User32/um/WinUser/HGESTUREINFO.Manual.cs
+++ b/sources/Interop/User32/um/WinUser/HGESTUREINFO.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HGESTUREINFO value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HGESTUREINFO other) && Equals(other);
 
         public bool Equals(HGESTUREINFO other) => this == other;
 

--- a/sources/Interop/User32/um/WinUser/HRAWINPUT.Manual.cs
+++ b/sources/Interop/User32/um/WinUser/HRAWINPUT.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HRAWINPUT value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HRAWINPUT other) && Equals(other);
 
         public bool Equals(HRAWINPUT other) => this == other;
 

--- a/sources/Interop/User32/um/WinUser/HSYNTHETICPOINTERDEVICE.Manual.cs
+++ b/sources/Interop/User32/um/WinUser/HSYNTHETICPOINTERDEVICE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HSYNTHETICPOINTERDEVICE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HSYNTHETICPOINTERDEVICE other) && Equals(other);
 
         public bool Equals(HSYNTHETICPOINTERDEVICE other) => this == other;
 

--- a/sources/Interop/User32/um/WinUser/HTOUCHINPUT.Manual.cs
+++ b/sources/Interop/User32/um/WinUser/HTOUCHINPUT.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HTOUCHINPUT value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HTOUCHINPUT other) && Equals(other);
 
         public bool Equals(HTOUCHINPUT other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HGLOBAL.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HGLOBAL.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HGLOBAL value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HGLOBAL other) && Equals(other);
 
         public bool Equals(HGLOBAL other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HINSTANCE.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HINSTANCE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HINSTANCE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HINSTANCE other) && Equals(other);
 
         public bool Equals(HINSTANCE other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HKL.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HKL.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HKL value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HKL other) && Equals(other);
 
         public bool Equals(HKL other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HMETAFILE.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HMETAFILE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HMETAFILE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HMETAFILE other) && Equals(other);
 
         public bool Equals(HMETAFILE other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HRGN.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HRGN.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HRGN value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HRGN other) && Equals(other);
 
         public bool Equals(HRGN other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HRSRC.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HRSRC.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HRSRC value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HRSRC other) && Equals(other);
 
         public bool Equals(HRSRC other) => this == other;
 

--- a/sources/Interop/Windows/shared/minwindef/HWINSTA.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/HWINSTA.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HWINSTA value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HWINSTA other) && Equals(other);
 
         public bool Equals(HWINSTA other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/DPI_AWARENESS_CONTEXT.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/DPI_AWARENESS_CONTEXT.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(DPI_AWARENESS_CONTEXT value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is DPI_AWARENESS_CONTEXT other) && Equals(other);
 
         public bool Equals(DPI_AWARENESS_CONTEXT other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HACCEL.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HACCEL.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HACCEL value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HACCEL other) && Equals(other);
 
         public bool Equals(HACCEL other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HBRUSH.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HBRUSH.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HBRUSH value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HBRUSH other) && Equals(other);
 
         public bool Equals(HBRUSH other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HCOLORSPACE.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HCOLORSPACE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HCOLORSPACE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HCOLORSPACE other) && Equals(other);
 
         public bool Equals(HCOLORSPACE other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HDC.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HDC.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HDC value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HDC other) && Equals(other);
 
         public bool Equals(HDC other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HDESK.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HDESK.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HDESK value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HDESK other) && Equals(other);
 
         public bool Equals(HDESK other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HENHMETAFILE.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HENHMETAFILE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HENHMETAFILE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HENHMETAFILE other) && Equals(other);
 
         public bool Equals(HENHMETAFILE other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HFONT.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HFONT.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HFONT value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HFONT other) && Equals(other);
 
         public bool Equals(HFONT other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HGDIOBJ.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HGDIOBJ.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HGDIOBJ value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HGDIOBJ other) && Equals(other);
 
         public bool Equals(HGDIOBJ other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HGLRC.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HGLRC.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HGLRC value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HGLRC other) && Equals(other);
 
         public bool Equals(HGLRC other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HHOOK.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HHOOK.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HHOOK value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HHOOK other) && Equals(other);
 
         public bool Equals(HHOOK other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HICON.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HICON.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HICON value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HICON other) && Equals(other);
 
         public bool Equals(HICON other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HMENU.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HMENU.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HMENU value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HMENU other) && Equals(other);
 
         public bool Equals(HMENU other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HMONITOR.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HMONITOR.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HMONITOR value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HMONITOR other) && Equals(other);
 
         public bool Equals(HMONITOR other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HPALETTE.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HPALETTE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HPALETTE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HPALETTE other) && Equals(other);
 
         public bool Equals(HPALETTE other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HPEN.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HPEN.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HPEN value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HPEN other) && Equals(other);
 
         public bool Equals(HPEN other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HWINEVENTHOOK.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HWINEVENTHOOK.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HWINEVENTHOOK value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HWINEVENTHOOK other) && Equals(other);
 
         public bool Equals(HWINEVENTHOOK other) => this == other;
 

--- a/sources/Interop/Windows/shared/windef/HWND.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/HWND.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HWND value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HWND other) && Equals(other);
 
         public bool Equals(HWND other) => this == other;
 

--- a/sources/Interop/Windows/um/winnt/HANDLE.Manual.cs
+++ b/sources/Interop/Windows/um/winnt/HANDLE.Manual.cs
@@ -34,7 +34,7 @@ namespace TerraFX.Interop
 
         public static implicit operator void*(HANDLE value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HANDLE other) && Equals(other);
 
         public bool Equals(HANDLE other) => this == other;
 

--- a/sources/Interop/Windows/um/winnt/HRESULT.Manual.cs
+++ b/sources/Interop/Windows/um/winnt/HRESULT.Manual.cs
@@ -8,7 +8,7 @@ using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop
 {
-    public unsafe struct HRESULT : IEquatable<HRESULT>
+    public struct HRESULT : IEquatable<HRESULT>
     {
         private int _value;
 
@@ -29,7 +29,7 @@ namespace TerraFX.Interop
 
         public static implicit operator int(HRESULT value) => value._value;
 
-        public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
+        public override bool Equals(object? obj) => (obj is HRESULT other) && Equals(other);
 
         public bool Equals(HRESULT other) => this == other;
 


### PR DESCRIPTION
This cleans up the generation files to not specify --libraryPath when it would conflict and fixes the `Equals(object)` overload for the wrapper types to compare against the correct type.