### PR TITLE
Target an explicit netcoreapp5.0 version and multitarget netcoreapp3.1

### DIFF
--- a/samples/DirectX/TerraFX.Samples.DirectX.csproj
+++ b/samples/DirectX/TerraFX.Samples.DirectX.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -120,7 +120,7 @@ try {
     $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
     Create-Directory -Path $DotNetInstallDirectory
 
-    & $DotNetInstallScript -Channel master -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
+    & $DotNetInstallScript -Channel master -Version 5.0.100-preview.2.20156.8 -InstallDir $DotNetInstallDirectory -Architecture $architecture
     & $DotNetInstallScript -Channel 3.1 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture -Runtime dotnet
 
     $env:PATH="$DotNetInstallDirectory;$env:PATH"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,7 +204,7 @@ if [[ ! -z "$architecture" ]]; then
   DotNetInstallDirectory="$ArtifactsDir/dotnet"
   CreateDirectory "$DotNetInstallDirectory"
 
-  . "$DotNetInstallScript" --channel master --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
+  . "$DotNetInstallScript" --channel master --version "5.0.100-preview.2.20156.8" --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
   . "$DotNetInstallScript" --channel 3.1 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture" --runtime dotnet
 
   PATH="$DotNetInstallDirectory:$PATH:"

--- a/sources/Directory.Build.targets
+++ b/sources/Directory.Build.targets
@@ -37,7 +37,7 @@
   <Target Name="GenerateSkipLocalsInit"
           BeforeTargets="CoreCompile"
           DependsOnTargets="PrepareForBuild"
-          Condition="'$(Language)' == 'C#'"
+          Condition="('$(Language)' == 'C#') AND ('$(TargetFramework)' != 'netcoreapp3.1')"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(GeneratedSkipLocalsInitFile)">
     <WriteLinesToFile Lines="$(GeneratedSkipLocalsInitFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" File="$(GeneratedSkipLocalsInitFile)" />

--- a/sources/Interop/D2D1/TerraFX.Interop.D2D1.csproj
+++ b/sources/Interop/D2D1/TerraFX.Interop.D2D1.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/D3D11/TerraFX.Interop.D3D11.csproj
+++ b/sources/Interop/D3D11/TerraFX.Interop.D3D11.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/D3D12/TerraFX.Interop.D3D12.csproj
+++ b/sources/Interop/D3D12/TerraFX.Interop.D3D12.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/D3DCommon/TerraFX.Interop.D3DCommon.csproj
+++ b/sources/Interop/D3DCommon/TerraFX.Interop.D3DCommon.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/sources/Interop/D3DCompiler/TerraFX.Interop.D3DCompiler.csproj
+++ b/sources/Interop/D3DCompiler/TerraFX.Interop.D3DCompiler.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DCommon/TerraFX.Interop.DCommon.csproj
+++ b/sources/Interop/DCommon/TerraFX.Interop.DCommon.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DWrite/TerraFX.Interop.DWrite.csproj
+++ b/sources/Interop/DWrite/TerraFX.Interop.DWrite.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DXGI/TerraFX.Interop.DXGI.csproj
+++ b/sources/Interop/DXGI/TerraFX.Interop.DXGI.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.csproj
+++ b/sources/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/sources/Interop/Gdi32/TerraFX.Interop.Gdi32.csproj
+++ b/sources/Interop/Gdi32/TerraFX.Interop.Gdi32.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/Kernel32/TerraFX.Interop.Kernel32.csproj
+++ b/sources/Interop/Kernel32/TerraFX.Interop.Kernel32.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/User32/TerraFX.Interop.User32.csproj
+++ b/sources/Interop/User32/TerraFX.Interop.User32.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/WinCodec/TerraFX.Interop.WinCodec.csproj
+++ b/sources/Interop/WinCodec/TerraFX.Interop.WinCodec.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/Interop/Windows/TerraFX.Interop.Windows.csproj
+++ b/sources/Interop/Windows/TerraFX.Interop.Windows.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1573;1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/Interop/D2D1/TerraFX.Interop.D2D1.UnitTests.csproj
+++ b/tests/Interop/D2D1/TerraFX.Interop.D2D1.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/D3D12/TerraFX.Interop.D3D12.UnitTests.csproj
+++ b/tests/Interop/D3D12/TerraFX.Interop.D3D12.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/D3DCommon/TerraFX.Interop.D3DCommon.UnitTests.csproj
+++ b/tests/Interop/D3DCommon/TerraFX.Interop.D3DCommon.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DCommon/TerraFX.Interop.DCommon.UnitTests.csproj
+++ b/tests/Interop/DCommon/TerraFX.Interop.DCommon.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DWrite/TerraFX.Interop.DWrite.UnitTests.csproj
+++ b/tests/Interop/DWrite/TerraFX.Interop.DWrite.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DXGI/TerraFX.Interop.DXGI.UnitTests.csproj
+++ b/tests/Interop/DXGI/TerraFX.Interop.DXGI.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.UnitTests.csproj
+++ b/tests/Interop/DXGIDebug/TerraFX.Interop.DXGIDebug.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/Gdi32/TerraFX.Interop.Gdi32.UnitTests.csproj
+++ b/tests/Interop/Gdi32/TerraFX.Interop.Gdi32.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/User32/TerraFX.Interop.User32.UnitTests.csproj
+++ b/tests/Interop/User32/TerraFX.Interop.User32.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/WinCodec/TerraFX.Interop.WinCodec.UnitTests.csproj
+++ b/tests/Interop/WinCodec/TerraFX.Interop.WinCodec.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interop/Windows/TerraFX.Interop.Windows.UnitTests.csproj
+++ b/tests/Interop/Windows/TerraFX.Interop.Windows.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This targets an explicit netcoreapp5.0 version so that builds always work and multitargets netcoreapp3.1 so this is still usable on the current LTS.