### PR TITLE
Fix compiler messages in sample projects

### DIFF
--- a/samples/DirectX/D3D11/HelloTriangle11.cs
+++ b/samples/DirectX/D3D11/HelloTriangle11.cs
@@ -51,7 +51,7 @@ namespace TerraFX.Samples.DirectX.D3D11
                 iid = IID_IDXGIFactory1;
                 ThrowIfFailed(nameof(CreateDXGIFactory1), CreateDXGIFactory1(&iid, (void**)&factory));
 
-                if (_useWarpDevice)
+                if (UseWarpDevice)
                 {
                     throw new NotImplementedException("WARP Device not supported for D3D11.");
                 }
@@ -70,8 +70,8 @@ namespace TerraFX.Samples.DirectX.D3D11
                 // Describe and create the swap chain.
                 var swapChainDesc = new DXGI_SWAP_CHAIN_DESC {
                     BufferDesc = new DXGI_MODE_DESC {
-                        Width = _width,
-                        Height = _height,
+                        Width = Width,
+                        Height = Height,
                         Format = DXGI_FORMAT_R8G8B8A8_UNORM,
                     },
                     SampleDesc = new DXGI_SAMPLE_DESC {
@@ -107,8 +107,8 @@ namespace TerraFX.Samples.DirectX.D3D11
                 }
 
                 var vp = new D3D11_VIEWPORT {
-                    Width = _width,
-                    Height = _height,
+                    Width = Width,
+                    Height = Height,
                     MinDepth = 0.0f,
                     MaxDepth = 1.0f,
                     TopLeftX = 0,
@@ -173,15 +173,15 @@ namespace TerraFX.Samples.DirectX.D3D11
                 var triangleVertices = stackalloc Vertex[3];
                 {
                     triangleVertices[0] = new Vertex {
-                        Position = new Vector3(0.0f, 0.25f * _aspectRatio, 0.0f),
+                        Position = new Vector3(0.0f, 0.25f * AspectRatio, 0.0f),
                         Color = new Vector4(1.0f, 0.0f, 0.0f, 1.0f)
                     };
                     triangleVertices[1] = new Vertex {
-                        Position = new Vector3(0.25f, -0.25f * _aspectRatio, 0.0f),
+                        Position = new Vector3(0.25f, -0.25f * AspectRatio, 0.0f),
                         Color = new Vector4(0.0f, 1.0f, 0.0f, 1.0f)
                     };
                     triangleVertices[2] = new Vertex {
-                        Position = new Vector3(-0.25f, -0.25f * _aspectRatio, 0.0f),
+                        Position = new Vector3(-0.25f, -0.25f * AspectRatio, 0.0f),
                         Color = new Vector4(0.0f, 0.0f, 1.0f, 1.0f)
                     };
                 }
@@ -266,10 +266,7 @@ namespace TerraFX.Samples.DirectX.D3D11
             ThrowIfFailed(nameof(IDXGISwapChain.Present), _swapChain->Present(0, 0));
         }
 
-        public override void OnDestroy()
-        {
-            _immediateContext->ClearState();
-        }
+        public override void OnDestroy() => _immediateContext->ClearState();
 
         protected override void Dispose(bool isDisposing)
         {

--- a/samples/DirectX/D3D11/HelloWindow11.cs
+++ b/samples/DirectX/D3D11/HelloWindow11.cs
@@ -39,7 +39,7 @@ namespace TerraFX.Samples.DirectX.D3D11
                 iid = IID_IDXGIFactory1;
                 ThrowIfFailed(nameof(CreateDXGIFactory1), CreateDXGIFactory1(&iid, (void**)&factory));
 
-                if (_useWarpDevice)
+                if (UseWarpDevice)
                 {
                     throw new NotImplementedException("WARP Device not supported for D3D11.");
                 }
@@ -58,8 +58,8 @@ namespace TerraFX.Samples.DirectX.D3D11
                 // Describe and create the swap chain.
                 var swapChainDesc = new DXGI_SWAP_CHAIN_DESC {
                     BufferDesc = new DXGI_MODE_DESC {
-                        Width = _width,
-                        Height = _height,
+                        Width = Width,
+                        Height = Height,
                         Format = DXGI_FORMAT_R8G8B8A8_UNORM,
                     },
                     SampleDesc = new DXGI_SAMPLE_DESC {
@@ -95,8 +95,8 @@ namespace TerraFX.Samples.DirectX.D3D11
                 }
 
                 var vp = new D3D11_VIEWPORT {
-                    Width = _width,
-                    Height = _height,
+                    Width = Width,
+                    Height = Height,
                     MinDepth = 0.0f,
                     MaxDepth = 1.0f,
                     TopLeftX = 0,
@@ -143,10 +143,7 @@ namespace TerraFX.Samples.DirectX.D3D11
             ThrowIfFailed(nameof(IDXGISwapChain.Present), _swapChain->Present(0, 0));
         }
 
-        public override void OnDestroy()
-        {
-            _immediateContext->ClearState();
-        }
+        public override void OnDestroy() => _immediateContext->ClearState();
 
         protected override void Dispose(bool isDisposing)
         {

--- a/samples/DirectX/D3D12/HelloTriangle12.cs
+++ b/samples/DirectX/D3D12/HelloTriangle12.cs
@@ -52,7 +52,7 @@ namespace TerraFX.Samples.DirectX.D3D12
         private RECT _scissorRect;
         private IDXGISwapChain3* _swapChain;
         private ID3D12Device* _device;
-        private ID3D12Resource*[] _renderTargets;
+        private readonly ID3D12Resource*[] _renderTargets;
         private ID3D12CommandAllocator* _commandAllocator;
         private ID3D12CommandQueue* _commandQueue;
         private ID3D12RootSignature* _rootSignature;
@@ -111,11 +111,11 @@ namespace TerraFX.Samples.DirectX.D3D12
             PopulateCommandList();
 
             // Execute the command list.
-            const int ppCommandListsCount = 1;
-            var ppCommandLists = stackalloc ID3D12CommandList*[ppCommandListsCount] {
+            const int CommandListsCount = 1;
+            var ppCommandLists = stackalloc ID3D12CommandList*[CommandListsCount] {
                 (ID3D12CommandList*)_commandList,
             };
-            _commandQueue->ExecuteCommandLists(ppCommandListsCount, ppCommandLists);
+            _commandQueue->ExecuteCommandLists(CommandListsCount, ppCommandLists);
 
             // Present the frame.
             ThrowIfFailed(nameof(IDXGISwapChain3.Present), _swapChain->Present(SyncInterval: 1, Flags: 0));
@@ -163,7 +163,7 @@ namespace TerraFX.Samples.DirectX.D3D12
                 iid = IID_IDXGIFactory4;
                 ThrowIfFailed(nameof(CreateDXGIFactory2), CreateDXGIFactory2(dxgiFactoryFlags, &iid, (void**)&factory));
 
-                if (_useWarpDevice)
+                if (UseWarpDevice)
                 {
                     iid = IID_IDXGIAdapter;
                     ThrowIfFailed(nameof(IDXGIFactory4.EnumWarpAdapter), factory->EnumWarpAdapter(&iid, (void**)&adapter));
@@ -191,8 +191,8 @@ namespace TerraFX.Samples.DirectX.D3D12
                 // Describe and create the swap chain.
                 var swapChainDesc = new DXGI_SWAP_CHAIN_DESC1 {
                     BufferCount = FrameCount,
-                    Width = _width,
-                    Height = _height,
+                    Width = Width,
+                    Height = Height,
                     Format = DXGI_FORMAT_R8G8B8A8_UNORM,
                     BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
                     SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
@@ -330,7 +330,7 @@ namespace TerraFX.Samples.DirectX.D3D12
                     }
 
                     // Define the vertex input layout.
-                    const int inputElementDescsCount = 2;
+                    const int InputElementDescsCount = 2;
 
                     var semanticName0 = stackalloc ulong[2] {
                         0x4E4F495449534F50,     // POSITION
@@ -341,7 +341,7 @@ namespace TerraFX.Samples.DirectX.D3D12
                         0x000000524F4C4F43,     // COLOR
                     };
 
-                    var inputElementDescs = stackalloc D3D12_INPUT_ELEMENT_DESC[inputElementDescsCount] {
+                    var inputElementDescs = stackalloc D3D12_INPUT_ELEMENT_DESC[InputElementDescsCount] {
                         new D3D12_INPUT_ELEMENT_DESC {
                             SemanticName = (sbyte*)semanticName0,
                             Format = DXGI_FORMAT_R32G32B32_FLOAT,
@@ -359,7 +359,7 @@ namespace TerraFX.Samples.DirectX.D3D12
                     var psoDesc = new D3D12_GRAPHICS_PIPELINE_STATE_DESC {
                         InputLayout = new D3D12_INPUT_LAYOUT_DESC {
                             pInputElementDescs = inputElementDescs,
-                            NumElements = inputElementDescsCount,
+                            NumElements = InputElementDescsCount,
                         },
                         pRootSignature = _rootSignature,
                         VS = new D3D12_SHADER_BYTECODE(vertexShader),
@@ -396,23 +396,23 @@ namespace TerraFX.Samples.DirectX.D3D12
                 // Create the vertex buffer.
                 {
                     // Define the geometry for a triangle.
-                    const int triangleVerticesCount = 3;
-                    var triangleVertices = stackalloc Vertex[triangleVerticesCount] {
+                    const int TriangleVerticesCount = 3;
+                    var triangleVertices = stackalloc Vertex[TriangleVerticesCount] {
                         new Vertex {
-                            Position = new Vector3(0.0f, 0.25f * _aspectRatio, 0.0f),
+                            Position = new Vector3(0.0f, 0.25f * AspectRatio, 0.0f),
                             Color = new Vector4(1.0f, 0.0f, 0.0f, 1.0f)
                         },
                         new Vertex {
-                            Position = new Vector3(0.25f, -0.25f * _aspectRatio, 0.0f),
+                            Position = new Vector3(0.25f, -0.25f * AspectRatio, 0.0f),
                             Color = new Vector4(0.0f, 1.0f, 0.0f, 1.0f)
                         },
                         new Vertex {
-                            Position = new Vector3(-0.25f, -0.25f * _aspectRatio, 0.0f),
+                            Position = new Vector3(-0.25f, -0.25f * AspectRatio, 0.0f),
                             Color = new Vector4(0.0f, 0.0f, 1.0f, 1.0f)
                         },
                     };
 
-                    var vertexBufferSize = (uint)sizeof(Vertex) * triangleVerticesCount;
+                    var vertexBufferSize = (uint)sizeof(Vertex) * TriangleVerticesCount;
 
                     // Note: using upload heaps to transfer static data like vert buffers is not
                     // recommended. Every time the GPU needs it, the upload heap will be marshalled
@@ -526,7 +526,7 @@ namespace TerraFX.Samples.DirectX.D3D12
             _commandList->ResourceBarrier(1, &barrier);
 
             var rtvHandle = _rtvHeap->GetCPUDescriptorHandleForHeapStart();
-            rtvHandle.ptr = (UIntPtr)((byte*)rtvHandle.ptr + _frameIndex * _rtvDescriptorSize);
+            rtvHandle.ptr = (UIntPtr)((byte*)rtvHandle.ptr + (_frameIndex * _rtvDescriptorSize));
             _commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, null);
 
             // Record commands.

--- a/samples/DirectX/D3D12/HelloWindow12.cs
+++ b/samples/DirectX/D3D12/HelloWindow12.cs
@@ -28,7 +28,7 @@ namespace TerraFX.Samples.DirectX.D3D12
         // Pipeline objects
         private IDXGISwapChain3* _swapChain;
         private ID3D12Device* _device;
-        private ID3D12Resource*[] _renderTargets;
+        private readonly ID3D12Resource*[] _renderTargets;
         private ID3D12CommandAllocator* _commandAllocator;
         private ID3D12CommandQueue* _commandQueue;
         private ID3D12DescriptorHeap* _rtvHeap;
@@ -66,11 +66,11 @@ namespace TerraFX.Samples.DirectX.D3D12
             PopulateCommandList();
 
             // Execute the command list.
-            const int ppCommandListsCount = 1;
-            var ppCommandLists = stackalloc ID3D12CommandList*[ppCommandListsCount] {
+            const int CommandListsCount = 1;
+            var ppCommandLists = stackalloc ID3D12CommandList*[CommandListsCount] {
                 (ID3D12CommandList*)_commandList,
             };
-            _commandQueue->ExecuteCommandLists(ppCommandListsCount, ppCommandLists);
+            _commandQueue->ExecuteCommandLists(CommandListsCount, ppCommandLists);
 
             // Present the frame.
             ThrowIfFailed(nameof(IDXGISwapChain3.Present), _swapChain->Present(SyncInterval: 1, Flags: 0));
@@ -118,7 +118,7 @@ namespace TerraFX.Samples.DirectX.D3D12
                 iid = IID_IDXGIFactory4;
                 ThrowIfFailed(nameof(CreateDXGIFactory2), CreateDXGIFactory2(dxgiFactoryFlags, &iid, (void**)&factory));
 
-                if (_useWarpDevice)
+                if (UseWarpDevice)
                 {
                     iid = IID_IDXGIAdapter;
                     ThrowIfFailed(nameof(IDXGIFactory4.EnumWarpAdapter), factory->EnumWarpAdapter(&iid, (void**)&adapter));
@@ -146,8 +146,8 @@ namespace TerraFX.Samples.DirectX.D3D12
                 // Describe and create the swap chain.
                 var swapChainDesc = new DXGI_SWAP_CHAIN_DESC1 {
                     BufferCount = FrameCount,
-                    Width = _width,
-                    Height = _height,
+                    Width = Width,
+                    Height = Height,
                     Format = DXGI_FORMAT_R8G8B8A8_UNORM,
                     BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
                     SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
@@ -289,7 +289,7 @@ namespace TerraFX.Samples.DirectX.D3D12
             _commandList->ResourceBarrier(1, &barrier);
 
             var rtvHandle = _rtvHeap->GetCPUDescriptorHandleForHeapStart();
-            rtvHandle.ptr = (UIntPtr)((byte*)rtvHandle.ptr + _frameIndex * _rtvDescriptorSize);
+            rtvHandle.ptr = (UIntPtr)((byte*)rtvHandle.ptr + (_frameIndex * _rtvDescriptorSize));
 
             // Record commands.
             var clearColor = stackalloc float[4];

--- a/samples/DirectX/Program.cs
+++ b/samples/DirectX/Program.cs
@@ -11,7 +11,7 @@ namespace TerraFX.Samples.DirectX
 {
     public static unsafe class Program
     {
-        private static readonly DXSample[] s_samples = {
+        private static readonly DXSample[] Samples = {
             new HelloWindow11(1280, 720, "D3D11.HelloWindow"),
             new HelloTriangle11(1280, 720, "D3D11.HelloTriangle"),
             new HelloWindow12(1280, 720, "D3D12.HelloWindow"),
@@ -45,7 +45,7 @@ namespace TerraFX.Samples.DirectX
 
             Console.WriteLine("Available Samples - Can specify multiple");
 
-            foreach (var sample in s_samples)
+            foreach (var sample in Samples)
             {
                 Console.WriteLine($"    {sample.Title}");
             }
@@ -63,7 +63,7 @@ namespace TerraFX.Samples.DirectX
 
             if (args.Any((arg) => Matches(arg, "all")))
             {
-                foreach (var sample in s_samples)
+                foreach (var sample in Samples)
                 {
                     RunSample(sample);
                     ranAnySamples = true;
@@ -72,7 +72,7 @@ namespace TerraFX.Samples.DirectX
 
             foreach (var arg in args)
             {
-                foreach (var sample in s_samples.Where((sample) => arg.Equals(sample.Title, StringComparison.OrdinalIgnoreCase)))
+                foreach (var sample in Samples.Where((sample) => arg.Equals(sample.Title, StringComparison.OrdinalIgnoreCase)))
                 {
                     RunSample(sample);
                     ranAnySamples = true;

--- a/samples/DirectX/Shared/DXSample.cs
+++ b/samples/DirectX/Shared/DXSample.cs
@@ -16,14 +16,14 @@ namespace TerraFX.Samples.DirectX
     public abstract unsafe class DXSample : IDisposable
     {
         // Viewport dimensions
-        protected uint _width;
+        private uint _width;
 
-        protected uint _height;
+        private uint _height;
 
-        protected float _aspectRatio;
+        private float _aspectRatio;
 
         // Adapter info
-        protected bool _useWarpDevice;
+        private bool _useWarpDevice;
 
         // Root assets path
         private readonly string _assetsPath;
@@ -48,6 +48,12 @@ namespace TerraFX.Samples.DirectX
         public uint Width => _width;
 
         public uint Height => _height;
+
+        public float AspectRatio => _aspectRatio;
+
+        public bool UseWarpDevice => _useWarpDevice;
+
+        public string AssetsPath => _assetsPath;
 
         public string Title => _title;
 
@@ -92,7 +98,7 @@ namespace TerraFX.Samples.DirectX
         }
 
         // Helper function for resolving the full path of assets
-        protected string GetAssetFullPath(string assetName) => Path.Combine(_assetsPath, assetName);
+        protected string GetAssetFullPath(string assetName) => Path.Combine(AssetsPath, assetName);
 
         // Helper function for acquiring the first available hardware adapter that supports the required Direct3D version.
         // If no such adapter can be found, returns null.


### PR DESCRIPTION
[Bug Fix] Sorry, no bug#. Feel free to ignore :)
This fix creates a clean build of the samples solution with all messages of the compiler attended to.
Biggest change is replacing
`protected type _name;`
with
`private type _name;  public type Name => _name;`

