### PR TITLE
Added missing macro

### DIFF
--- a/sources/Interop/Windows/um/WinUser/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/WinUser/Windows.Manual.cs
@@ -5717,6 +5717,8 @@ namespace TerraFX.Interop
 
         public const int RI_MOUSE_BUTTON_5_UP = 0x0200;
 
+        public const int RI_MOUSE_WHEEL = 0x0400;
+
         public const int RI_MOUSE_HWHEEL = 0x0800;
 
         public const int MOUSE_MOVE_RELATIVE = 0;


### PR DESCRIPTION
I'm not sure how this macro was missed, but apparently it was. I ran my `Convert-Macros.ps1` script on `WinUser.h` again and it generated the macro.