### PR TITLE
Fixing other/dxc/dxcapi to use the correct VTBL indices

### DIFF
--- a/sources/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf16.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf16.cs
@@ -35,31 +35,31 @@ namespace TerraFX.Interop
         [return: NativeTypeName("LPVOID")]
         public void* GetBufferPointer()
         {
-            return ((delegate* stdcall<IDxcBlobUtf16*, void*>)(lpVtbl[0]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf16*, void*>)(lpVtbl[3]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("SIZE_T")]
         public nuint GetBufferSize()
         {
-            return ((delegate* stdcall<IDxcBlobUtf16*, nuint>)(lpVtbl[1]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf16*, nuint>)(lpVtbl[4]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetEncoding([NativeTypeName("BOOL *")] int* pKnown, [NativeTypeName("UINT32 *")] uint* pCodePage)
         {
-            return ((delegate* stdcall<IDxcBlobUtf16*, int*, uint*, int>)(lpVtbl[0]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this), pKnown, pCodePage);
+            return ((delegate* stdcall<IDxcBlobUtf16*, int*, uint*, int>)(lpVtbl[5]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this), pKnown, pCodePage);
         }
 
         [return: NativeTypeName("LPCWSTR")]
         public ushort* GetStringPointer()
         {
-            return ((delegate* stdcall<IDxcBlobUtf16*, ushort*>)(lpVtbl[0]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf16*, ushort*>)(lpVtbl[6]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("SIZE_T")]
         public nuint GetStringLength()
         {
-            return ((delegate* stdcall<IDxcBlobUtf16*, nuint>)(lpVtbl[1]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf16*, nuint>)(lpVtbl[7]))((IDxcBlobUtf16*)Unsafe.AsPointer(ref this));
         }
     }
 }

--- a/sources/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf8.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf8.cs
@@ -35,31 +35,31 @@ namespace TerraFX.Interop
         [return: NativeTypeName("LPVOID")]
         public void* GetBufferPointer()
         {
-            return ((delegate* stdcall<IDxcBlobUtf8*, void*>)(lpVtbl[0]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf8*, void*>)(lpVtbl[3]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("SIZE_T")]
         public nuint GetBufferSize()
         {
-            return ((delegate* stdcall<IDxcBlobUtf8*, nuint>)(lpVtbl[1]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf8*, nuint>)(lpVtbl[4]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetEncoding([NativeTypeName("BOOL *")] int* pKnown, [NativeTypeName("UINT32 *")] uint* pCodePage)
         {
-            return ((delegate* stdcall<IDxcBlobUtf8*, int*, uint*, int>)(lpVtbl[0]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this), pKnown, pCodePage);
+            return ((delegate* stdcall<IDxcBlobUtf8*, int*, uint*, int>)(lpVtbl[5]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this), pKnown, pCodePage);
         }
 
         [return: NativeTypeName("LPCSTR")]
         public sbyte* GetStringPointer()
         {
-            return ((delegate* stdcall<IDxcBlobUtf8*, sbyte*>)(lpVtbl[0]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf8*, sbyte*>)(lpVtbl[6]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("SIZE_T")]
         public nuint GetStringLength()
         {
-            return ((delegate* stdcall<IDxcBlobUtf8*, nuint>)(lpVtbl[1]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcBlobUtf8*, nuint>)(lpVtbl[7]))((IDxcBlobUtf8*)Unsafe.AsPointer(ref this));
         }
     }
 }

--- a/sources/Interop/Windows/other/dxc/dxcapi/IDxcCompiler3.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/IDxcCompiler3.cs
@@ -35,13 +35,13 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public int Compile([NativeTypeName("const DxcBuffer *")] DxcBuffer* pSource, [NativeTypeName("LPCWSTR *")] ushort** pArguments, [NativeTypeName("UINT32")] uint argCount, [NativeTypeName("IDxcIncludeHandler *")] IDxcIncludeHandler* pIncludeHandler, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("LPVOID *")] void** ppResult)
         {
-            return ((delegate* stdcall<IDxcCompiler3*, DxcBuffer*, ushort**, uint, IDxcIncludeHandler*, Guid*, void**, int>)(lpVtbl[0]))((IDxcCompiler3*)Unsafe.AsPointer(ref this), pSource, pArguments, argCount, pIncludeHandler, riid, ppResult);
+            return ((delegate* stdcall<IDxcCompiler3*, DxcBuffer*, ushort**, uint, IDxcIncludeHandler*, Guid*, void**, int>)(lpVtbl[3]))((IDxcCompiler3*)Unsafe.AsPointer(ref this), pSource, pArguments, argCount, pIncludeHandler, riid, ppResult);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int Disassemble([NativeTypeName("const DxcBuffer *")] DxcBuffer* pObject, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("LPVOID *")] void** ppResult)
         {
-            return ((delegate* stdcall<IDxcCompiler3*, DxcBuffer*, Guid*, void**, int>)(lpVtbl[1]))((IDxcCompiler3*)Unsafe.AsPointer(ref this), pObject, riid, ppResult);
+            return ((delegate* stdcall<IDxcCompiler3*, DxcBuffer*, Guid*, void**, int>)(lpVtbl[4]))((IDxcCompiler3*)Unsafe.AsPointer(ref this), pObject, riid, ppResult);
         }
     }
 }

--- a/sources/Interop/Windows/other/dxc/dxcapi/IDxcCompilerArgs.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/IDxcCompilerArgs.cs
@@ -35,31 +35,31 @@ namespace TerraFX.Interop
         [return: NativeTypeName("LPCWSTR *")]
         public ushort** GetArguments()
         {
-            return ((delegate* stdcall<IDxcCompilerArgs*, ushort**>)(lpVtbl[0]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcCompilerArgs*, ushort**>)(lpVtbl[3]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("UINT32")]
         public uint GetCount()
         {
-            return ((delegate* stdcall<IDxcCompilerArgs*, uint>)(lpVtbl[1]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcCompilerArgs*, uint>)(lpVtbl[4]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this));
         }
 
         [return: NativeTypeName("HRESULT")]
         public int AddArguments([NativeTypeName("LPCWSTR *")] ushort** pArguments, [NativeTypeName("UINT32")] uint argCount)
         {
-            return ((delegate* stdcall<IDxcCompilerArgs*, ushort**, uint, int>)(lpVtbl[2]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this), pArguments, argCount);
+            return ((delegate* stdcall<IDxcCompilerArgs*, ushort**, uint, int>)(lpVtbl[5]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this), pArguments, argCount);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int AddArgumentsUTF8([NativeTypeName("LPCSTR *")] sbyte** pArguments, [NativeTypeName("UINT32")] uint argCount)
         {
-            return ((delegate* stdcall<IDxcCompilerArgs*, sbyte**, uint, int>)(lpVtbl[3]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this), pArguments, argCount);
+            return ((delegate* stdcall<IDxcCompilerArgs*, sbyte**, uint, int>)(lpVtbl[6]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this), pArguments, argCount);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int AddDefines([NativeTypeName("const DxcDefine *")] DxcDefine* pDefines, [NativeTypeName("UINT32")] uint defineCount)
         {
-            return ((delegate* stdcall<IDxcCompilerArgs*, DxcDefine*, uint, int>)(lpVtbl[4]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this), pDefines, defineCount);
+            return ((delegate* stdcall<IDxcCompilerArgs*, DxcDefine*, uint, int>)(lpVtbl[7]))((IDxcCompilerArgs*)Unsafe.AsPointer(ref this), pDefines, defineCount);
         }
     }
 }

--- a/sources/Interop/Windows/other/dxc/dxcapi/IDxcResult.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/IDxcResult.cs
@@ -35,47 +35,47 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public int GetStatus([NativeTypeName("HRESULT *")] int* pStatus)
         {
-            return ((delegate* stdcall<IDxcResult*, int*, int>)(lpVtbl[0]))((IDxcResult*)Unsafe.AsPointer(ref this), pStatus);
+            return ((delegate* stdcall<IDxcResult*, int*, int>)(lpVtbl[3]))((IDxcResult*)Unsafe.AsPointer(ref this), pStatus);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetResult([NativeTypeName("IDxcBlob **")] IDxcBlob** ppResult)
         {
-            return ((delegate* stdcall<IDxcResult*, IDxcBlob**, int>)(lpVtbl[1]))((IDxcResult*)Unsafe.AsPointer(ref this), ppResult);
+            return ((delegate* stdcall<IDxcResult*, IDxcBlob**, int>)(lpVtbl[4]))((IDxcResult*)Unsafe.AsPointer(ref this), ppResult);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetErrorBuffer([NativeTypeName("IDxcBlobEncoding **")] IDxcBlobEncoding** ppErrors)
         {
-            return ((delegate* stdcall<IDxcResult*, IDxcBlobEncoding**, int>)(lpVtbl[2]))((IDxcResult*)Unsafe.AsPointer(ref this), ppErrors);
+            return ((delegate* stdcall<IDxcResult*, IDxcBlobEncoding**, int>)(lpVtbl[5]))((IDxcResult*)Unsafe.AsPointer(ref this), ppErrors);
         }
 
         [return: NativeTypeName("BOOL")]
         public int HasOutput(DXC_OUT_KIND dxcOutKind)
         {
-            return ((delegate* stdcall<IDxcResult*, DXC_OUT_KIND, int>)(lpVtbl[0]))((IDxcResult*)Unsafe.AsPointer(ref this), dxcOutKind);
+            return ((delegate* stdcall<IDxcResult*, DXC_OUT_KIND, int>)(lpVtbl[6]))((IDxcResult*)Unsafe.AsPointer(ref this), dxcOutKind);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetOutput(DXC_OUT_KIND dxcOutKind, [NativeTypeName("const IID &")] Guid* iid, [NativeTypeName("void **")] void** ppvObject, [NativeTypeName("IDxcBlobUtf16 **")] IDxcBlobUtf16** ppOutputName)
         {
-            return ((delegate* stdcall<IDxcResult*, DXC_OUT_KIND, Guid*, void**, IDxcBlobUtf16**, int>)(lpVtbl[1]))((IDxcResult*)Unsafe.AsPointer(ref this), dxcOutKind, iid, ppvObject, ppOutputName);
+            return ((delegate* stdcall<IDxcResult*, DXC_OUT_KIND, Guid*, void**, IDxcBlobUtf16**, int>)(lpVtbl[7]))((IDxcResult*)Unsafe.AsPointer(ref this), dxcOutKind, iid, ppvObject, ppOutputName);
         }
 
         [return: NativeTypeName("UINT32")]
         public uint GetNumOutputs()
         {
-            return ((delegate* stdcall<IDxcResult*, uint>)(lpVtbl[2]))((IDxcResult*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcResult*, uint>)(lpVtbl[8]))((IDxcResult*)Unsafe.AsPointer(ref this));
         }
 
         public DXC_OUT_KIND GetOutputByIndex([NativeTypeName("UINT32")] uint Index)
         {
-            return ((delegate* stdcall<IDxcResult*, uint, DXC_OUT_KIND>)(lpVtbl[3]))((IDxcResult*)Unsafe.AsPointer(ref this), Index);
+            return ((delegate* stdcall<IDxcResult*, uint, DXC_OUT_KIND>)(lpVtbl[9]))((IDxcResult*)Unsafe.AsPointer(ref this), Index);
         }
 
         public DXC_OUT_KIND PrimaryOutput()
         {
-            return ((delegate* stdcall<IDxcResult*, DXC_OUT_KIND>)(lpVtbl[4]))((IDxcResult*)Unsafe.AsPointer(ref this));
+            return ((delegate* stdcall<IDxcResult*, DXC_OUT_KIND>)(lpVtbl[10]))((IDxcResult*)Unsafe.AsPointer(ref this));
         }
     }
 }

--- a/sources/Interop/Windows/other/dxc/dxcapi/IDxcUtils.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/IDxcUtils.cs
@@ -35,79 +35,79 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public int CreateBlobFromBlob([NativeTypeName("IDxcBlob *")] IDxcBlob* pBlob, [NativeTypeName("UINT32")] uint offset, [NativeTypeName("UINT32")] uint length, [NativeTypeName("IDxcBlob **")] IDxcBlob** ppResult)
         {
-            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, uint, uint, IDxcBlob**, int>)(lpVtbl[0]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, offset, length, ppResult);
+            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, uint, uint, IDxcBlob**, int>)(lpVtbl[3]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, offset, length, ppResult);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int CreateBlobFromPinned([NativeTypeName("LPCVOID")] void* pData, [NativeTypeName("UINT32")] uint size, [NativeTypeName("UINT32")] uint codePage, [NativeTypeName("IDxcBlobEncoding **")] IDxcBlobEncoding** pBlobEncoding)
         {
-            return ((delegate* stdcall<IDxcUtils*, void*, uint, uint, IDxcBlobEncoding**, int>)(lpVtbl[1]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, size, codePage, pBlobEncoding);
+            return ((delegate* stdcall<IDxcUtils*, void*, uint, uint, IDxcBlobEncoding**, int>)(lpVtbl[4]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, size, codePage, pBlobEncoding);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int MoveToBlob([NativeTypeName("LPCVOID")] void* pData, [NativeTypeName("IMalloc *")] IMalloc* pIMalloc, [NativeTypeName("UINT32")] uint size, [NativeTypeName("UINT32")] uint codePage, [NativeTypeName("IDxcBlobEncoding **")] IDxcBlobEncoding** pBlobEncoding)
         {
-            return ((delegate* stdcall<IDxcUtils*, void*, IMalloc*, uint, uint, IDxcBlobEncoding**, int>)(lpVtbl[2]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, pIMalloc, size, codePage, pBlobEncoding);
+            return ((delegate* stdcall<IDxcUtils*, void*, IMalloc*, uint, uint, IDxcBlobEncoding**, int>)(lpVtbl[5]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, pIMalloc, size, codePage, pBlobEncoding);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int CreateBlob([NativeTypeName("LPCVOID")] void* pData, [NativeTypeName("UINT32")] uint size, [NativeTypeName("UINT32")] uint codePage, [NativeTypeName("IDxcBlobEncoding **")] IDxcBlobEncoding** pBlobEncoding)
         {
-            return ((delegate* stdcall<IDxcUtils*, void*, uint, uint, IDxcBlobEncoding**, int>)(lpVtbl[3]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, size, codePage, pBlobEncoding);
+            return ((delegate* stdcall<IDxcUtils*, void*, uint, uint, IDxcBlobEncoding**, int>)(lpVtbl[6]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, size, codePage, pBlobEncoding);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int LoadFile([NativeTypeName("LPCWSTR")] ushort* pFileName, [NativeTypeName("UINT32 *")] uint* pCodePage, [NativeTypeName("IDxcBlobEncoding **")] IDxcBlobEncoding** pBlobEncoding)
         {
-            return ((delegate* stdcall<IDxcUtils*, ushort*, uint*, IDxcBlobEncoding**, int>)(lpVtbl[4]))((IDxcUtils*)Unsafe.AsPointer(ref this), pFileName, pCodePage, pBlobEncoding);
+            return ((delegate* stdcall<IDxcUtils*, ushort*, uint*, IDxcBlobEncoding**, int>)(lpVtbl[7]))((IDxcUtils*)Unsafe.AsPointer(ref this), pFileName, pCodePage, pBlobEncoding);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int CreateReadOnlyStreamFromBlob([NativeTypeName("IDxcBlob *")] IDxcBlob* pBlob, [NativeTypeName("IStream **")] IStream** ppStream)
         {
-            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IStream**, int>)(lpVtbl[5]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, ppStream);
+            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IStream**, int>)(lpVtbl[8]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, ppStream);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int CreateDefaultIncludeHandler([NativeTypeName("IDxcIncludeHandler **")] IDxcIncludeHandler** ppResult)
         {
-            return ((delegate* stdcall<IDxcUtils*, IDxcIncludeHandler**, int>)(lpVtbl[6]))((IDxcUtils*)Unsafe.AsPointer(ref this), ppResult);
+            return ((delegate* stdcall<IDxcUtils*, IDxcIncludeHandler**, int>)(lpVtbl[9]))((IDxcUtils*)Unsafe.AsPointer(ref this), ppResult);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetBlobAsUtf8([NativeTypeName("IDxcBlob *")] IDxcBlob* pBlob, [NativeTypeName("IDxcBlobUtf8 **")] IDxcBlobUtf8** pBlobEncoding)
         {
-            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IDxcBlobUtf8**, int>)(lpVtbl[7]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, pBlobEncoding);
+            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IDxcBlobUtf8**, int>)(lpVtbl[10]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, pBlobEncoding);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetBlobAsUtf16([NativeTypeName("IDxcBlob *")] IDxcBlob* pBlob, [NativeTypeName("IDxcBlobUtf16 **")] IDxcBlobUtf16** pBlobEncoding)
         {
-            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IDxcBlobUtf16**, int>)(lpVtbl[8]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, pBlobEncoding);
+            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IDxcBlobUtf16**, int>)(lpVtbl[11]))((IDxcUtils*)Unsafe.AsPointer(ref this), pBlob, pBlobEncoding);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetDxilContainerPart([NativeTypeName("const DxcBuffer *")] DxcBuffer* pShader, [NativeTypeName("UINT32")] uint DxcPart, [NativeTypeName("void **")] void** ppPartData, [NativeTypeName("UINT32 *")] uint* pPartSizeInBytes)
         {
-            return ((delegate* stdcall<IDxcUtils*, DxcBuffer*, uint, void**, uint*, int>)(lpVtbl[9]))((IDxcUtils*)Unsafe.AsPointer(ref this), pShader, DxcPart, ppPartData, pPartSizeInBytes);
+            return ((delegate* stdcall<IDxcUtils*, DxcBuffer*, uint, void**, uint*, int>)(lpVtbl[12]))((IDxcUtils*)Unsafe.AsPointer(ref this), pShader, DxcPart, ppPartData, pPartSizeInBytes);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int CreateReflection([NativeTypeName("const DxcBuffer *")] DxcBuffer* pData, [NativeTypeName("const IID &")] Guid* iid, [NativeTypeName("void **")] void** ppvReflection)
         {
-            return ((delegate* stdcall<IDxcUtils*, DxcBuffer*, Guid*, void**, int>)(lpVtbl[10]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, iid, ppvReflection);
+            return ((delegate* stdcall<IDxcUtils*, DxcBuffer*, Guid*, void**, int>)(lpVtbl[13]))((IDxcUtils*)Unsafe.AsPointer(ref this), pData, iid, ppvReflection);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int BuildArguments([NativeTypeName("LPCWSTR")] ushort* pSourceName, [NativeTypeName("LPCWSTR")] ushort* pEntryPoint, [NativeTypeName("LPCWSTR")] ushort* pTargetProfile, [NativeTypeName("LPCWSTR *")] ushort** pArguments, [NativeTypeName("UINT32")] uint argCount, [NativeTypeName("const DxcDefine *")] DxcDefine* pDefines, [NativeTypeName("UINT32")] uint defineCount, [NativeTypeName("IDxcCompilerArgs **")] IDxcCompilerArgs** ppArgs)
         {
-            return ((delegate* stdcall<IDxcUtils*, ushort*, ushort*, ushort*, ushort**, uint, DxcDefine*, uint, IDxcCompilerArgs**, int>)(lpVtbl[11]))((IDxcUtils*)Unsafe.AsPointer(ref this), pSourceName, pEntryPoint, pTargetProfile, pArguments, argCount, pDefines, defineCount, ppArgs);
+            return ((delegate* stdcall<IDxcUtils*, ushort*, ushort*, ushort*, ushort**, uint, DxcDefine*, uint, IDxcCompilerArgs**, int>)(lpVtbl[14]))((IDxcUtils*)Unsafe.AsPointer(ref this), pSourceName, pEntryPoint, pTargetProfile, pArguments, argCount, pDefines, defineCount, ppArgs);
         }
 
         [return: NativeTypeName("HRESULT")]
         public int GetPDBContents([NativeTypeName("IDxcBlob *")] IDxcBlob* pPDBBlob, [NativeTypeName("IDxcBlob **")] IDxcBlob** ppHash, [NativeTypeName("IDxcBlob **")] IDxcBlob** ppContainer)
         {
-            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IDxcBlob**, IDxcBlob**, int>)(lpVtbl[12]))((IDxcUtils*)Unsafe.AsPointer(ref this), pPDBBlob, ppHash, ppContainer);
+            return ((delegate* stdcall<IDxcUtils*, IDxcBlob*, IDxcBlob**, IDxcBlob**, int>)(lpVtbl[15]))((IDxcUtils*)Unsafe.AsPointer(ref this), pPDBBlob, ppHash, ppContainer);
         }
     }
 }


### PR DESCRIPTION
It was missed in the regeneration after the hierarchy issue was fixed.