### PR TITLE
Ensure tests are regenerated by default

### DIFF
--- a/generation/other/dxc/dxcapi/generate.rsp
+++ b/generation/other/dxc/dxcapi/generate.rsp
@@ -46,6 +46,8 @@ IDxcVersionInfo2
 other-dxcapi.h
 --output
 ../../../../sources/Interop/Windows/other/dxc/dxcapi
+--test-output
+../../../../tests/Interop/Windows/other/dxc/dxcapi
 --traverse
 include/dxc/dxcapi.h
 --with-attribute

--- a/generation/settings.rsp
+++ b/generation/settings.rsp
@@ -6,6 +6,7 @@
 -Wno-nonportable-include-path
 -Wno-pragma-pack
 --config
+generate-tests-nunit
 multi-file
 preview-codegen-fnptr
 preview-codegen-nint

--- a/generation/shared/dcomptypes/generate.rsp
+++ b/generation/shared/dcomptypes/generate.rsp
@@ -4,5 +4,7 @@
 shared-dcomptypes.h
 --output
 ../../../sources/Interop/Windows/shared/dcomptypes
+--test-output
+../../../tests/Interop/Windows/shared/dcomptypes
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dcomptypes.h

--- a/generation/shared/devpropdef/generate.rsp
+++ b/generation/shared/devpropdef/generate.rsp
@@ -9,5 +9,7 @@ operator!=(const DEVPROPCOMPKEY &, const DEVPROPCOMPKEY &):bool
 shared-devpropdef.h
 --output
 ../../../sources/Interop/Windows/shared/devpropdef
+--test-output
+../../../tests/Interop/Windows/shared/devpropdef
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/devpropdef.h

--- a/generation/shared/dxgi/generate.rsp
+++ b/generation/shared/dxgi/generate.rsp
@@ -37,6 +37,8 @@ __MIDL_itf_dxgi_0000_0014_v0_0_s_ifspec
 shared-dxgi.h
 --output
 ../../../sources/Interop/Windows/shared/dxgi
+--test-output
+../../../tests/Interop/Windows/shared/dxgi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgi.h
 --with-attribute

--- a/generation/shared/dxgi1_2/generate.rsp
+++ b/generation/shared/dxgi1_2/generate.rsp
@@ -28,6 +28,8 @@ __MIDL_itf_dxgi1_2_0000_0009_v0_0_s_ifspec
 shared-dxgi1_2.h
 --output
 ../../../sources/Interop/Windows/shared/dxgi1_2
+--test-output
+../../../tests/Interop/Windows/shared/dxgi1_2
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgi1_2.h
 --with-attribute

--- a/generation/shared/dxgi1_3/generate.rsp
+++ b/generation/shared/dxgi1_3/generate.rsp
@@ -25,6 +25,8 @@ __MIDL_itf_dxgi1_3_0000_0008_v0_0_s_ifspec
 shared-dxgi1_3.h
 --output
 ../../../sources/Interop/Windows/shared/dxgi1_3
+--test-output
+../../../tests/Interop/Windows/shared/dxgi1_3
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgi1_3.h
 --with-attribute

--- a/generation/shared/dxgi1_4/generate.rsp
+++ b/generation/shared/dxgi1_4/generate.rsp
@@ -17,6 +17,8 @@ __MIDL_itf_dxgi1_4_0000_0004_v0_0_s_ifspec
 shared-dxgi1_4.h
 --output
 ../../../sources/Interop/Windows/shared/dxgi1_4
+--test-output
+../../../tests/Interop/Windows/shared/dxgi1_4
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgi1_4.h
 --with-attribute

--- a/generation/shared/dxgi1_5/generate.rsp
+++ b/generation/shared/dxgi1_5/generate.rsp
@@ -19,6 +19,8 @@ __MIDL_itf_dxgi1_5_0000_0004_v0_0_s_ifspec
 shared-dxgi1_5.h
 --output
 ../../../sources/Interop/Windows/shared/dxgi1_5
+--test-output
+../../../tests/Interop/Windows/shared/dxgi1_5
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgi1_5.h
 --with-attribute

--- a/generation/shared/dxgi1_6/generate.rsp
+++ b/generation/shared/dxgi1_6/generate.rsp
@@ -31,6 +31,8 @@ operator~(DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS):DXGI_HARDWARE_COMPOSITION_SUP
 shared-dxgi1_6.h
 --output
 ../../../sources/Interop/Windows/shared/dxgi1_6
+--test-output
+../../../tests/Interop/Windows/shared/dxgi1_6
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgi1_6.h
 --with-attribute

--- a/generation/shared/dxgicommon/generate.rsp
+++ b/generation/shared/dxgicommon/generate.rsp
@@ -4,6 +4,8 @@
 shared-dxgicommon.h
 --output
 ../../../sources/Interop/Windows/shared/dxgicommon
+--test-output
+../../../tests/Interop/Windows/shared/dxgicommon
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgicommon.h
 --with-type

--- a/generation/shared/dxgiformat/generate.rsp
+++ b/generation/shared/dxgiformat/generate.rsp
@@ -4,6 +4,8 @@
 shared-dxgiformat.h
 --output
 ../../../sources/Interop/Windows/shared/dxgiformat
+--test-output
+../../../tests/Interop/Windows/shared/dxgiformat
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgiformat.h
 --with-type

--- a/generation/shared/dxgitype/generate.rsp
+++ b/generation/shared/dxgitype/generate.rsp
@@ -4,5 +4,7 @@
 shared-dxgitype.h
 --output
 ../../../sources/Interop/Windows/shared/dxgitype
+--test-output
+../../../tests/Interop/Windows/shared/dxgitype
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/dxgitype.h

--- a/generation/shared/hidclass/generate.rsp
+++ b/generation/shared/hidclass/generate.rsp
@@ -8,5 +8,7 @@ GUID_HID_INTERFACE_HIDPARSE
 shared-hidclass.h
 --output
 ../../../sources/Interop/Windows/shared/hidclass
+--test-output
+../../../tests/Interop/Windows/shared/hidclass
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/hidclass.h

--- a/generation/shared/hidpi/generate.rsp
+++ b/generation/shared/hidpi/generate.rsp
@@ -6,6 +6,8 @@ _HIDP_PREPARSED_DATA
 shared-hidpi.h
 --output
 ../../../sources/Interop/Windows/shared/hidpi
+--test-output
+../../../tests/Interop/Windows/shared/hidpi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/hidpi.h
 --with-librarypath

--- a/generation/shared/hidsdi/generate.rsp
+++ b/generation/shared/hidsdi/generate.rsp
@@ -6,6 +6,8 @@ _HIDP_PREPARSED_DATA
 shared-hidsdi.h
 --output
 ../../../sources/Interop/Windows/shared/hidsdi
+--test-output
+../../../tests/Interop/Windows/shared/hidsdi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/hidsdi.h
 --with-librarypath

--- a/generation/shared/hidusage/generate.rsp
+++ b/generation/shared/hidusage/generate.rsp
@@ -4,5 +4,7 @@
 shared-hidusage.h
 --output
 ../../../sources/Interop/Windows/shared/hidusage
+--test-output
+../../../tests/Interop/Windows/shared/hidusage
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/hidusage.h

--- a/generation/shared/intsafe/generate.rsp
+++ b/generation/shared/intsafe/generate.rsp
@@ -179,5 +179,7 @@ UShortToUInt8(USHORT, UINT8 *):HRESULT
 shared-intsafe.h
 --output
 ../../../sources/Interop/Windows/shared/intsafe
+--test-output
+../../../tests/Interop/Windows/shared/intsafe
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/intsafe.h

--- a/generation/shared/minwindef/generate.rsp
+++ b/generation/shared/minwindef/generate.rsp
@@ -16,5 +16,7 @@ HWINSTA__
 shared-minwindef.h
 --output
 ../../../sources/Interop/Windows/shared/minwindef
+--test-output
+../../../tests/Interop/Windows/shared/minwindef
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/minwindef.h

--- a/generation/shared/mmreg/generate.rsp
+++ b/generation/shared/mmreg/generate.rsp
@@ -9,5 +9,7 @@ tag_s_RIFFWAVE_INST
 shared-mmreg.h
 --output
 ../../../sources/Interop/Windows/shared/mmreg
+--test-output
+../../../tests/Interop/Windows/shared/mmreg
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/mmreg.h

--- a/generation/shared/tvout/generate.rsp
+++ b/generation/shared/tvout/generate.rsp
@@ -6,6 +6,8 @@ NOSYSPARAMSINFO
 shared-tvout.h
 --output
 ../../../sources/Interop/Windows/shared/tvout
+--test-output
+../../../tests/Interop/Windows/shared/tvout
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/tvout.h
 --with-librarypath

--- a/generation/shared/windef/generate.rsp
+++ b/generation/shared/windef/generate.rsp
@@ -24,5 +24,7 @@ HWND__
 shared-windef.h
 --output
 ../../../sources/Interop/Windows/shared/windef
+--test-output
+../../../tests/Interop/Windows/shared/windef
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/windef.h

--- a/generation/shared/winerror/generate.rsp
+++ b/generation/shared/winerror/generate.rsp
@@ -4,5 +4,7 @@
 shared-winerror.h
 --output
 ../../../sources/Interop/Windows/shared/winerror
+--test-output
+../../../tests/Interop/Windows/shared/winerror
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/winerror.h

--- a/generation/shared/winioctl/generate.rsp
+++ b/generation/shared/winioctl/generate.rsp
@@ -4,5 +4,7 @@
 shared-winioctl.h
 --output
 ../../../sources/Interop/Windows/shared/winioctl
+--test-output
+../../../tests/Interop/Windows/shared/winioctl
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/winioctl.h

--- a/generation/shared/wtypes/generate.rsp
+++ b/generation/shared/wtypes/generate.rsp
@@ -11,5 +11,7 @@ __MIDL_itf_wtypes_0000_0001_v0_0_s_ifspec
 shared-wtypes.h
 --output
 ../../../sources/Interop/Windows/shared/wtypes
+--test-output
+../../../tests/Interop/Windows/shared/wtypes
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/wtypes.h

--- a/generation/shared/wtypesbase/generate.rsp
+++ b/generation/shared/wtypesbase/generate.rsp
@@ -11,5 +11,7 @@ __MIDL_itf_wtypesbase_0000_0001_v0_0_s_ifspec
 shared-wtypesbase.h
 --output
 ../../../sources/Interop/Windows/shared/wtypesbase
+--test-output
+../../../tests/Interop/Windows/shared/wtypesbase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/shared/wtypesbase.h

--- a/generation/um/AudioSessionTypes/generate.rsp
+++ b/generation/um/AudioSessionTypes/generate.rsp
@@ -4,5 +4,7 @@
 um-AudioSessionTypes.h
 --output
 ../../../sources/Interop/Windows/um/AudioSessionTypes
+--test-output
+../../../tests/Interop/Windows/um/AudioSessionTypes
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/AudioSessionTypes.h

--- a/generation/um/D2DErr/generate.rsp
+++ b/generation/um/D2DErr/generate.rsp
@@ -4,5 +4,7 @@
 um-D2DErr.h
 --output
 ../../../sources/Interop/Windows/um/D2DErr
+--test-output
+../../../tests/Interop/Windows/um/D2DErr
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/D2DErr.h

--- a/generation/um/DXGIMessages/generate.rsp
+++ b/generation/um/DXGIMessages/generate.rsp
@@ -4,5 +4,7 @@
 um-DXGIMessages.h
 --output
 ../../../sources/Interop/Windows/um/DXGIMessages
+--test-output
+../../../tests/Interop/Windows/um/DXGIMessages
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/DXGIMessages.h

--- a/generation/um/DirectML/generate.rsp
+++ b/generation/um/DirectML/generate.rsp
@@ -30,6 +30,8 @@ operator~(DML_TENSOR_FLAGS):DML_TENSOR_FLAGS
 um-DirectML.h
 --output
 ../../../sources/Interop/Windows/um/DirectML
+--test-output
+../../../tests/Interop/Windows/um/DirectML
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/DirectML.h
 --with-attribute

--- a/generation/um/DocumentTarget/generate.rsp
+++ b/generation/um/DocumentTarget/generate.rsp
@@ -24,6 +24,8 @@ __MIDL_itf_documenttarget_0000_0004_v0_0_s_ifspec
 um-DocumentTarget.h
 --output
 ../../../sources/Interop/Windows/um/DocumentTarget
+--test-output
+../../../tests/Interop/Windows/um/DocumentTarget
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/DocumentTarget.h
 --with-attribute

--- a/generation/um/OAIdl/generate.rsp
+++ b/generation/um/OAIdl/generate.rsp
@@ -180,6 +180,8 @@ __MIDL_itf_oaidl_0000_0023_v0_0_s_ifspec
 um-OAIdl.h
 --output
 ../../../sources/Interop/Windows/um/OAIdl
+--test-output
+../../../tests/Interop/Windows/um/OAIdl
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/OAIdl.h
 --with-attribute

--- a/generation/um/OCIdl/generate.rsp
+++ b/generation/um/OCIdl/generate.rsp
@@ -169,6 +169,8 @@ __MIDL_itf_ocidl_0000_0041_v0_0_s_ifspec
 um-OCIdl.h
 --output
 ../../../sources/Interop/Windows/um/OCIdl
+--test-output
+../../../tests/Interop/Windows/um/OCIdl
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/OCIdl.h
 --with-attribute

--- a/generation/um/ObjIdl/generate.rsp
+++ b/generation/um/ObjIdl/generate.rsp
@@ -321,6 +321,8 @@ __MIDL_itf_objidl_0000_0091_v0_0_s_ifspec
 um-ObjIdl.h
 --output
 ../../../sources/Interop/Windows/um/ObjIdl
+--test-output
+../../../tests/Interop/Windows/um/ObjIdl
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/ObjIdl.h
 --with-attribute

--- a/generation/um/ObjIdlbase/generate.rsp
+++ b/generation/um/ObjIdlbase/generate.rsp
@@ -124,6 +124,8 @@ __MIDL_itf_objidlbase_0000_0053_v0_0_s_ifspec
 um-ObjIdlbase.h
 --output
 ../../../sources/Interop/Windows/um/ObjIdlbase
+--test-output
+../../../tests/Interop/Windows/um/ObjIdlbase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/ObjIdlbase.h
 --with-attribute

--- a/generation/um/PropIdlBase/generate.rsp
+++ b/generation/um/PropIdlBase/generate.rsp
@@ -37,6 +37,8 @@ __MIDL_itf_propidlbase_0000_0004_v0_0_s_ifspec
 um-PropIdlBase.h
 --output
 ../../../sources/Interop/Windows/um/PropIdlBase
+--test-output
+../../../tests/Interop/Windows/um/PropIdlBase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/PropIdlBase.h
 --with-attribute

--- a/generation/um/SetupAPI/generate.rsp
+++ b/generation/um/SetupAPI/generate.rsp
@@ -4,6 +4,8 @@
 um-SetupAPI.h
 --output
 ../../../sources/Interop/Windows/um/SetupAPI
+--test-output
+../../../tests/Interop/Windows/um/SetupAPI
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/SetupAPI.h
 --with-librarypath

--- a/generation/um/SoftPub/generate.rsp
+++ b/generation/um/SoftPub/generate.rsp
@@ -4,5 +4,7 @@
 um-SoftPub.h
 --output
 ../../../sources/Interop/Windows/um/SoftPub
+--test-output
+../../../tests/Interop/Windows/um/SoftPub
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/SoftPub.h

--- a/generation/um/Unknwnbase/generate.rsp
+++ b/generation/um/Unknwnbase/generate.rsp
@@ -31,6 +31,8 @@ __MIDL_itf_unknwnbase_0000_0003_v0_0_s_ifspec
 um-Unknwnbase.h
 --output
 ../../../sources/Interop/Windows/um/Unknwnbase
+--test-output
+../../../tests/Interop/Windows/um/Unknwnbase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/Unknwnbase.h
 --with-attribute

--- a/generation/um/WinBase/generate.rsp
+++ b/generation/um/WinBase/generate.rsp
@@ -35,6 +35,8 @@ _InterlockedXor(volatile unsigned long long *, unsigned long long):unsigned long
 um-WinBase.h
 --output
 ../../../sources/Interop/Windows/um/WinBase
+--test-output
+../../../tests/Interop/Windows/um/WinBase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/WinBase.h
 --with-librarypath

--- a/generation/um/WinTrust/generate.rsp
+++ b/generation/um/WinTrust/generate.rsp
@@ -8,6 +8,8 @@ SIP_SUBJECTINFO_
 um-WinTrust.h
 --output
 ../../../sources/Interop/Windows/um/wintrust
+--test-output
+../../../tests/Interop/Windows/um/wintrust
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/WinTrust.h
 --with-librarypath

--- a/generation/um/WinUser/generate.rsp
+++ b/generation/um/WinUser/generate.rsp
@@ -45,6 +45,8 @@ WINSTAENUMPROCW
 um-WinUser.h
 --output
 ../../../sources/Interop/Windows/um/WinUser
+--test-output
+../../../tests/Interop/Windows/um/WinUser
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/WinUser.h
 --with-type

--- a/generation/um/Xinput/generate.rsp
+++ b/generation/um/Xinput/generate.rsp
@@ -4,6 +4,8 @@
 um-Xinput.h
 --output
 ../../../sources/Interop/Windows/um/Xinput
+--test-output
+../../../tests/Interop/Windows/um/Xinput
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/Xinput.h
 --with-librarypath

--- a/generation/um/combaseapi/generate.rsp
+++ b/generation/um/combaseapi/generate.rsp
@@ -8,6 +8,8 @@ IID_PPV_ARGS_Helper<T>(T **):void **
 um-combaseapi.h
 --output
 ../../../sources/Interop/Windows/um/combaseapi
+--test-output
+../../../tests/Interop/Windows/um/combaseapi
 --with-attribute
 COINITBASE=Flags
 COWAIT_FLAGS=Flags

--- a/generation/um/d2d1/generate.rsp
+++ b/generation/um/d2d1/generate.rsp
@@ -152,6 +152,8 @@ operator~(D2D1_WINDOW_STATE):D2D1_WINDOW_STATE
 um-d2d1.h
 --output
 ../../../sources/Interop/Windows/um/d2d1
+--test-output
+../../../tests/Interop/Windows/um/d2d1
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1.h
 --with-attribute

--- a/generation/um/d2d1_1/generate.rsp
+++ b/generation/um/d2d1_1/generate.rsp
@@ -145,6 +145,8 @@ operator~(D2D1_MAP_OPTIONS):D2D1_MAP_OPTIONS
 um-d2d1_1.h
 --output
 ../../../sources/Interop/Windows/um/d2d1_1
+--test-output
+../../../tests/Interop/Windows/um/d2d1_1
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1_1.h
 --with-attribute

--- a/generation/um/d2d1_2/generate.rsp
+++ b/generation/um/d2d1_2/generate.rsp
@@ -53,6 +53,8 @@ IID_ID2D1GeometryRealization
 um-d2d1_2.h
 --output
 ../../../sources/Interop/Windows/um/d2d1_2
+--test-output
+../../../tests/Interop/Windows/um/d2d1_2
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1_2.h
 --with-attribute

--- a/generation/um/d2d1_3/generate.rsp
+++ b/generation/um/d2d1_3/generate.rsp
@@ -122,6 +122,8 @@ operator~(D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS):D2D1_TRANSFORMED_IMAGE_SOURCE_O
 um-d2d1_3.h
 --output
 ../../../sources/Interop/Windows/um/d2d1_3
+--test-output
+../../../tests/Interop/Windows/um/d2d1_3
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1_3.h
 --with-attribute

--- a/generation/um/d2d1effectauthor/generate.rsp
+++ b/generation/um/d2d1effectauthor/generate.rsp
@@ -45,6 +45,8 @@ operator~(D2D1_VERTEX_OPTIONS):D2D1_VERTEX_OPTIONS
 um-d2d1effectauthor.h
 --output
 ../../../sources/Interop/Windows/um/d2d1effectauthor
+--test-output
+../../../tests/Interop/Windows/um/d2d1effectauthor
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1effectauthor.h
 --with-attribute

--- a/generation/um/d2d1effectauthor_1/generate.rsp
+++ b/generation/um/d2d1effectauthor_1/generate.rsp
@@ -7,6 +7,8 @@ IID_ID2D1EffectContext2
 um-d2d1effectauthor_1.h
 --output
 ../../../sources/Interop/Windows/um/d2d1effectauthor_1
+--test-output
+../../../tests/Interop/Windows/um/d2d1effectauthor_1
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1effectauthor_1.h
 --with-attribute

--- a/generation/um/d2d1effects/generate.rsp
+++ b/generation/um/d2d1effects/generate.rsp
@@ -46,6 +46,8 @@ CLSID_D2D1UnPremultiply
 um-d2d1effects.h
 --output
 ../../../sources/Interop/Windows/um/d2d1effects
+--test-output
+../../../tests/Interop/Windows/um/d2d1effects
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1effects.h
 --with-type

--- a/generation/um/d2d1effects_1/generate.rsp
+++ b/generation/um/d2d1effects_1/generate.rsp
@@ -6,6 +6,8 @@ CLSID_D2D1YCbCr
 um-d2d1effects_1.h
 --output
 ../../../sources/Interop/Windows/um/d2d1effects_1
+--test-output
+../../../tests/Interop/Windows/um/d2d1effects_1
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1effects_1.h
 --with-type

--- a/generation/um/d2d1effects_2/generate.rsp
+++ b/generation/um/d2d1effects_2/generate.rsp
@@ -28,6 +28,8 @@ CLSID_D2D1WhiteLevelAdjustment
 um-d2d1effects_2.h
 --output
 ../../../sources/Interop/Windows/um/d2d1effects_2
+--test-output
+../../../tests/Interop/Windows/um/d2d1effects_2
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1effects_2.h
 --with-type

--- a/generation/um/d2d1svg/generate.rsp
+++ b/generation/um/d2d1svg/generate.rsp
@@ -19,6 +19,8 @@ IID_ID2D1SvgStrokeDashArray
 um-d2d1svg.h
 --output
 ../../../sources/Interop/Windows/um/d2d1svg
+--test-output
+../../../tests/Interop/Windows/um/d2d1svg
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d2d1svg.h
 --with-attribute

--- a/generation/um/d3d11/generate.rsp
+++ b/generation/um/d3d11/generate.rsp
@@ -192,6 +192,8 @@ operator!=
 um-d3d11.h
 --output
 ../../../sources/Interop/Windows/um/d3d11
+--test-output
+../../../tests/Interop/Windows/um/d3d11
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11.h
 --with-attribute

--- a/generation/um/d3d11_1/generate.rsp
+++ b/generation/um/d3d11_1/generate.rsp
@@ -26,6 +26,8 @@ __MIDL_itf_d3d11_1_0000_0009_v0_0_s_ifspec
 um-d3d11_1.h
 --output
 ../../../sources/Interop/Windows/um/d3d11_1
+--test-output
+../../../tests/Interop/Windows/um/d3d11_1
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11_1.h
 --with-attribute

--- a/generation/um/d3d11_2/generate.rsp
+++ b/generation/um/d3d11_2/generate.rsp
@@ -11,6 +11,8 @@ __MIDL_itf_d3d11_2_0000_0002_v0_0_s_ifspec
 um-d3d11_2.h
 --output
 ../../../sources/Interop/Windows/um/d3d11_2
+--test-output
+../../../tests/Interop/Windows/um/d3d11_2
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11_2.h
 --with-attribute

--- a/generation/um/d3d11_3/generate.rsp
+++ b/generation/um/d3d11_3/generate.rsp
@@ -48,6 +48,8 @@ operator~(D3D11_FENCE_FLAG):D3D11_FENCE_FLAG
 um-d3d11_3.h
 --output
 ../../../sources/Interop/Windows/um/d3d11_3
+--test-output
+../../../tests/Interop/Windows/um/d3d11_3
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11_3.h
 --with-attribute

--- a/generation/um/d3d11_4/generate.rsp
+++ b/generation/um/d3d11_4/generate.rsp
@@ -33,6 +33,8 @@ operator~(D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS):D3D11_VIDEO_DECODER_HIS
 um-d3d11_4.h
 --output
 ../../../sources/Interop/Windows/um/d3d11_4
+--test-output
+../../../tests/Interop/Windows/um/d3d11_4
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11_4.h
 --with-attribute

--- a/generation/um/d3d11on12/generate.rsp
+++ b/generation/um/d3d11on12/generate.rsp
@@ -14,6 +14,8 @@ __MIDL_itf_d3d11on12_0000_0003_v0_0_s_ifspec
 um-d3d11on12.h
 --output
 ../../../sources/Interop/Windows/um/d3d11on12
+--test-output
+../../../tests/Interop/Windows/um/d3d11on12
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11on12.h
 --with-attribute

--- a/generation/um/d3d11sdklayers/generate.rsp
+++ b/generation/um/d3d11sdklayers/generate.rsp
@@ -29,6 +29,8 @@ __MIDL_itf_d3d11sdklayers_0000_0006_v0_0_s_ifspec
 um-d3d11sdklayers.h
 --output
 ../../../sources/Interop/Windows/um/d3d11sdklayers
+--test-output
+../../../tests/Interop/Windows/um/d3d11sdklayers
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11sdklayers.h
 --with-attribute

--- a/generation/um/d3d11shader/generate.rsp
+++ b/generation/um/d3d11shader/generate.rsp
@@ -38,6 +38,8 @@ IID_ID3D11ShaderReflectionVariable
 um-d3d11shader.h
 --output
 ../../../sources/Interop/Windows/um/d3d11shader
+--test-output
+../../../tests/Interop/Windows/um/d3d11shader
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11shader.h
 --with-attribute

--- a/generation/um/d3d11shadertracing/generate.rsp
+++ b/generation/um/d3d11shadertracing/generate.rsp
@@ -12,6 +12,8 @@ __MIDL_itf_d3d11ShaderTracing_0000_0002_v0_0_s_ifspec
 um-d3d11shadertracing.h
 --output
 ../../../sources/Interop/Windows/um/d3d11shadertracing
+--test-output
+../../../tests/Interop/Windows/um/d3d11shadertracing
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d11shadertracing.h
 --with-attribute

--- a/generation/um/d3d12/generate.rsp
+++ b/generation/um/d3d12/generate.rsp
@@ -395,6 +395,8 @@ __MIDL_itf_d3d12_0000_0052_v0_0_s_ifspec
 um-d3d12.h
 --output
 ../../../sources/Interop/Windows/um/d3d12
+--test-output
+../../../tests/Interop/Windows/um/d3d12
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d12.h
 --with-attribute

--- a/generation/um/d3d12sdklayers/generate.rsp
+++ b/generation/um/d3d12sdklayers/generate.rsp
@@ -61,6 +61,8 @@ __MIDL_itf_d3d12sdklayers_0000_0013_v0_0_s_ifspec
 um-d3d12sdklayers.h
 --output
 ../../../sources/Interop/Windows/um/d3d12sdklayers
+--test-output
+../../../tests/Interop/Windows/um/d3d12sdklayers
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d12sdklayers.h
 --with-attribute

--- a/generation/um/d3d12shader/generate.rsp
+++ b/generation/um/d3d12shader/generate.rsp
@@ -18,6 +18,8 @@ IID_ID3D12FunctionParameterReflection
 um-d3d12shader.h
 --output
 ../../../sources/Interop/Windows/um/d3d12shader
+--test-output
+../../../tests/Interop/Windows/um/d3d12shader
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d12shader.h
 --with-attribute

--- a/generation/um/d3d12video/generate.rsp
+++ b/generation/um/d3d12video/generate.rsp
@@ -170,6 +170,8 @@ __MIDL_itf_d3d12video_0000_0020_v0_0_s_ifspec
 um-d3d12video.h
 --output
 ../../../sources/Interop/Windows/um/d3d12video
+--test-output
+../../../tests/Interop/Windows/um/d3d12video
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3d12video.h
 --with-attribute

--- a/generation/um/d3dcommon/generate.rsp
+++ b/generation/um/d3dcommon/generate.rsp
@@ -18,6 +18,8 @@ __MIDL_itf_d3dcommon_0000_0002_v0_0_s_ifspec
 um-d3dcommon.h
 --output
 ../../../sources/Interop/Windows/um/d3dcommon
+--test-output
+../../../tests/Interop/Windows/um/d3dcommon
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3dcommon.h
 --with-attribute

--- a/generation/um/d3dcompiler/generate.rsp
+++ b/generation/um/d3dcompiler/generate.rsp
@@ -7,6 +7,8 @@ ID3D10Effect
 um-d3dcompiler.h
 --output
 ../../../sources/Interop/Windows/um/d3dcompiler
+--test-output
+../../../tests/Interop/Windows/um/d3dcompiler
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/d3dcompiler.h
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um\d3dcompiler.inl

--- a/generation/um/dcommon/generate.rsp
+++ b/generation/um/dcommon/generate.rsp
@@ -13,6 +13,8 @@ operator~(DWRITE_GLYPH_IMAGE_FORMATS):DWRITE_GLYPH_IMAGE_FORMATS
 um-dcommon.h
 --output
 ../../../sources/Interop/Windows/um/dcommon
+--test-output
+../../../tests/Interop/Windows/um/dcommon
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dcommon.h
 --with-attribute

--- a/generation/um/dcomp/generate.rsp
+++ b/generation/um/dcomp/generate.rsp
@@ -4,6 +4,8 @@
 um-dcomp.h
 --output
 ../../../sources/Interop/Windows/um/dcomp
+--test-output
+../../../tests/Interop/Windows/um/dcomp
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dcomp.h
 --with-attribute

--- a/generation/um/dcompanimation/generate.rsp
+++ b/generation/um/dcompanimation/generate.rsp
@@ -10,6 +10,8 @@ __MIDL_itf_dcompanimation_0000_0001_v0_0_s_ifspec
 um-dcompanimation.h
 --output
 ../../../sources/Interop/Windows/um/dcompanimation
+--test-output
+../../../tests/Interop/Windows/um/dcompanimation
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dcompanimation.h
 --with-attribute

--- a/generation/um/dwrite/generate.rsp
+++ b/generation/um/dwrite/generate.rsp
@@ -20,6 +20,8 @@ operator~(DWRITE_SCRIPT_SHAPES):DWRITE_SCRIPT_SHAPES
 um-dwrite.h
 --output
 ../../../sources/Interop/Windows/um/dwrite
+--test-output
+../../../tests/Interop/Windows/um/dwrite
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dwrite.h
 --with-attribute

--- a/generation/um/dwrite_1/generate.rsp
+++ b/generation/um/dwrite_1/generate.rsp
@@ -4,6 +4,8 @@
 um-dwrite_1.h
 --output
 ../../../sources/Interop/Windows/um/dwrite_1
+--test-output
+../../../tests/Interop/Windows/um/dwrite_1
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dwrite_1.h
 --with-attribute

--- a/generation/um/dwrite_2/generate.rsp
+++ b/generation/um/dwrite_2/generate.rsp
@@ -6,6 +6,8 @@ _D3DCOLORVALUE
 um-dwrite_2.h
 --output
 ../../../sources/Interop/Windows/um/dwrite_2
+--test-output
+../../../tests/Interop/Windows/um/dwrite_2
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dwrite_2.h
 --with-attribute

--- a/generation/um/dwrite_3/generate.rsp
+++ b/generation/um/dwrite_3/generate.rsp
@@ -19,6 +19,8 @@ operator~(DWRITE_FONT_AXIS_ATTRIBUTES):DWRITE_FONT_AXIS_ATTRIBUTES
 um-dwrite_3.h
 --output
 ../../../sources/Interop/Windows/um/dwrite_3
+--test-output
+../../../tests/Interop/Windows/um/dwrite_3
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dwrite_3.h
 --with-attribute

--- a/generation/um/dxcapi/generate.rsp
+++ b/generation/um/dxcapi/generate.rsp
@@ -22,6 +22,8 @@ DxcVersionInfoFlags_None
 um-dxcapi.h
 --output
 ../../../sources/Interop/Windows/um/dxcapi
+--test-output
+../../../tests/Interop/Windows/um/dxcapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dxcapi.h
 --with-attribute

--- a/generation/um/dxcore/generate.rsp
+++ b/generation/um/dxcore/generate.rsp
@@ -6,6 +6,8 @@ DXCoreCreateAdapterFactory<T>(T **):HRESULT
 um-dxcore.h
 --output
 ../../../sources/Interop/Windows/um/dxcore
+--test-output
+../../../tests/Interop/Windows/um/dxcore
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dxcore.h
 --with-librarypath

--- a/generation/um/dxcore_interface/generate.rsp
+++ b/generation/um/dxcore_interface/generate.rsp
@@ -20,6 +20,8 @@ IID_IDXCoreAdapterList
 um-dxcore_interface.h
 --output
 ../../../sources/Interop/Windows/um/dxcore_interface
+--test-output
+../../../tests/Interop/Windows/um/dxcore_interface
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dxcore_interface.h
 --with-attribute

--- a/generation/um/dxgidebug/generate.rsp
+++ b/generation/um/dxgidebug/generate.rsp
@@ -16,6 +16,8 @@ __MIDL_itf_dxgidebug_0000_0003_v0_0_s_ifspec
 um-dxgidebug.h
 --output
 ../../../sources/Interop/Windows/um/dxgidebug
+--test-output
+../../../tests/Interop/Windows/um/dxgidebug
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dxgidebug.h
 --with-attribute

--- a/generation/um/fileapi/generate.rsp
+++ b/generation/um/fileapi/generate.rsp
@@ -4,6 +4,8 @@
 um-fileapi.h
 --output
 ../../../sources/Interop/Windows/um/fileapi
+--test-output
+../../../tests/Interop/Windows/um/fileapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/fileapi.h
 --with-librarypath

--- a/generation/um/handleapi/generate.rsp
+++ b/generation/um/handleapi/generate.rsp
@@ -4,6 +4,8 @@
 um-handleapi.h
 --output
 ../../../sources/Interop/Windows/um/handleapi
+--test-output
+../../../tests/Interop/Windows/um/handleapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/handleapi.h
 --with-librarypath

--- a/generation/um/heapapi/generate.rsp
+++ b/generation/um/heapapi/generate.rsp
@@ -4,6 +4,8 @@
 um-heapapi.h
 --output
 ../../../sources/Interop/Windows/um/heapapi
+--test-output
+../../../tests/Interop/Windows/um/heapapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/heapapi.h
 --with-librarypath

--- a/generation/um/ioapiset/generate.rsp
+++ b/generation/um/ioapiset/generate.rsp
@@ -4,6 +4,8 @@
 um-ioapiset.h
 --output
 ../../../sources/Interop/Windows/um/ioapiset
+--test-output
+../../../tests/Interop/Windows/um/ioapiset
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/ioapiset.h
 --with-librarypath

--- a/generation/um/libloaderapi/generate.rsp
+++ b/generation/um/libloaderapi/generate.rsp
@@ -4,6 +4,8 @@
 um-libloaderapi.h
 --output
 ../../../sources/Interop/Windows/um/libloaderapi
+--test-output
+../../../tests/Interop/Windows/um/libloaderapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/libloaderapi.h
 --with-librarypath

--- a/generation/um/minwinbase/generate.rsp
+++ b/generation/um/minwinbase/generate.rsp
@@ -4,5 +4,7 @@
 um-minwinbase.h
 --output
 ../../../sources/Interop/Windows/um/minwinbase
+--test-output
+../../../tests/Interop/Windows/um/minwinbase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/minwinbase.h

--- a/generation/um/mmeapi/generate.rsp
+++ b/generation/um/mmeapi/generate.rsp
@@ -18,6 +18,8 @@ WAVECALLBACK
 um-mmeapi.h
 --output
 ../../../sources/Interop/Windows/um/mmeapi
+--test-output
+../../../tests/Interop/Windows/um/mmeapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/mmeapi.h
 --with-librarypath

--- a/generation/um/mmsyscom/generate.rsp
+++ b/generation/um/mmsyscom/generate.rsp
@@ -8,5 +8,7 @@ PDRVCALLBACK
 um-mmsyscom.h
 --output
 ../../../sources/Interop/Windows/um/mmsyscom
+--test-output
+../../../tests/Interop/Windows/um/mmsyscom
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/mmsyscom.h

--- a/generation/um/mssip/generate.rsp
+++ b/generation/um/mssip/generate.rsp
@@ -4,6 +4,8 @@
 um-mssip.h
 --output
 ../../../sources/Interop/Windows/um/mssip
+--test-output
+../../../tests/Interop/Windows/um/mssip
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/mssip.h
 --with-librarypath

--- a/generation/um/msxml/generate.rsp
+++ b/generation/um/msxml/generate.rsp
@@ -49,6 +49,8 @@ __MIDL_itf_msxml_0000_0001_v0_0_s_ifspec
 um-msxml.h
 --output
 ../../../sources/Interop/Windows/um/msxml
+--test-output
+../../../tests/Interop/Windows/um/msxml
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/msxml.h
 --with-attribute
@@ -80,4 +82,4 @@ IXMLElementCollection=Guid("65725580-9B5D-11D0-9BFE-00C04FC99C8E")
 IXMLError=Guid("948C5AD3-C58D-11D0-9C0B-00C04FC99C8E")
 IXMLHttpRequest=Guid("ED8C108D-4349-11D2-91A4-00C04F7969E8")
 IXTLRuntime=Guid("3EFAA425-272F-11D2-836F-0000F87A7782")
-XMLDOMDocumentEvents=Guid("7D5ED177-3263-3311-A8AD-9B085C7F6C79")
+XMLDOMDocumentEvents=Guid("3EFAA427-272F-11D2-836F-0000F87A7782")

--- a/generation/um/ntstatus/generate.rsp
+++ b/generation/um/ntstatus/generate.rsp
@@ -4,5 +4,7 @@
 um-ntstatus.h
 --output
 ../../../sources/Interop/Windows/um/ntstatus
+--test-output
+../../../tests/Interop/Windows/um/ntstatus
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/ntstatus.h

--- a/generation/um/oleidl/generate.rsp
+++ b/generation/um/oleidl/generate.rsp
@@ -129,6 +129,8 @@ __MIDL_itf_oleidl_0000_0025_v0_0_s_ifspec
 um-oleidl.h
 --output
 ../../../sources/Interop/Windows/um/oleidl
+--test-output
+../../../tests/Interop/Windows/um/oleidl
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/oleidl.h
 --with-attribute

--- a/generation/um/processthreadsapi/generate.rsp
+++ b/generation/um/processthreadsapi/generate.rsp
@@ -9,6 +9,8 @@ _PROC_THREAD_ATTRIBUTE_LIST
 um-processthreadsapi.h
 --output
 ../../../sources/Interop/Windows/um/processthreadsapi
+--test-output
+../../../tests/Interop/Windows/um/processthreadsapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/processthreadsapi.h
 --with-librarypath

--- a/generation/um/profileapi/generate.rsp
+++ b/generation/um/profileapi/generate.rsp
@@ -4,6 +4,8 @@
 um-profileapi.h
 --output
 ../../../sources/Interop/Windows/um/profileapi
+--test-output
+../../../tests/Interop/Windows/um/profileapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/profileapi.h
 --with-librarypath

--- a/generation/um/prsht/generate.rsp
+++ b/generation/um/prsht/generate.rsp
@@ -6,6 +6,8 @@ _PSP
 um-prsht.h
 --output
 ../../../sources/Interop/Windows/um/prsht
+--test-output
+../../../tests/Interop/Windows/um/prsht
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/prsht.h
 --with-librarypath

--- a/generation/um/securitybaseapi/generate.rsp
+++ b/generation/um/securitybaseapi/generate.rsp
@@ -4,6 +4,8 @@
 um-securitybaseapi.h
 --output
 ../../../sources/Interop/Windows/um/securitybaseapi
+--test-output
+../../../tests/Interop/Windows/um/securitybaseapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/securitybaseapi.h
 --with-librarypath

--- a/generation/um/servprov/generate.rsp
+++ b/generation/um/servprov/generate.rsp
@@ -15,6 +15,8 @@ __MIDL_itf_servprov_0000_0001_v0_0_s_ifspec
 um-servprov.h
 --output
 ../../../sources/Interop/Windows/um/servprov
+--test-output
+../../../tests/Interop/Windows/um/servprov
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/servprov.h
 --with-attribute

--- a/generation/um/synchapi/generate.rsp
+++ b/generation/um/synchapi/generate.rsp
@@ -4,6 +4,8 @@
 um-synchapi.h
 --output
 ../../../sources/Interop/Windows/um/synchapi
+--test-output
+../../../tests/Interop/Windows/um/synchapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/synchapi.h
 --with-librarypath

--- a/generation/um/sysinfoapi/generate.rsp
+++ b/generation/um/sysinfoapi/generate.rsp
@@ -4,6 +4,8 @@
 um-sysinfoapi.h
 --output
 ../../../sources/Interop/Windows/um/sysinfoapi
+--test-output
+../../../tests/Interop/Windows/um/sysinfoapi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/sysinfoapi.h
 --with-librarypath

--- a/generation/um/urlmon/generate.rsp
+++ b/generation/um/urlmon/generate.rsp
@@ -256,6 +256,8 @@ __MIDL_itf_urlmon_0000_0055_v0_0_s_ifspec
 um-urlmon.h
 --output
 ../../../sources/Interop/Windows/um/urlmon
+--test-output
+../../../tests/Interop/Windows/um/urlmon
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/urlmon.h
 --with-attribute

--- a/generation/um/wincodec/generate.rsp
+++ b/generation/um/wincodec/generate.rsp
@@ -226,6 +226,8 @@ __MIDL_itf_wincodec_0000_0040_v0_0_s_ifspec
 um-wincodec.h
 --output
 ../../../sources/Interop/Windows/um/wincodec
+--test-output
+../../../tests/Interop/Windows/um/wincodec
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/wincodec.h
 --with-attribute

--- a/generation/um/wincodecsdk/generate.rsp
+++ b/generation/um/wincodecsdk/generate.rsp
@@ -166,6 +166,8 @@ __MIDL_itf_wincodecsdk_0000_0010_v0_0_s_ifspec
 um-wincodecsdk.h
 --output
 ../../../sources/Interop/Windows/um/wincodecsdk
+--test-output
+../../../tests/Interop/Windows/um/wincodecsdk
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/wincodecsdk.h
 --with-attribute

--- a/generation/um/wincrypt/generate.rsp
+++ b/generation/um/wincrypt/generate.rsp
@@ -4,6 +4,8 @@
 um-wincrypt.h
 --output
 ../../../sources/Interop/Windows/um/wincrypt
+--test-output
+../../../tests/Interop/Windows/um/wincrypt
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/wincrypt.h
 --with-librarypath

--- a/generation/um/wingdi/generate.rsp
+++ b/generation/um/wingdi/generate.rsp
@@ -8,6 +8,8 @@ FONTENUMPROCW
 um-wingdi.h
 --output
 ../../../sources/Interop/Windows/um/wingdi
+--test-output
+../../../tests/Interop/Windows/um/wingdi
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/wingdi.h
 --with-type

--- a/generation/um/winnt/generate.rsp
+++ b/generation/um/winnt/generate.rsp
@@ -419,6 +419,8 @@ __writefsword(DWORD, WORD):void
 um-winnt.h
 --output
 ../../../sources/Interop/Windows/um/winnt
+--test-output
+../../../tests/Interop/Windows/um/winnt
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/winnt.h
 --with-attribute

--- a/generation/um/x3daudio/generate.rsp
+++ b/generation/um/x3daudio/generate.rsp
@@ -10,6 +10,8 @@ um-x3daudio.h
 ./
 --output
 ../../../sources/Interop/Windows/um/x3daudio
+--test-output
+../../../tests/Interop/Windows/um/x3daudio
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/x3daudio.h
 --with-using

--- a/generation/um/xapo/generate.rsp
+++ b/generation/um/xapo/generate.rsp
@@ -7,6 +7,8 @@ IID_IXAPOParameters
 um-xapo.h
 --output
 ../../../sources/Interop/Windows/um/xapo
+--test-output
+../../../tests/Interop/Windows/um/xapo
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xapo.h
 --with-attribute

--- a/generation/um/xapobase/generate.rsp
+++ b/generation/um/xapobase/generate.rsp
@@ -7,5 +7,7 @@ CXAPOParametersBase
 um-xapobase.h
 --output
 ../../../sources/Interop/Windows/um/xapobase
+--test-output
+../../../tests/Interop/Windows/um/xapobase
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xapobase.h

--- a/generation/um/xapofx/generate.rsp
+++ b/generation/um/xapofx/generate.rsp
@@ -13,6 +13,8 @@ FXReverb
 um-xapofx.h
 --output
 ../../../sources/Interop/Windows/um/xapofx
+--test-output
+../../../tests/Interop/Windows/um/xapofx
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xapofx.h
 --with-librarypath

--- a/generation/um/xaudio2/generate.rsp
+++ b/generation/um/xaudio2/generate.rsp
@@ -71,6 +71,8 @@ XAudio2Create(IXAudio2 **, UINT32, XAUDIO2_PROCESSOR):HRESULT
 um-xaudio2.h
 --output
 ../../../sources/Interop/Windows/um/xaudio2
+--test-output
+../../../tests/Interop/Windows/um/xaudio2
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xaudio2.h
 --with-attribute

--- a/generation/um/xaudio2fx/generate.rsp
+++ b/generation/um/xaudio2fx/generate.rsp
@@ -12,6 +12,8 @@ XAudio2CreateVolumeMeter(IUnknown **, UINT32):HRESULT
 um-xaudio2fx.h
 --output
 ../../../sources/Interop/Windows/um/xaudio2fx
+--test-output
+../../../tests/Interop/Windows/um/xaudio2fx
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xaudio2fx.h
 --with-librarypath

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RANGE.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RANGE.Manual.cs
@@ -3,8 +3,6 @@
 // Ported from d3dx12.h in DirectX-Graphics-Samples commit a7a87f1853b5540f10920518021d91ae641033fb
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
-using System;
-
 namespace TerraFX.Interop
 {
     public partial struct D3D12_RANGE

--- a/sources/Interop/Windows/other/d3dx12/D3D12_SHADER_BYTECODE.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_SHADER_BYTECODE.Manual.cs
@@ -3,8 +3,6 @@
 // Ported from d3dx12.h in DirectX-Graphics-Samples commit a7a87f1853b5540f10920518021d91ae641033fb
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
-using System;
-
 namespace TerraFX.Interop
 {
     public unsafe partial struct D3D12_SHADER_BYTECODE

--- a/sources/Interop/Windows/other/dxc/dxcapi/Windows.Manual.cs
+++ b/sources/Interop/Windows/other/dxc/dxcapi/Windows.Manual.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {

--- a/sources/Interop/Windows/shared/devpropdef/DEVPROPCOMPKEY.cs
+++ b/sources/Interop/Windows/shared/devpropdef/DEVPROPCOMPKEY.cs
@@ -3,6 +3,8 @@
 // Ported from shared/devpropdef.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public unsafe partial struct DEVPROPCOMPKEY

--- a/sources/Interop/Windows/shared/devpropdef/DEVPROPERTY.cs
+++ b/sources/Interop/Windows/shared/devpropdef/DEVPROPERTY.cs
@@ -3,6 +3,8 @@
 // Ported from shared/devpropdef.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public unsafe partial struct DEVPROPERTY

--- a/sources/Interop/Windows/um/ObjIdl/FLAG_STGMEDIUM.cs
+++ b/sources/Interop/Windows/um/ObjIdl/FLAG_STGMEDIUM.cs
@@ -3,6 +3,8 @@
 // Ported from um/ObjIdl.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct FLAG_STGMEDIUM

--- a/sources/Interop/Windows/um/WinUser/MOUSEHOOKSTRUCTEX.cs
+++ b/sources/Interop/Windows/um/WinUser/MOUSEHOOKSTRUCTEX.cs
@@ -3,6 +3,8 @@
 // Ported from um/WinUser.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct MOUSEHOOKSTRUCTEX

--- a/sources/Interop/Windows/um/WinUser/POINTER_PEN_INFO.cs
+++ b/sources/Interop/Windows/um/WinUser/POINTER_PEN_INFO.cs
@@ -3,6 +3,8 @@
 // Ported from um/WinUser.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct POINTER_PEN_INFO

--- a/sources/Interop/Windows/um/WinUser/POINTER_TOUCH_INFO.cs
+++ b/sources/Interop/Windows/um/WinUser/POINTER_TOUCH_INFO.cs
@@ -3,6 +3,8 @@
 // Ported from um/WinUser.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct POINTER_TOUCH_INFO

--- a/sources/Interop/Windows/um/WinUser/POINTER_TYPE_INFO.cs
+++ b/sources/Interop/Windows/um/WinUser/POINTER_TYPE_INFO.cs
@@ -3,6 +3,7 @@
 // Ported from um/WinUser.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop

--- a/sources/Interop/Windows/um/WinUser/RAWINPUT.cs
+++ b/sources/Interop/Windows/um/WinUser/RAWINPUT.cs
@@ -3,6 +3,7 @@
 // Ported from um/WinUser.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_OUTPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_OUTPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_OUTPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_ACESSIBILITY_OUTPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_ACESSIBILITY_OUTPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_ACESSIBILITY_OUTPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT_OUTPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT_OUTPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT_OUTPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT

--- a/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT_OUTPUT.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT_OUTPUT.cs
@@ -3,6 +3,8 @@
 // Ported from um/d3d11.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
+
 namespace TerraFX.Interop
 {
     public partial struct D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT_OUTPUT

--- a/sources/Interop/Windows/um/dxcapi/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/dxcapi/Windows.Manual.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop
 {

--- a/sources/Interop/Windows/um/minwinbase/DEBUG_EVENT.cs
+++ b/sources/Interop/Windows/um/minwinbase/DEBUG_EVENT.cs
@@ -3,6 +3,7 @@
 // Ported from um/minwinbase.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop

--- a/sources/Interop/Windows/um/mmeapi/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/mmeapi/Windows.Manual.cs
@@ -3,9 +3,6 @@
 // Ported from um/mmeapi.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
-using System;
-using System.Runtime.InteropServices;
-
 namespace TerraFX.Interop
 {
     public static unsafe partial class Windows

--- a/sources/Interop/Windows/um/x3daudio/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/x3daudio/Windows.Manual.cs
@@ -3,8 +3,6 @@
 // Ported from um/x3daudio.h in the Windows SDK for Windows 10.0.19041.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
-using System.Runtime.InteropServices;
-
 namespace TerraFX.Interop
 {
     public static unsafe partial class Windows

--- a/tests/Interop/Windows/other/dxc/dxcapi/DxcBufferTests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/DxcBufferTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/other/dxc/dxcapi/DxcShaderHashTests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/DxcShaderHashTests.cs
@@ -1,10 +1,9 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf16Tests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf16Tests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf8Tests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/IDxcBlobUtf8Tests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/other/dxc/dxcapi/IDxcCompiler3Tests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/IDxcCompiler3Tests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/other/dxc/dxcapi/IDxcCompilerArgsTests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/IDxcCompilerArgsTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/other/dxc/dxcapi/IDxcResultTests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/IDxcResultTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/other/dxc/dxcapi/IDxcUtilsTests.cs
+++ b/tests/Interop/Windows/other/dxc/dxcapi/IDxcUtilsTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from include/dxc/dxcapi.h in the microsoft/DirectXCompiler commit e0cde072b09b51506c0460697b2695d6cccca59d
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/shared/dcomptypes/DCOMPOSITION_FRAME_STATISTICSTests.cs
+++ b/tests/Interop/Windows/shared/dcomptypes/DCOMPOSITION_FRAME_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/devpropdef/DEVPROPKEYTests.cs
+++ b/tests/Interop/Windows/shared/devpropdef/DEVPROPKEYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi/DXGI_DISPLAY_COLOR_SPACETests.cs
+++ b/tests/Interop/Windows/shared/dxgi/DXGI_DISPLAY_COLOR_SPACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi/DXGI_FRAME_STATISTICSTests.cs
+++ b/tests/Interop/Windows/shared/dxgi/DXGI_FRAME_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi/DXGI_SURFACE_DESCTests.cs
+++ b/tests/Interop/Windows/shared/dxgi/DXGI_SURFACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_MODE_DESC1Tests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_MODE_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_DESCTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_FRAME_INFOTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_FRAME_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_MOVE_RECTTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_MOVE_RECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_POINTER_POSITIONTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_POINTER_POSITIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_POINTER_SHAPE_INFOTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_OUTDUPL_POINTER_SHAPE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_SWAP_CHAIN_DESC1Tests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_SWAP_CHAIN_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_2/DXGI_SWAP_CHAIN_FULLSCREEN_DESCTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_2/DXGI_SWAP_CHAIN_FULLSCREEN_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_3/DXGI_DECODE_SWAP_CHAIN_DESCTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_3/DXGI_DECODE_SWAP_CHAIN_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_3/DXGI_FRAME_STATISTICS_MEDIATests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_3/DXGI_FRAME_STATISTICS_MEDIATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_3/DXGI_MATRIX_3X2_FTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_3/DXGI_MATRIX_3X2_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_4/DXGI_QUERY_VIDEO_MEMORY_INFOTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_4/DXGI_QUERY_VIDEO_MEMORY_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_5/DXGI_HDR_METADATA_HDR10PLUSTests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_5/DXGI_HDR_METADATA_HDR10PLUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgi1_5/DXGI_HDR_METADATA_HDR10Tests.cs
+++ b/tests/Interop/Windows/shared/dxgi1_5/DXGI_HDR_METADATA_HDR10Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgicommon/DXGI_RATIONALTests.cs
+++ b/tests/Interop/Windows/shared/dxgicommon/DXGI_RATIONALTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgicommon/DXGI_SAMPLE_DESCTests.cs
+++ b/tests/Interop/Windows/shared/dxgicommon/DXGI_SAMPLE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_GAMMA_CONTROLTests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_GAMMA_CONTROLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_GAMMA_CONTROL_CAPABILITIESTests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_GAMMA_CONTROL_CAPABILITIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_JPEG_AC_HUFFMAN_TABLETests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_JPEG_AC_HUFFMAN_TABLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_JPEG_DC_HUFFMAN_TABLETests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_JPEG_DC_HUFFMAN_TABLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_JPEG_QUANTIZATION_TABLETests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_JPEG_QUANTIZATION_TABLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_MODE_DESCTests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_MODE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_RGBATests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_RGBATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/dxgitype/DXGI_RGBTests.cs
+++ b/tests/Interop/Windows/shared/dxgitype/DXGI_RGBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidclass/HID_COLLECTION_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/shared/hidclass/HID_COLLECTION_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidclass/HID_DRIVER_CONFIGTests.cs
+++ b/tests/Interop/Windows/shared/hidclass/HID_DRIVER_CONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/HIDP_BUTTON_CAPSTests.cs
+++ b/tests/Interop/Windows/shared/hidpi/HIDP_BUTTON_CAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/HIDP_CAPSTests.cs
+++ b/tests/Interop/Windows/shared/hidpi/HIDP_CAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/HIDP_DATATests.cs
+++ b/tests/Interop/Windows/shared/hidpi/HIDP_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/HIDP_KEYBOARD_MODIFIER_STATETests.cs
+++ b/tests/Interop/Windows/shared/hidpi/HIDP_KEYBOARD_MODIFIER_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/HIDP_UNKNOWN_TOKENTests.cs
+++ b/tests/Interop/Windows/shared/hidpi/HIDP_UNKNOWN_TOKENTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/HIDP_VALUE_CAPSTests.cs
+++ b/tests/Interop/Windows/shared/hidpi/HIDP_VALUE_CAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidpi/USAGE_AND_PAGETests.cs
+++ b/tests/Interop/Windows/shared/hidpi/USAGE_AND_PAGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/hidsdi/HIDD_ATTRIBUTESTests.cs
+++ b/tests/Interop/Windows/shared/hidsdi/HIDD_ATTRIBUTESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/minwindef/FILETIMETests.cs
+++ b/tests/Interop/Windows/shared/minwindef/FILETIMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/ADPCMCOEFSETTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/ADPCMCOEFSETTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/ADPCMEWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/ADPCMEWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/ADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/ADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/APTXWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/APTXWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/AUDIOFILE_AF10WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/AUDIOFILE_AF10WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/AUDIOFILE_AF36WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/AUDIOFILE_AF36WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/CONTRESCR10WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/CONTRESCR10WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/CONTRESVQLPCWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/CONTRESVQLPCWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/CREATIVEADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/CREATIVEADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/CREATIVEFASTSPEECH10WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/CREATIVEFASTSPEECH10WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/CREATIVEFASTSPEECH8WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/CREATIVEFASTSPEECH8WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/CSIMAADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/CSIMAADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DIALOGICOKIADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DIALOGICOKIADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DIGIADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DIGIADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DIGIFIXWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DIGIFIXWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DIGIREALWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DIGIREALWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DIGISTDWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DIGISTDWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DOLBYAC2WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DOLBYAC2WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DRMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DRMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/DVIADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/DVIADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/ECHOSC1WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/ECHOSC1WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/ECHOWAVEFILTERTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/ECHOWAVEFILTERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/EXBMINFOHEADERTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/EXBMINFOHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/FMTOWNS_SND_WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/FMTOWNS_SND_WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/G721_ADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/G721_ADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/G723_ADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/G723_ADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/GSM610WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/GSM610WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/HEAACWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/HEAACWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/HEAACWAVEINFOTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/HEAACWAVEINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/IMAADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/IMAADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/JPEGINFOHEADERTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/JPEGINFOHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/MEDIASPACEADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/MEDIASPACEADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/MPEG1WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/MPEG1WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/MPEGLAYER3WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/MPEGLAYER3WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/MSAUDIO1WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/MSAUDIO1WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/NMS_VBXADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/NMS_VBXADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/OLIADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/OLIADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/OLICELPWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/OLICELPWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/OLIGSMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/OLIGSMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/OLIOPRWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/OLIOPRWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/OLISBCWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/OLISBCWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/SIERRAADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/SIERRAADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/SONARCWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/SONARCWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/TRUESPEECHWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/TRUESPEECHWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/VOLUMEWAVEFILTERTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/VOLUMEWAVEFILTERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/WAVEFILTERTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/WAVEFILTERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/WAVEFORMATEXTENSIBLETests.cs
+++ b/tests/Interop/Windows/shared/mmreg/WAVEFORMATEXTENSIBLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/WMAUDIO2WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/WMAUDIO2WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/WMAUDIO3WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/WMAUDIO3WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/YAMAHA_ADPCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/YAMAHA_ADPCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/mmreg/s_RIFFWAVE_instTests.cs
+++ b/tests/Interop/Windows/shared/mmreg/s_RIFFWAVE_instTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/tvout/VIDEOPARAMETERSTests.cs
+++ b/tests/Interop/Windows/shared/tvout/VIDEOPARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/APP_LOCAL_DEVICE_IDTests.cs
+++ b/tests/Interop/Windows/shared/windef/APP_LOCAL_DEVICE_IDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/POINTLTests.cs
+++ b/tests/Interop/Windows/shared/windef/POINTLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/POINTSTests.cs
+++ b/tests/Interop/Windows/shared/windef/POINTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/POINTTests.cs
+++ b/tests/Interop/Windows/shared/windef/POINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/RECTLTests.cs
+++ b/tests/Interop/Windows/shared/windef/RECTLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/RECTTests.cs
+++ b/tests/Interop/Windows/shared/windef/RECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/windef/SIZETests.cs
+++ b/tests/Interop/Windows/shared/windef/SIZETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/CSPLATFORMTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/CSPLATFORMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/CYTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/CYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/DECIMALTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/DECIMALTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/PROPERTYKEYTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/PROPERTYKEYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/QUERYCONTEXTTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/QUERYCONTEXTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemBRUSHTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemBRUSHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemHBITMAPTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemHBITMAPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemHENHMETAFILETests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemHENHMETAFILETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemHGLOBALTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemHGLOBALTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemHMETAFILEPICTTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemHMETAFILEPICTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemHPALETTETests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemHPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/RemotableHandleTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/RemotableHandleTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userBITMAPTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userBITMAPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userHBITMAPTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userHBITMAPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userHENHMETAFILETests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userHENHMETAFILETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userHGLOBALTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userHGLOBALTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userHMETAFILEPICTTests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userHMETAFILEPICTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userHMETAFILETests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userHMETAFILETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypes/userHPALETTETests.cs
+++ b/tests/Interop/Windows/shared/wtypes/userHPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypesbase/BYTE_BLOBTests.cs
+++ b/tests/Interop/Windows/shared/wtypesbase/BYTE_BLOBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypesbase/DWORD_BLOBTests.cs
+++ b/tests/Interop/Windows/shared/wtypesbase/DWORD_BLOBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypesbase/FLAGGED_BYTE_BLOBTests.cs
+++ b/tests/Interop/Windows/shared/wtypesbase/FLAGGED_BYTE_BLOBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypesbase/FLAGGED_WORD_BLOBTests.cs
+++ b/tests/Interop/Windows/shared/wtypesbase/FLAGGED_WORD_BLOBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/shared/wtypesbase/WORD_BLOBTests.cs
+++ b/tests/Interop/Windows/shared/wtypesbase/WORD_BLOBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_BINDING_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_BINDING_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_BUFFER_BINDINGTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_BUFFER_BINDINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_FEATURE_DATA_FEATURE_LEVELSTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_FEATURE_DATA_FEATURE_LEVELSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_SCALE_BIASTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_SCALE_BIASTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/DirectML/DML_SIZE_2DTests.cs
+++ b/tests/Interop/Windows/um/DirectML/DML_SIZE_2DTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_ALTPLATFORM_INFO_V1Tests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_ALTPLATFORM_INFO_V1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_ALTPLATFORM_INFO_V2Tests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_ALTPLATFORM_INFO_V2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_ALTPLATFORM_INFO_V3Tests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_ALTPLATFORM_INFO_V3Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V1_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V1_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V1_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V1_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V2_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V2_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V2_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_BACKUP_QUEUE_PARAMS_V2_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_CLASSINSTALL_HEADERTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_CLASSINSTALL_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_DEVICE_INTERFACE_DETAIL_DATA_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_DEVICE_INTERFACE_DETAIL_DATA_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_DEVICE_INTERFACE_DETAIL_DATA_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_DEVICE_INTERFACE_DETAIL_DATA_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_ENABLECLASS_PARAMSTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_ENABLECLASS_PARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_INF_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_INF_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V1_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V1_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V1_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V1_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V2_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V2_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V2_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_INF_SIGNER_INFO_V2_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_ORIGINAL_FILE_INFO_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_ORIGINAL_FILE_INFO_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_ORIGINAL_FILE_INFO_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_ORIGINAL_FILE_INFO_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_POWERMESSAGEWAKE_PARAMS_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_POWERMESSAGEWAKE_PARAMS_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_POWERMESSAGEWAKE_PARAMS_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_POWERMESSAGEWAKE_PARAMS_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_PROPCHANGE_PARAMSTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_PROPCHANGE_PARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_REMOVEDEVICE_PARAMSTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_REMOVEDEVICE_PARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_SELECTDEVICE_PARAMS_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_SELECTDEVICE_PARAMS_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_SELECTDEVICE_PARAMS_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_SELECTDEVICE_PARAMS_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_TROUBLESHOOTER_PARAMS_ATests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_TROUBLESHOOTER_PARAMS_ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_TROUBLESHOOTER_PARAMS_WTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_TROUBLESHOOTER_PARAMS_WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SetupAPI/SP_UNREMOVEDEVICE_PARAMSTests.cs
+++ b/tests/Interop/Windows/um/SetupAPI/SP_UNREMOVEDEVICE_PARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SoftPub/CONFIG_CI_PROV_INFO_RESULTTests.cs
+++ b/tests/Interop/Windows/um/SoftPub/CONFIG_CI_PROV_INFO_RESULTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/SoftPub/DRIVER_VER_MAJORMINORTests.cs
+++ b/tests/Interop/Windows/um/SoftPub/DRIVER_VER_MAJORMINORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/COMMCONFIGTests.cs
+++ b/tests/Interop/Windows/um/WinBase/COMMCONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/COMMPROPTests.cs
+++ b/tests/Interop/Windows/um/WinBase/COMMPROPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/COMMTIMEOUTSTests.cs
+++ b/tests/Interop/Windows/um/WinBase/COMMTIMEOUTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/COMSTATTests.cs
+++ b/tests/Interop/Windows/um/WinBase/COMSTATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/DCBTests.cs
+++ b/tests/Interop/Windows/um/WinBase/DCBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/EVENTLOG_FULL_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/WinBase/EVENTLOG_FULL_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ALIGNMENT_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ALIGNMENT_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ALLOCATION_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ALLOCATION_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ATTRIBUTE_TAG_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ATTRIBUTE_TAG_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_BASIC_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_BASIC_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_CASE_SENSITIVE_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_CASE_SENSITIVE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_COMPRESSION_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_COMPRESSION_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_DISPOSITION_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_DISPOSITION_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_DISPOSITION_INFO_EXTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_DISPOSITION_INFO_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_END_OF_FILE_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_END_OF_FILE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_FULL_DIR_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_FULL_DIR_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ID_BOTH_DIR_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ID_BOTH_DIR_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ID_DESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ID_DESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ID_EXTD_DIR_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ID_EXTD_DIR_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_ID_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_ID_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_IO_PRIORITY_HINT_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_IO_PRIORITY_HINT_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_NAME_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_NAME_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_REMOTE_PROTOCOL_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_REMOTE_PROTOCOL_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_STANDARD_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_STANDARD_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_STORAGE_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_STORAGE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/FILE_STREAM_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/FILE_STREAM_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/HW_PROFILE_INFOATests.cs
+++ b/tests/Interop/Windows/um/WinBase/HW_PROFILE_INFOATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/HW_PROFILE_INFOWTests.cs
+++ b/tests/Interop/Windows/um/WinBase/HW_PROFILE_INFOWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/JIT_DEBUG_INFOTests.cs
+++ b/tests/Interop/Windows/um/WinBase/JIT_DEBUG_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/OFSTRUCTTests.cs
+++ b/tests/Interop/Windows/um/WinBase/OFSTRUCTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/OPERATION_END_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/WinBase/OPERATION_END_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/OPERATION_START_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/WinBase/OPERATION_START_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/SYSTEM_POWER_STATUSTests.cs
+++ b/tests/Interop/Windows/um/WinBase/SYSTEM_POWER_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/UMS_SYSTEM_THREAD_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/WinBase/UMS_SYSTEM_THREAD_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/WinBase/WIN32_STREAM_IDTests.cs
+++ b/tests/Interop/Windows/um/WinBase/WIN32_STREAM_IDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/Xinput/XINPUT_BATTERY_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/Xinput/XINPUT_BATTERY_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/Xinput/XINPUT_CAPABILITIESTests.cs
+++ b/tests/Interop/Windows/um/Xinput/XINPUT_CAPABILITIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/Xinput/XINPUT_GAMEPADTests.cs
+++ b/tests/Interop/Windows/um/Xinput/XINPUT_GAMEPADTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/Xinput/XINPUT_KEYSTROKETests.cs
+++ b/tests/Interop/Windows/um/Xinput/XINPUT_KEYSTROKETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/Xinput/XINPUT_STATETests.cs
+++ b/tests/Interop/Windows/um/Xinput/XINPUT_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/Xinput/XINPUT_VIBRATIONTests.cs
+++ b/tests/Interop/Windows/um/Xinput/XINPUT_VIBRATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/combaseapi/ServerInformationTests.cs
+++ b/tests/Interop/Windows/um/combaseapi/ServerInformationTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_ARC_SEGMENTTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_ARC_SEGMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_BEZIER_SEGMENTTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_BEZIER_SEGMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_BITMAP_BRUSH_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_BITMAP_BRUSH_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_BITMAP_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_BITMAP_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_BRUSH_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_BRUSH_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_DRAWING_STATE_DESCRIPTIONTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_DRAWING_STATE_DESCRIPTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_ELLIPSETests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_ELLIPSETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_FACTORY_OPTIONSTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_FACTORY_OPTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_GRADIENT_STOPTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_GRADIENT_STOPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_QUADRATIC_BEZIER_SEGMENTTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_QUADRATIC_BEZIER_SEGMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_RENDER_TARGET_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_RENDER_TARGET_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_ROUNDED_RECTTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_ROUNDED_RECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_STROKE_STYLE_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_STROKE_STYLE_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1/D2D1_TRIANGLETests.cs
+++ b/tests/Interop/Windows/um/d2d1/D2D1_TRIANGLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_BITMAP_BRUSH_PROPERTIES1Tests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_BITMAP_BRUSH_PROPERTIES1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_CREATION_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_CREATION_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_DRAWING_STATE_DESCRIPTION1Tests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_DRAWING_STATE_DESCRIPTION1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_IMAGE_BRUSH_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_IMAGE_BRUSH_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_POINT_DESCRIPTIONTests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_POINT_DESCRIPTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_PRINT_CONTROL_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_PRINT_CONTROL_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_RENDERING_CONTROLSTests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_RENDERING_CONTROLSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_1/D2D1_STROKE_STYLE_PROPERTIES1Tests.cs
+++ b/tests/Interop/Windows/um/d2d1_1/D2D1_STROKE_STYLE_PROPERTIES1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_3/D2D1_GRADIENT_MESH_PATCHTests.cs
+++ b/tests/Interop/Windows/um/d2d1_3/D2D1_GRADIENT_MESH_PATCHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_3/D2D1_INK_BEZIER_SEGMENTTests.cs
+++ b/tests/Interop/Windows/um/d2d1_3/D2D1_INK_BEZIER_SEGMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_3/D2D1_INK_POINTTests.cs
+++ b/tests/Interop/Windows/um/d2d1_3/D2D1_INK_POINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_3/D2D1_INK_STYLE_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1_3/D2D1_INK_STYLE_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_3/D2D1_SIMPLE_COLOR_PROFILETests.cs
+++ b/tests/Interop/Windows/um/d2d1_3/D2D1_SIMPLE_COLOR_PROFILETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1_3/D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d2d1_3/D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1effectauthor/D2D1_BLEND_DESCRIPTIONTests.cs
+++ b/tests/Interop/Windows/um/d2d1effectauthor/D2D1_BLEND_DESCRIPTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1effectauthor/D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONSTests.cs
+++ b/tests/Interop/Windows/um/d2d1effectauthor/D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1effectauthor/D2D1_FEATURE_DATA_DOUBLESTests.cs
+++ b/tests/Interop/Windows/um/d2d1effectauthor/D2D1_FEATURE_DATA_DOUBLESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1effectauthor/D2D1_INPUT_DESCRIPTIONTests.cs
+++ b/tests/Interop/Windows/um/d2d1effectauthor/D2D1_INPUT_DESCRIPTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1effectauthor/D2D1_VERTEX_RANGETests.cs
+++ b/tests/Interop/Windows/um/d2d1effectauthor/D2D1_VERTEX_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1svg/D2D1_SVG_LENGTHTests.cs
+++ b/tests/Interop/Windows/um/d2d1svg/D2D1_SVG_LENGTHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1svg/D2D1_SVG_PRESERVE_ASPECT_RATIOTests.cs
+++ b/tests/Interop/Windows/um/d2d1svg/D2D1_SVG_PRESERVE_ASPECT_RATIOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d2d1svg/D2D1_SVG_VIEWBOXTests.cs
+++ b/tests/Interop/Windows/um/d2d1svg/D2D1_SVG_VIEWBOXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_AES_CTR_IVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_AES_CTR_IVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_PROTECTION_FLAGSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_AUTHENTICATED_PROTECTION_FLAGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BLEND_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BLEND_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BOXTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BOXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BUFFEREX_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BUFFEREX_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_BUFFER_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_CLASS_INSTANCE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_CLASS_INSTANCE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_COUNTER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_COUNTER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_COUNTER_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_COUNTER_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_DEPTH_STENCILOP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_DEPTH_STENCILOP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_DEPTH_STENCIL_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_DEPTH_STENCIL_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_DEPTH_STENCIL_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_DEPTH_STENCIL_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_DRAW_INSTANCED_INDIRECT_ARGSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_DRAW_INSTANCED_INDIRECT_ARGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_ENCRYPTED_BLOCK_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_ENCRYPTED_BLOCK_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_ARCHITECTURE_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_ARCHITECTURE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS2Tests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS3Tests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS3Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS5Tests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONS5Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D11_OPTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_OPTIONS1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_OPTIONS1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_OPTIONSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_OPTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_DOUBLESTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_DOUBLESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_FORMAT_SUPPORT2Tests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_FORMAT_SUPPORT2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_FORMAT_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_FORMAT_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_MARKER_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_MARKER_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_SHADER_CACHETests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_SHADER_CACHETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_THREADINGTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_FEATURE_DATA_THREADINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_OMACTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_OMACTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DATA_PIPELINE_STATISTICSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DATA_PIPELINE_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DATA_SO_STATISTICSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DATA_SO_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DATA_TIMESTAMP_DISJOINTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DATA_TIMESTAMP_DISJOINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_QUERY_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_RASTERIZER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_RASTERIZER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_RENDER_TARGET_BLEND_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_RENDER_TARGET_BLEND_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_RENDER_TARGET_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_RENDER_TARGET_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_SAMPLER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_SAMPLER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_SHADER_RESOURCE_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_SHADER_RESOURCE_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_ARRAY_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX1D_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_ARRAY_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_ARRAY_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_ARRAY_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_ARRAY_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2DMS_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_VPOVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_ARRAY_VPOVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_VDOVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_VDOVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_VPIVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_VPIVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_VPOVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX2D_VPOVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX3D_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX3D_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX3D_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX3D_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEX3D_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEX3D_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEXCUBE_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEXCUBE_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEXCUBE_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEXCUBE_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEXTURE1D_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEXTURE1D_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEXTURE2D_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEXTURE2D_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_TEXTURE3D_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_TEXTURE3D_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_UNORDERED_ACCESS_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_UNORDERED_ACCESS_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_COLORTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_COLORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_COLOR_RGBATests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_COLOR_RGBATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_COLOR_YCbCrATests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_COLOR_YCbCrATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_CONTENT_PROTECTION_CAPSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_CONTENT_PROTECTION_CAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_DECODER_CONFIGTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_DECODER_CONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_DECODER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_DECODER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_CAPSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_CAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_COLOR_SPACETests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_COLOR_SPACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_CONTENT_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_CONTENT_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_CUSTOM_RATETests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_CUSTOM_RATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_FILTER_RANGETests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_FILTER_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPSTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11/D3D11_VIEWPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d11/D3D11_VIEWPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_BLEND_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_BLEND_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATATests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATATests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_RASTERIZER_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_RASTERIZER_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_RENDER_TARGET_BLEND_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_RENDER_TARGET_BLEND_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCKTests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCKTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINTTests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_1/D3D11_VIDEO_SAMPLE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11_1/D3D11_VIDEO_SAMPLE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_2/D3D11_PACKED_MIP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11_2/D3D11_PACKED_MIP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_2/D3D11_SUBRESOURCE_TILINGTests.cs
+++ b/tests/Interop/Windows/um/d3d11_2/D3D11_SUBRESOURCE_TILINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_2/D3D11_TILED_RESOURCE_COORDINATETests.cs
+++ b/tests/Interop/Windows/um/d3d11_2/D3D11_TILED_RESOURCE_COORDINATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_2/D3D11_TILE_REGION_SIZETests.cs
+++ b/tests/Interop/Windows/um/d3d11_2/D3D11_TILE_REGION_SIZETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_2/D3D11_TILE_SHAPETests.cs
+++ b/tests/Interop/Windows/um/d3d11_2/D3D11_TILE_SHAPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_QUERY_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_QUERY_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_RASTERIZER_DESC2Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_RASTERIZER_DESC2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_RENDER_TARGET_VIEW_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_RENDER_TARGET_VIEW_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_SHADER_RESOURCE_VIEW_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_SHADER_RESOURCE_VIEW_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_ARRAY_RTV1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_ARRAY_RTV1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_ARRAY_SRV1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_ARRAY_SRV1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_ARRAY_UAV1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_ARRAY_UAV1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_RTV1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_RTV1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_SRV1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_SRV1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_UAV1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEX2D_UAV1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEXTURE2D_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEXTURE2D_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_TEXTURE3D_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_TEXTURE3D_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_3/D3D11_UNORDERED_ACCESS_VIEW_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_3/D3D11_UNORDERED_ACCESS_VIEW_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_4/D3D11_FEATURE_DATA_D3D11_OPTIONS4Tests.cs
+++ b/tests/Interop/Windows/um/d3d11_4/D3D11_FEATURE_DATA_D3D11_OPTIONS4Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11_4/D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAMTests.cs
+++ b/tests/Interop/Windows/um/d3d11_4/D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11on12/D3D11_RESOURCE_FLAGSTests.cs
+++ b/tests/Interop/Windows/um/d3d11on12/D3D11_RESOURCE_FLAGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_COMPUTE_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_COMPUTE_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_DOMAIN_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_DOMAIN_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_GEOMETRY_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_GEOMETRY_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_HULL_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_HULL_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_PIXEL_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_PIXEL_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_REGISTERTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_REGISTERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_STATSTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_STATSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_STEPTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_STEPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_VALUETests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_TRACE_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d11shadertracing/D3D11_VERTEX_SHADER_TRACE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d11shadertracing/D3D11_VERTEX_SHADER_TRACE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BLEND_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BLEND_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BOXTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BOXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BUFFER_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BUFFER_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BUFFER_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BUFFER_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BUFFER_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BUFFER_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADERTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_CLEAR_VALUETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_CLEAR_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_COMMAND_QUEUE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_COMMAND_QUEUE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_CONSTANT_BUFFER_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_CONSTANT_BUFFER_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCILOP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCILOP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_VALUETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DEPTH_STENCIL_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DESCRIPTOR_HEAP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DESCRIPTOR_HEAP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DESCRIPTOR_RANGE1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DESCRIPTOR_RANGE1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DESCRIPTOR_RANGETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DESCRIPTOR_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DISPATCH_ARGUMENTSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DISPATCH_ARGUMENTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DISPATCH_MESH_ARGUMENTSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DISPATCH_MESH_ARGUMENTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DISPATCH_RAYS_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DISPATCH_RAYS_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DRAW_ARGUMENTSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DRAW_ARGUMENTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_DRAW_INDEXED_ARGUMENTSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_DRAW_INDEXED_ARGUMENTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_ARCHITECTURE1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_ARCHITECTURE1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_ARCHITECTURETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_ARCHITECTURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITYTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_CROSS_NODETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_CROSS_NODETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS2Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS3Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS3Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS4Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS4Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS5Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS5Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS6Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS6Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS7Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONS7Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_D3D12_OPTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_EXISTING_HEAPSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_EXISTING_HEAPSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_FORMAT_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_FORMAT_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_FORMAT_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_FORMAT_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_ROOT_SIGNATURETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_ROOT_SIGNATURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_SERIALIZATIONTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_SERIALIZATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_SHADER_CACHETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_SHADER_CACHETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_SHADER_MODELTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_FEATURE_DATA_SHADER_MODELTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_GPU_DESCRIPTOR_HANDLETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_GPU_DESCRIPTOR_HANDLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_GPU_VIRTUAL_ADDRESS_RANGETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_GPU_VIRTUAL_ADDRESS_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_HEAP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_HEAP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_HEAP_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_HEAP_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_INDEX_BUFFER_VIEWTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_INDEX_BUFFER_VIEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_INDIRECT_ARGUMENT_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_INDIRECT_ARGUMENT_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_MIP_REGIONTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_MIP_REGIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_NODE_MASKTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_NODE_MASKTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_PACKED_MIP_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_PACKED_MIP_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_PLACED_SUBRESOURCE_FOOTPRINTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_PLACED_SUBRESOURCE_FOOTPRINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_PROTECTED_RESOURCE_SESSION_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_PROTECTED_RESOURCE_SESSION_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_PROTECTED_RESOURCE_SESSION_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_PROTECTED_RESOURCE_SESSION_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_QUERY_DATA_PIPELINE_STATISTICSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_QUERY_DATA_PIPELINE_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_QUERY_DATA_SO_STATISTICSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_QUERY_DATA_SO_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_QUERY_HEAP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_QUERY_HEAP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RANGE_UINT64Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RANGE_UINT64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RASTERIZER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RASTERIZER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_AABBTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_AABBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_GEOMETRY_AABBS_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_GEOMETRY_AABBS_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_GEOMETRY_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_GEOMETRY_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_INSTANCE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_INSTANCE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_PIPELINE_CONFIG1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_PIPELINE_CONFIG1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_PIPELINE_CONFIGTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_PIPELINE_CONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_SHADER_CONFIGTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RAYTRACING_SHADER_CONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RENDER_PASS_BEGINNING_ACCESSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RENDER_PASS_BEGINNING_ACCESSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RENDER_TARGET_BLEND_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RENDER_TARGET_BLEND_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RENDER_TARGET_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RENDER_TARGET_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_ALLOCATION_INFO1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_ALLOCATION_INFO1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_ALLOCATION_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_ALLOCATION_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_DESC1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_DESC1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RESOURCE_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_ROOT_CONSTANTSTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_ROOT_CONSTANTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_ROOT_DESCRIPTOR1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_ROOT_DESCRIPTOR1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_ROOT_DESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_ROOT_DESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_RT_FORMAT_ARRAYTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_RT_FORMAT_ARRAYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SAMPLER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SAMPLER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SAMPLE_POSITIONTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SAMPLE_POSITIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIERTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADERTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SHADER_RESOURCE_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SHADER_RESOURCE_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_STATE_OBJECT_CONFIGTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_STATE_OBJECT_CONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_STATIC_SAMPLER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_STATIC_SAMPLER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_STREAM_OUTPUT_BUFFER_VIEWTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_STREAM_OUTPUT_BUFFER_VIEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_FOOTPRINTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_FOOTPRINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_RANGE_UINT64Tests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_RANGE_UINT64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_TILINGTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_SUBRESOURCE_TILINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_ARRAY_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX1D_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_ARRAY_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_ARRAY_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_ARRAY_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_ARRAY_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2DMS_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_ARRAY_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_DSVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_DSVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX2D_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX3D_RTVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX3D_RTVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX3D_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX3D_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEX3D_UAVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEX3D_UAVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEXCUBE_ARRAY_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEXCUBE_ARRAY_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TEXCUBE_SRVTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TEXCUBE_SRVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TILED_RESOURCE_COORDINATETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TILED_RESOURCE_COORDINATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TILE_REGION_SIZETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TILE_REGION_SIZETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_TILE_SHAPETests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_TILE_SHAPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_UNORDERED_ACCESS_VIEW_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_UNORDERED_ACCESS_VIEW_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_VERTEX_BUFFER_VIEWTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_VERTEX_BUFFER_VIEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_VIEWPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_VIEWPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_VIEW_INSTANCE_LOCATIONTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_VIEW_INSTANCE_LOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12/D3D12_WRITEBUFFERIMMEDIATE_PARAMETERTests.cs
+++ b/tests/Interop/Windows/um/d3d12/D3D12_WRITEBUFFERIMMEDIATE_PARAMETERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12sdklayers/D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGSTests.cs
+++ b/tests/Interop/Windows/um/d3d12sdklayers/D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12sdklayers/D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGSTests.cs
+++ b/tests/Interop/Windows/um/d3d12sdklayers/D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12sdklayers/D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTORTests.cs
+++ b/tests/Interop/Windows/um/d3d12sdklayers/D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_ARCHITECTURETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_ARCHITECTURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1Tests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAMTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCESTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATORTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCESTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_SIZETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_SIZETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMSTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCESTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_INFOTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICSTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_RESOLVE_VIDEO_MOTION_VECTOR_HEAP_OUTPUTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_RESOLVE_VIDEO_MOTION_VECTOR_HEAP_OUTPUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_RESOURCE_COORDINATETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_RESOURCE_COORDINATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODER_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODER_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODER_HEAP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODER_HEAP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODE_COMPRESSED_BITSTREAMTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODE_COMPRESSED_BITSTREAMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODE_CONFIGURATIONTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODE_CONFIGURATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODE_OUTPUT_HISTOGRAMTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_DECODE_OUTPUT_HISTOGRAMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_EXTENSION_COMMAND_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_EXTENSION_COMMAND_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_FORMATTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_FORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_MOTION_ESTIMATOR_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_MOTION_ESTIMATOR_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_MOTION_VECTOR_HEAP_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_MOTION_VECTOR_HEAP_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_ALPHA_BLENDINGTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_ALPHA_BLENDINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_FILTER_RANGETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_FILTER_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_INPUT_STREAM_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_INPUT_STREAM_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_INPUT_STREAM_RATETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_INPUT_STREAM_RATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_LUMA_KEYTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_LUMA_KEYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESCTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_TRANSFORMTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_PROCESS_TRANSFORMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_SAMPLETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_SAMPLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_SCALE_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_SCALE_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_SIZE_RANGETests.cs
+++ b/tests/Interop/Windows/um/d3d12video/D3D12_VIDEO_SIZE_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/d3dcommon/ID3DIncludeTests.cs
+++ b/tests/Interop/Windows/um/d3dcommon/ID3DIncludeTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/dcommon/D2D1_PIXEL_FORMATTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D1_PIXEL_FORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_MATRIX_3X2_FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_MATRIX_3X2_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_MATRIX_4X3_FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_MATRIX_4X3_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_MATRIX_4X4_FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_MATRIX_4X4_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_MATRIX_5X4_FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_MATRIX_5X4_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_POINT_2FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_POINT_2FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_POINT_2UTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_POINT_2UTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_RECT_FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_RECT_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_RECT_UTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_RECT_UTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_SIZE_FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_SIZE_FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_SIZE_UTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_SIZE_UTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_VECTOR_2FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_VECTOR_2FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_VECTOR_3FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_VECTOR_3FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dcommon/D2D_VECTOR_4FTests.cs
+++ b/tests/Interop/Windows/um/dcommon/D2D_VECTOR_4FTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/documenttarget/PrintDocumentPackageStatusTests.cs
+++ b/tests/Interop/Windows/um/documenttarget/PrintDocumentPackageStatusTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_CLUSTER_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_CLUSTER_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_FONT_FEATURETests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_FONT_FEATURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_FONT_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_FONT_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_GLYPH_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_GLYPH_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_GLYPH_OFFSETTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_GLYPH_OFFSETTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_HIT_TEST_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_HIT_TEST_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_INLINE_OBJECT_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_INLINE_OBJECT_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_LINE_BREAKPOINTTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_LINE_BREAKPOINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_LINE_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_LINE_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_MATRIXTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_MATRIXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_OVERHANG_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_OVERHANG_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_SCRIPT_ANALYSISTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_SCRIPT_ANALYSISTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_SHAPING_GLYPH_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_SHAPING_GLYPH_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_SHAPING_TEXT_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_SHAPING_TEXT_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_TEXT_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_TEXT_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_TEXT_RANGETests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_TEXT_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite/DWRITE_TRIMMINGTests.cs
+++ b/tests/Interop/Windows/um/dwrite/DWRITE_TRIMMINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_1/DWRITE_CARET_METRICSTests.cs
+++ b/tests/Interop/Windows/um/dwrite_1/DWRITE_CARET_METRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_1/DWRITE_FONT_METRICS1Tests.cs
+++ b/tests/Interop/Windows/um/dwrite_1/DWRITE_FONT_METRICS1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_1/DWRITE_JUSTIFICATION_OPPORTUNITYTests.cs
+++ b/tests/Interop/Windows/um/dwrite_1/DWRITE_JUSTIFICATION_OPPORTUNITYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_1/DWRITE_PANOSETests.cs
+++ b/tests/Interop/Windows/um/dwrite_1/DWRITE_PANOSETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_1/DWRITE_SCRIPT_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/dwrite_1/DWRITE_SCRIPT_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_1/DWRITE_UNICODE_RANGETests.cs
+++ b/tests/Interop/Windows/um/dwrite_1/DWRITE_UNICODE_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_2/DWRITE_TEXT_METRICS1Tests.cs
+++ b/tests/Interop/Windows/um/dwrite_2/DWRITE_TEXT_METRICS1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_3/DWRITE_FILE_FRAGMENTTests.cs
+++ b/tests/Interop/Windows/um/dwrite_3/DWRITE_FILE_FRAGMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_3/DWRITE_FONT_AXIS_RANGETests.cs
+++ b/tests/Interop/Windows/um/dwrite_3/DWRITE_FONT_AXIS_RANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_3/DWRITE_FONT_AXIS_VALUETests.cs
+++ b/tests/Interop/Windows/um/dwrite_3/DWRITE_FONT_AXIS_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_3/DWRITE_LINE_METRICS1Tests.cs
+++ b/tests/Interop/Windows/um/dwrite_3/DWRITE_LINE_METRICS1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dwrite_3/DWRITE_LINE_SPACINGTests.cs
+++ b/tests/Interop/Windows/um/dwrite_3/DWRITE_LINE_SPACINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dxcapi/DxcDefineTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/DxcDefineTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcAssemblerTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcAssemblerTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcBlobEncodingTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcBlobEncodingTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcBlobTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcBlobTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcCompiler2Tests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcCompiler2Tests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcCompilerTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcCompilerTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcContainerBuilderTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcContainerBuilderTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcContainerReflectionTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcContainerReflectionTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcIncludeHandlerTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcIncludeHandlerTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcLibraryTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcLibraryTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcLinkerTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcLinkerTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcOperationResultTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcOperationResultTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcOptimizerPassTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcOptimizerPassTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcOptimizerTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcOptimizerTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcValidatorTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcValidatorTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcVersionInfo2Tests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcVersionInfo2Tests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcapi/IDxcVersionInfoTests.cs
+++ b/tests/Interop/Windows/um/dxcapi/IDxcVersionInfoTests.cs
@@ -1,7 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 // Ported from um/dxcapi.h in the Windows SDK for Windows 10.0.19041.0
-// Original source is Copyright © Microsoft. All rights reserved.
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
 
 using NUnit.Framework;
 using System;

--- a/tests/Interop/Windows/um/dxcore_interface/DXCoreAdapterMemoryBudgetNodeSegmentGroupTests.cs
+++ b/tests/Interop/Windows/um/dxcore_interface/DXCoreAdapterMemoryBudgetNodeSegmentGroupTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dxcore_interface/DXCoreAdapterMemoryBudgetTests.cs
+++ b/tests/Interop/Windows/um/dxcore_interface/DXCoreAdapterMemoryBudgetTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/dxcore_interface/DXCoreHardwareIDTests.cs
+++ b/tests/Interop/Windows/um/dxcore_interface/DXCoreHardwareIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/fileapi/BY_HANDLE_FILE_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/fileapi/BY_HANDLE_FILE_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/fileapi/DISK_SPACE_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/fileapi/DISK_SPACE_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/fileapi/WIN32_FILE_ATTRIBUTE_DATATests.cs
+++ b/tests/Interop/Windows/um/fileapi/WIN32_FILE_ATTRIBUTE_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/fileapi/WIN32_FIND_STREAM_DATATests.cs
+++ b/tests/Interop/Windows/um/fileapi/WIN32_FIND_STREAM_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/minwinbase/EXIT_PROCESS_DEBUG_INFOTests.cs
+++ b/tests/Interop/Windows/um/minwinbase/EXIT_PROCESS_DEBUG_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/minwinbase/EXIT_THREAD_DEBUG_INFOTests.cs
+++ b/tests/Interop/Windows/um/minwinbase/EXIT_THREAD_DEBUG_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/minwinbase/RIP_INFOTests.cs
+++ b/tests/Interop/Windows/um/minwinbase/RIP_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/minwinbase/SYSTEMTIMETests.cs
+++ b/tests/Interop/Windows/um/minwinbase/SYSTEMTIMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/minwinbase/WIN32_FIND_DATAATests.cs
+++ b/tests/Interop/Windows/um/minwinbase/WIN32_FIND_DATAATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/minwinbase/WIN32_FIND_DATAWTests.cs
+++ b/tests/Interop/Windows/um/minwinbase/WIN32_FIND_DATAWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/AUXCAPS2ATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/AUXCAPS2ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/AUXCAPS2WTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/AUXCAPS2WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/AUXCAPSATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/AUXCAPSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/AUXCAPSWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/AUXCAPSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIEVENTTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIEVENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIINCAPS2ATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIINCAPS2ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIINCAPS2WTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIINCAPS2WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIINCAPSATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIINCAPSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIINCAPSWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIINCAPSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPS2ATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPS2ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPS2WTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPS2WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPSATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPSWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIOUTCAPSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIPROPTEMPOTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIPROPTEMPOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDIPROPTIMEDIVTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDIPROPTIMEDIVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIDISTRMBUFFVERTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIDISTRMBUFFVERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCAPS2ATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCAPS2ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCAPS2WTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCAPS2WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCAPSATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCAPSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCAPSWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCAPSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_BOOLEANTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_BOOLEANTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_LISTTEXTATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_LISTTEXTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_LISTTEXTWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_LISTTEXTWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_SIGNEDTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_SIGNEDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_UNSIGNEDTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLDETAILS_UNSIGNEDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/MIXERCONTROLWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/MIXERCONTROLWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/PCMWAVEFORMATTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/PCMWAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEFORMATEXTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEFORMATEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEFORMATTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEINCAPS2ATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEINCAPS2ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEINCAPS2WTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEINCAPS2WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEINCAPSATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEINCAPSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEINCAPSWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEINCAPSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPS2ATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPS2ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPS2WTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPS2WTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPSATests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPSWTests.cs
+++ b/tests/Interop/Windows/um/mmeapi/WAVEOUTCAPSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mmsyscom/MMTIMETests.cs
+++ b/tests/Interop/Windows/um/mmsyscom/MMTIMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mssip/SIP_CAP_SET_V2Tests.cs
+++ b/tests/Interop/Windows/um/mssip/SIP_CAP_SET_V2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/mssip/SIP_CAP_SET_V3Tests.cs
+++ b/tests/Interop/Windows/um/mssip/SIP_CAP_SET_V3Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/oaidl/SAFEARRAYBOUNDTests.cs
+++ b/tests/Interop/Windows/um/oaidl/SAFEARRAYBOUNDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/oaidl/TLIBATTRTests.cs
+++ b/tests/Interop/Windows/um/oaidl/TLIBATTRTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/oaidl/_wireVARIANTTests.cs
+++ b/tests/Interop/Windows/um/oaidl/_wireVARIANTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/objidl/BIND_OPTSTests.cs
+++ b/tests/Interop/Windows/um/objidl/BIND_OPTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/objidl/DVTARGETDEVICETests.cs
+++ b/tests/Interop/Windows/um/objidl/DVTARGETDEVICETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/objidl/RemSNBTests.cs
+++ b/tests/Interop/Windows/um/objidl/RemSNBTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/objidl/RemSTGMEDIUMTests.cs
+++ b/tests/Interop/Windows/um/objidl/RemSTGMEDIUMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/ocidl/AspectInfoTests.cs
+++ b/tests/Interop/Windows/um/ocidl/AspectInfoTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/ocidl/ExtentInfoTests.cs
+++ b/tests/Interop/Windows/um/ocidl/ExtentInfoTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/ocidl/LICINFOTests.cs
+++ b/tests/Interop/Windows/um/ocidl/LICINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/ocidl/POINTFTests.cs
+++ b/tests/Interop/Windows/um/ocidl/POINTFTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/ocidl/QACONTROLTests.cs
+++ b/tests/Interop/Windows/um/ocidl/QACONTROLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/oleidl/OBJECTDESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/oleidl/OBJECTDESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/oleidl/OleMenuGroupWidthsTests.cs
+++ b/tests/Interop/Windows/um/oleidl/OleMenuGroupWidthsTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/processthreadsapi/APP_MEMORY_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/processthreadsapi/APP_MEMORY_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/processthreadsapi/MEMORY_PRIORITY_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/processthreadsapi/MEMORY_PRIORITY_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/processthreadsapi/PROCESS_LEAP_SECOND_INFOTests.cs
+++ b/tests/Interop/Windows/um/processthreadsapi/PROCESS_LEAP_SECOND_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/processthreadsapi/PROCESS_POWER_THROTTLING_STATETests.cs
+++ b/tests/Interop/Windows/um/processthreadsapi/PROCESS_POWER_THROTTLING_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/processthreadsapi/PROCESS_PROTECTION_LEVEL_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/processthreadsapi/PROCESS_PROTECTION_LEVEL_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/processthreadsapi/THREAD_POWER_THROTTLING_STATETests.cs
+++ b/tests/Interop/Windows/um/processthreadsapi/THREAD_POWER_THROTTLING_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/propidlbase/STATPROPSETSTGTests.cs
+++ b/tests/Interop/Windows/um/propidlbase/STATPROPSETSTGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/sysinfoapi/MEMORYSTATUSEXTests.cs
+++ b/tests/Interop/Windows/um/sysinfoapi/MEMORYSTATUSEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/urlmon/AUTHENTICATEINFOTests.cs
+++ b/tests/Interop/Windows/um/urlmon/AUTHENTICATEINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/urlmon/DATAINFOTests.cs
+++ b/tests/Interop/Windows/um/urlmon/DATAINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/urlmon/REMSECURITY_ATTRIBUTESTests.cs
+++ b/tests/Interop/Windows/um/urlmon/REMSECURITY_ATTRIBUTESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/urlmon/RemFORMATETCTests.cs
+++ b/tests/Interop/Windows/um/urlmon/RemFORMATETCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/urlmon/ZONEATTRIBUTESTests.cs
+++ b/tests/Interop/Windows/um/urlmon/ZONEATTRIBUTESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICBitmapPlaneDescriptionTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICBitmapPlaneDescriptionTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICDdsFormatInfoTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICDdsFormatInfoTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICDdsParametersTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICDdsParametersTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICImageParametersTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICImageParametersTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICJpegFrameHeaderTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICJpegFrameHeaderTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICJpegScanHeaderTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICJpegScanHeaderTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICRawCapabilitiesInfoTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICRawCapabilitiesInfoTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICRawToneCurvePointTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICRawToneCurvePointTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICRawToneCurveTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICRawToneCurveTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincodec/WICRectTests.cs
+++ b/tests/Interop/Windows/um/wincodec/WICRectTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PARATests.cs
+++ b/tests/Interop/Windows/um/wincrypt/AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PARATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_BASIC_CONSTRAINTS2_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_BASIC_CONSTRAINTS2_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_FORTEZZA_DATA_PROPTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_FORTEZZA_DATA_PROPTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_POLICY_CONSTRAINTS_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_POLICY_CONSTRAINTS_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_PRIVATE_KEY_VALIDITYTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_PRIVATE_KEY_VALIDITYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_REVOCATION_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_REVOCATION_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_SYSTEM_STORE_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_SYSTEM_STORE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CERT_TRUST_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CERT_TRUST_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARATests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CMSG_RC2_AUX_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CMSG_RC2_AUX_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CMSG_RC4_AUX_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CMSG_RC4_AUX_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CMSG_SP3_COMPATIBLE_AUX_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CMSG_SP3_COMPATIBLE_AUX_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPTNET_URL_CACHE_FLUSH_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPTNET_URL_CACHE_FLUSH_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPTNET_URL_CACHE_PRE_FETCH_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPTNET_URL_CACHE_PRE_FETCH_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_3DES_KEY_STATETests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_3DES_KEY_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_AES_128_KEY_STATETests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_AES_128_KEY_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_AES_256_KEY_STATETests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_AES_256_KEY_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_DES_KEY_STATETests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_DES_KEY_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_PKCS12_PBE_PARAMSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_PKCS12_PBE_PARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_RC2_CBC_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_RC2_CBC_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_RC4_KEY_STATETests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_RC4_KEY_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_SMART_CARD_ROOT_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_SMART_CARD_ROOT_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/CRYPT_TIMESTAMP_ACCURACYTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/CRYPT_TIMESTAMP_ACCURACYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/DSSSEEDTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/DSSSEEDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/EV_EXTRA_CERT_CHAIN_POLICY_PARATests.cs
+++ b/tests/Interop/Windows/um/wincrypt/EV_EXTRA_CERT_CHAIN_POLICY_PARATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/EV_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/EV_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/KEY_TYPE_SUBTYPETests.cs
+++ b/tests/Interop/Windows/um/wincrypt/KEY_TYPE_SUBTYPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/OCSP_BASIC_REVOKED_INFOTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/OCSP_BASIC_REVOKED_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/PRIVKEYVER3Tests.cs
+++ b/tests/Interop/Windows/um/wincrypt/PRIVKEYVER3Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/PROV_ENUMALGSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/PROV_ENUMALGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/PROV_ENUMALGS_EXTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/PROV_ENUMALGS_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/PUBKEYTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/PUBKEYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/PUBKEYVER3Tests.cs
+++ b/tests/Interop/Windows/um/wincrypt/PUBKEYVER3Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/PUBLICKEYSTRUCTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/PUBLICKEYSTRUCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/ROOT_INFO_LUIDTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/ROOT_INFO_LUIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/RSAPUBKEYTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/RSAPUBKEYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/SCHANNEL_ALGTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/SCHANNEL_ALGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wincrypt/SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wincrypt/SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ABCFLOATTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ABCFLOATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ABCTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ABCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ABORTPATHTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ABORTPATHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/AXESLISTATests.cs
+++ b/tests/Interop/Windows/um/wingdi/AXESLISTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/AXESLISTWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/AXESLISTWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/AXISINFOATests.cs
+++ b/tests/Interop/Windows/um/wingdi/AXISINFOATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/AXISINFOWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/AXISINFOWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPCOREHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPCOREHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPCOREINFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPCOREINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPFILEHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPFILEHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPINFOHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPINFOHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPINFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPV4HEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPV4HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BITMAPV5HEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BITMAPV5HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/BLENDFUNCTIONTests.cs
+++ b/tests/Interop/Windows/um/wingdi/BLENDFUNCTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/CHARSETINFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/CHARSETINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/CIEXYZTRIPLETests.cs
+++ b/tests/Interop/Windows/um/wingdi/CIEXYZTRIPLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/CIEXYZTests.cs
+++ b/tests/Interop/Windows/um/wingdi/CIEXYZTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/COLORADJUSTMENTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/COLORADJUSTMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/COLORCORRECTPALETTETests.cs
+++ b/tests/Interop/Windows/um/wingdi/COLORCORRECTPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/COLORMATCHTOTARGETTests.cs
+++ b/tests/Interop/Windows/um/wingdi/COLORMATCHTOTARGETTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DESIGNVECTORTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DESIGNVECTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DEVMODEATests.cs
+++ b/tests/Interop/Windows/um/wingdi/DEVMODEATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DEVMODEWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DEVMODEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_2DREGIONTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_2DREGIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_ADAPTER_NAMETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_ADAPTER_NAMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_DESKTOP_IMAGE_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_DESKTOP_IMAGE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_DEVICE_INFO_HEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_DEVICE_INFO_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_GET_ADVANCED_COLOR_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_GET_ADVANCED_COLOR_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_MODE_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_MODE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_PATH_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_PATH_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_PATH_SOURCE_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_PATH_SOURCE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_PATH_TARGET_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_PATH_TARGET_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_RATIONALTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_RATIONALTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SDR_WHITE_LEVELTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SDR_WHITE_LEVELTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SET_ADVANCED_COLOR_STATETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SET_ADVANCED_COLOR_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SET_TARGET_PERSISTENCETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SET_TARGET_PERSISTENCETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SOURCE_DEVICE_NAMETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SOURCE_DEVICE_NAMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SOURCE_MODETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SOURCE_MODETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTIONTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_BASE_TYPETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_BASE_TYPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_DEVICE_NAMETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_DEVICE_NAMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGSTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_MODETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_MODETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_PREFERRED_MODETests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_TARGET_PREFERRED_MODETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_VIDEO_SIGNAL_INFOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAYCONFIG_VIDEO_SIGNAL_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAY_DEVICEATests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAY_DEVICEATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DISPLAY_DEVICEWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DISPLAY_DEVICEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/DRAWPATRECTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/DRAWPATRECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRALPHABLENDTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRALPHABLENDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRANGLEARCTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRANGLEARCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRARCTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRARCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRBITBLTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRBITBLTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATEBRUSHINDIRECTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATEBRUSHINDIRECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATECOLORSPACETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATECOLORSPACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATECOLORSPACEWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATECOLORSPACEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATEDIBPATTERNBRUSHPTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATEDIBPATTERNBRUSHPTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATEMONOBRUSHTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATEMONOBRUSHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATEPALETTETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATEPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRCREATEPENTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRCREATEPENTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRELLIPSETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRELLIPSETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREOFTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREOFTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXCLUDECLIPRECTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXCLUDECLIPRECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXTCREATEFONTINDIRECTWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXTCREATEFONTINDIRECTWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXTCREATEPENTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXTCREATEPENTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXTESCAPETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXTESCAPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXTFLOODFILLTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXTFLOODFILLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXTSELECTCLIPRGNTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXTSELECTCLIPRGNTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMREXTTEXTOUTATests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMREXTTEXTOUTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRFILLPATHTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRFILLPATHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRFILLRGNTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRFILLRGNTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRFORMATTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRFRAMERGNTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRFRAMERGNTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRGDICOMMENTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRGDICOMMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRGLSBOUNDEDRECORDTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRGLSBOUNDEDRECORDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRGLSRECORDTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRGLSRECORDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRGRADIENTFILLTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRGRADIENTFILLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRINVERTRGNTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRINVERTRGNTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRLINETOTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRLINETOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRMASKBLTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRMASKBLTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRMODIFYWORLDTRANSFORMTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRMODIFYWORLDTRANSFORMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRNAMEDESCAPETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRNAMEDESCAPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMROFFSETCLIPRGNTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMROFFSETCLIPRGNTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPIXELFORMATTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPIXELFORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPLGBLTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPLGBLTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYDRAW16Tests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYDRAW16Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYDRAWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYDRAWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYLINE16Tests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYLINE16Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYLINETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYLINETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYPOLYLINE16Tests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYPOLYLINE16Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYPOLYLINETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYPOLYLINETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRPOLYTEXTOUTATests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRPOLYTEXTOUTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRRESIZEPALETTETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRRESIZEPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRRESTOREDCTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRRESTOREDCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRROUNDRECTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRROUNDRECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSCALEVIEWPORTEXTEXTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSCALEVIEWPORTEXTEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSELECTCLIPPATHTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSELECTCLIPPATHTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSELECTOBJECTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSELECTOBJECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSELECTPALETTETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSELECTPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETARCDIRECTIONTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETARCDIRECTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETCOLORADJUSTMENTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETCOLORADJUSTMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETCOLORSPACETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETCOLORSPACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETDIBITSTODEVICETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETDIBITSTODEVICETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETICMPROFILETests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETICMPROFILETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETMAPPERFLAGSTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETMAPPERFLAGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETMITERLIMITTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETMITERLIMITTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETPALETTEENTRIESTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETPALETTEENTRIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETPIXELVTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETPIXELVTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETTEXTCOLORTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETTEXTCOLORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETVIEWPORTEXTEXTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETVIEWPORTEXTEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETVIEWPORTORGEXTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETVIEWPORTORGEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSETWORLDTRANSFORMTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSETWORLDTRANSFORMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSTRETCHBLTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSTRETCHBLTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRSTRETCHDIBITSTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRSTRETCHDIBITSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRTEXTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRTEXTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRTRANSPARENTBLTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRTRANSPARENTBLTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EMRTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EMRTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENHMETAHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENHMETAHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENHMETARECORDTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENHMETARECORDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMLOGFONTATests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMLOGFONTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXATests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXDVATests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXDVATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXDVWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXDVWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMLOGFONTEXWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMLOGFONTWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMLOGFONTWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMTEXTMETRICATests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMTEXTMETRICATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/ENUMTEXTMETRICWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/ENUMTEXTMETRICWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EXTLOGFONTATests.cs
+++ b/tests/Interop/Windows/um/wingdi/EXTLOGFONTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EXTLOGFONTWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/EXTLOGFONTWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/EXTLOGPEN32Tests.cs
+++ b/tests/Interop/Windows/um/wingdi/EXTLOGPEN32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/FIXEDTests.cs
+++ b/tests/Interop/Windows/um/wingdi/FIXEDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/FONTSIGNATURETests.cs
+++ b/tests/Interop/Windows/um/wingdi/FONTSIGNATURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/GLYPHMETRICSFLOATTests.cs
+++ b/tests/Interop/Windows/um/wingdi/GLYPHMETRICSFLOATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/GLYPHMETRICSTests.cs
+++ b/tests/Interop/Windows/um/wingdi/GLYPHMETRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/GLYPHSETTests.cs
+++ b/tests/Interop/Windows/um/wingdi/GLYPHSETTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/GRADIENT_RECTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/GRADIENT_RECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/GRADIENT_TRIANGLETests.cs
+++ b/tests/Interop/Windows/um/wingdi/GRADIENT_TRIANGLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/KERNINGPAIRTests.cs
+++ b/tests/Interop/Windows/um/wingdi/KERNINGPAIRTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LAYERPLANEDESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/wingdi/LAYERPLANEDESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOCALESIGNATURETests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOCALESIGNATURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGBRUSH32Tests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGBRUSH32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGCOLORSPACEATests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGCOLORSPACEATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGCOLORSPACEWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGCOLORSPACEWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGFONTATests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGFONTATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGFONTWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGFONTWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGPALETTETests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGPALETTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/LOGPENTests.cs
+++ b/tests/Interop/Windows/um/wingdi/LOGPENTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/MAT2Tests.cs
+++ b/tests/Interop/Windows/um/wingdi/MAT2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/METAHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/METAHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/METARECORDTests.cs
+++ b/tests/Interop/Windows/um/wingdi/METARECORDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICATests.cs
+++ b/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICEXATests.cs
+++ b/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICEXATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICEXWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICEXWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/NEWTEXTMETRICWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PALETTEENTRYTests.cs
+++ b/tests/Interop/Windows/um/wingdi/PALETTEENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PANOSETests.cs
+++ b/tests/Interop/Windows/um/wingdi/PANOSETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PELARRAYTests.cs
+++ b/tests/Interop/Windows/um/wingdi/PELARRAYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PIXELFORMATDESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/wingdi/PIXELFORMATDESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/POINTFLOATTests.cs
+++ b/tests/Interop/Windows/um/wingdi/POINTFLOATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/POINTFXTests.cs
+++ b/tests/Interop/Windows/um/wingdi/POINTFXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PSFEATURE_CUSTPAPERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/PSFEATURE_CUSTPAPERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PSFEATURE_OUTPUTTests.cs
+++ b/tests/Interop/Windows/um/wingdi/PSFEATURE_OUTPUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/PSINJECTDATATests.cs
+++ b/tests/Interop/Windows/um/wingdi/PSINJECTDATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/RASTERIZER_STATUSTests.cs
+++ b/tests/Interop/Windows/um/wingdi/RASTERIZER_STATUSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/RGBQUADTests.cs
+++ b/tests/Interop/Windows/um/wingdi/RGBQUADTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/RGBTRIPLETests.cs
+++ b/tests/Interop/Windows/um/wingdi/RGBTRIPLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/RGNDATAHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/RGNDATAHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/RGNDATATests.cs
+++ b/tests/Interop/Windows/um/wingdi/RGNDATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/TEXTMETRICATests.cs
+++ b/tests/Interop/Windows/um/wingdi/TEXTMETRICATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/TEXTMETRICWTests.cs
+++ b/tests/Interop/Windows/um/wingdi/TEXTMETRICWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/TRIVERTEXTests.cs
+++ b/tests/Interop/Windows/um/wingdi/TRIVERTEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/TTPOLYCURVETests.cs
+++ b/tests/Interop/Windows/um/wingdi/TTPOLYCURVETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/TTPOLYGONHEADERTests.cs
+++ b/tests/Interop/Windows/um/wingdi/TTPOLYGONHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/WCRANGETests.cs
+++ b/tests/Interop/Windows/um/wingdi/WCRANGETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wingdi/XFORMTests.cs
+++ b/tests/Interop/Windows/um/wingdi/XFORMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_CALLBACK_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_CALLBACK_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_CALLBACK_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_CALLBACK_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_ALLOWED_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_DENIED_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_DENIED_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_DENIED_CALLBACK_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_DENIED_CALLBACK_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_DENIED_CALLBACK_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_DENIED_CALLBACK_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_DENIED_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_DENIED_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACCESS_REASONSTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACCESS_REASONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACE_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACE_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACLTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACL_REVISION_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACL_REVISION_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACL_SIZE_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACL_SIZE_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACTIVATION_CONTEXT_QUERY_INDEXTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACTIVATION_CONTEXT_QUERY_INDEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ADMINISTRATOR_POWER_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/ADMINISTRATOR_POWER_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ANON_OBJECT_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/ANON_OBJECT_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ANON_OBJECT_HEADER_BIGOBJTests.cs
+++ b/tests/Interop/Windows/um/winnt/ANON_OBJECT_HEADER_BIGOBJTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ANON_OBJECT_HEADER_V2Tests.cs
+++ b/tests/Interop/Windows/um/winnt/ANON_OBJECT_HEADER_V2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/APPLICATIONLAUNCH_SETTING_VALUETests.cs
+++ b/tests/Interop/Windows/um/winnt/APPLICATIONLAUNCH_SETTING_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/BATTERY_REPORTING_SCALETests.cs
+++ b/tests/Interop/Windows/um/winnt/BATTERY_REPORTING_SCALETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/CACHE_DESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/winnt/CACHE_DESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUETests.cs
+++ b/tests/Interop/Windows/um/winnt/CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1Tests.cs
+++ b/tests/Interop/Windows/um/winnt/CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/CM_Power_Data_sTests.cs
+++ b/tests/Interop/Windows/um/winnt/CM_Power_Data_sTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/COMPATIBILITY_CONTEXT_ELEMENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/COMPATIBILITY_CONTEXT_ELEMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/CONTEXTTests.cs
+++ b/tests/Interop/Windows/um/winnt/CONTEXTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/CORRELATION_VECTORTests.cs
+++ b/tests/Interop/Windows/um/winnt/CORRELATION_VECTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_CREATE_INFO_SGXTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_CREATE_INFO_SGXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_CREATE_INFO_VBSTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_CREATE_INFO_VBSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_CREATE_INFO_VBS_BASICTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_CREATE_INFO_VBS_BASICTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_INIT_INFO_SGXTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_INIT_INFO_SGXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_INIT_INFO_VBSTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_INIT_INFO_VBSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_INIT_INFO_VBS_BASICTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_INIT_INFO_VBS_BASICTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENCLAVE_LOAD_DATA_VBS_BASICTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENCLAVE_LOAD_DATA_VBS_BASICTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENLISTMENT_BASIC_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENLISTMENT_BASIC_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ENLISTMENT_CRM_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/ENLISTMENT_CRM_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/EVENTLOGRECORDTests.cs
+++ b/tests/Interop/Windows/um/winnt/EVENTLOGRECORDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/EVENTSFORLOGFILETests.cs
+++ b/tests/Interop/Windows/um/winnt/EVENTSFORLOGFILETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/EXCEPTION_RECORD32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/EXCEPTION_RECORD32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/EXCEPTION_RECORD64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/EXCEPTION_RECORD64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FILE_ID_128Tests.cs
+++ b/tests/Interop/Windows/um/winnt/FILE_ID_128Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FILE_NOTIFY_EXTENDED_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/FILE_NOTIFY_EXTENDED_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FILE_NOTIFY_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/FILE_NOTIFY_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FILE_SEGMENT_ELEMENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/FILE_SEGMENT_ELEMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FLOAT128Tests.cs
+++ b/tests/Interop/Windows/um/winnt/FLOAT128Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FLOATING_SAVE_AREATests.cs
+++ b/tests/Interop/Windows/um/winnt/FLOATING_SAVE_AREATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/FPO_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/FPO_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/GENERIC_MAPPINGTests.cs
+++ b/tests/Interop/Windows/um/winnt/GENERIC_MAPPINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/HARDWARE_COUNTER_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/HARDWARE_COUNTER_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/HEAP_OPTIMIZE_RESOURCES_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/HEAP_OPTIMIZE_RESOURCES_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/HIBERFILE_BUCKETTests.cs
+++ b/tests/Interop/Windows/um/winnt/HIBERFILE_BUCKETTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ARCHITECTURE_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ARCHITECTURE_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ARCHIVE_MEMBER_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ARCHIVE_MEMBER_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ARM64_RUNTIME_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ARM64_RUNTIME_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATATests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ARM_RUNTIME_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ARM_RUNTIME_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_AUX_SYMBOLTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_AUX_SYMBOLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_AUX_SYMBOL_EXTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_AUX_SYMBOL_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_AUX_SYMBOL_TOKEN_DEFTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_AUX_SYMBOL_TOKEN_DEFTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_BASE_RELOCATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_BASE_RELOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_BOUND_FORWARDER_REFTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_BOUND_FORWARDER_REFTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_BOUND_IMPORT_DESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_BOUND_IMPORT_DESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_CE_RUNTIME_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_CE_RUNTIME_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_COFF_SYMBOLS_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_COFF_SYMBOLS_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_COR20_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_COR20_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DATA_DIRECTORYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DATA_DIRECTORYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DEBUG_DIRECTORYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DEBUG_DIRECTORYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DEBUG_MISCTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DEBUG_MISCTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DELAYLOAD_DESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DELAYLOAD_DESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DOS_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DOS_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION32_V2Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION32_V2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION64_V2Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION64_V2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION_TABLETests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_DYNAMIC_RELOCATION_TABLETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ENCLAVE_CONFIG32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ENCLAVE_CONFIG32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ENCLAVE_CONFIG64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ENCLAVE_CONFIG64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ENCLAVE_IMPORTTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ENCLAVE_IMPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_EXPORT_DIRECTORYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_EXPORT_DIRECTORYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_FILE_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_FILE_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_FUNCTION_ENTRY64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_FUNCTION_ENTRY64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_HOT_PATCH_BASETests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_HOT_PATCH_BASETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_HOT_PATCH_HASHESTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_HOT_PATCH_HASHESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_HOT_PATCH_INFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_HOT_PATCH_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_IMPORT_BY_NAMETests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_IMPORT_BY_NAMETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_IMPORT_DESCRIPTORTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_IMPORT_DESCRIPTORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_LINENUMBERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_LINENUMBERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_LOAD_CONFIG_CODE_INTEGRITYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_LOAD_CONFIG_CODE_INTEGRITYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_LOAD_CONFIG_DIRECTORY32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_LOAD_CONFIG_DIRECTORY32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_LOAD_CONFIG_DIRECTORY64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_LOAD_CONFIG_DIRECTORY64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_NT_HEADERS64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_NT_HEADERS64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_NT_HEADERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_NT_HEADERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_OPTIONAL_HEADER64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_OPTIONAL_HEADER64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_OPTIONAL_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_OPTIONAL_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_OS2_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_OS2_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_POLICY_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_POLICY_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_POLICY_METADATATests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_POLICY_METADATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RELOCATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RELOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DATA_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DATA_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIRECTORYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIRECTORYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIRECTORY_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIRECTORY_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIRECTORY_STRINGTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIRECTORY_STRINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIR_STRING_UTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RESOURCE_DIR_STRING_UTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ROM_HEADERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ROM_HEADERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_ROM_OPTIONAL_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_ROM_OPTIONAL_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_RUNTIME_FUNCTION_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_RUNTIME_FUNCTION_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_SECTION_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_SECTION_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_SEPARATE_DEBUG_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_SEPARATE_DEBUG_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_SYMBOLTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_SYMBOLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_SYMBOL_EXTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_SYMBOL_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_THUNK_DATA32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_THUNK_DATA32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_THUNK_DATA64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_THUNK_DATA64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_TLS_DIRECTORY32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_TLS_DIRECTORY32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_TLS_DIRECTORY64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_TLS_DIRECTORY64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMAGE_VXD_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMAGE_VXD_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IMPORT_OBJECT_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/IMPORT_OBJECT_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/IO_COUNTERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/IO_COUNTERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_BASIC_ACCOUNTING_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_BASIC_ACCOUNTING_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_BASIC_UI_RESTRICTIONSTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_BASIC_UI_RESTRICTIONSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_CPU_RATE_CONTROL_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_CPU_RATE_CONTROL_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_END_OF_JOB_TIME_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_END_OF_JOB_TIME_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_IO_ATTRIBUTION_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_IO_ATTRIBUTION_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_IO_ATTRIBUTION_STATSTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_IO_ATTRIBUTION_STATSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_JOBSET_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_JOBSET_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_LIMIT_VIOLATION_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_LIMIT_VIOLATION_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2Tests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_NET_RATE_CONTROL_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_NET_RATE_CONTROL_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_NOTIFICATION_LIMIT_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_NOTIFICATION_LIMIT_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2Tests.cs
+++ b/tests/Interop/Windows/um/winnt/JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/KNONVOLATILE_CONTEXT_POINTERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/KNONVOLATILE_CONTEXT_POINTERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/KTMOBJECT_CURSORTests.cs
+++ b/tests/Interop/Windows/um/winnt/KTMOBJECT_CURSORTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/LARGE_INTEGERTests.cs
+++ b/tests/Interop/Windows/um/winnt/LARGE_INTEGERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/LDT_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/LDT_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/LIST_ENTRY32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/LIST_ENTRY32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/LIST_ENTRY64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/LIST_ENTRY64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/LUIDTests.cs
+++ b/tests/Interop/Windows/um/winnt/LUIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/LUID_AND_ATTRIBUTESTests.cs
+++ b/tests/Interop/Windows/um/winnt/LUID_AND_ATTRIBUTESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/M128ATests.cs
+++ b/tests/Interop/Windows/um/winnt/M128ATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MAXVERSIONTESTED_INFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/MAXVERSIONTESTED_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MEMORY_BASIC_INFORMATION32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/MEMORY_BASIC_INFORMATION32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MEMORY_BASIC_INFORMATION64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/MEMORY_BASIC_INFORMATION64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MEM_EXTENDED_PARAMETERTests.cs
+++ b/tests/Interop/Windows/um/winnt/MEM_EXTENDED_PARAMETERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MESSAGE_RESOURCE_BLOCKTests.cs
+++ b/tests/Interop/Windows/um/winnt/MESSAGE_RESOURCE_BLOCKTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MESSAGE_RESOURCE_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/MESSAGE_RESOURCE_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/MESSAGE_RESOURCE_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/MESSAGE_RESOURCE_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/NETWORK_APP_INSTANCE_EATests.cs
+++ b/tests/Interop/Windows/um/winnt/NETWORK_APP_INSTANCE_EATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/NON_PAGED_DEBUG_INFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/NON_PAGED_DEBUG_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/NOTIFY_USER_POWER_SETTINGTests.cs
+++ b/tests/Interop/Windows/um/winnt/NOTIFY_USER_POWER_SETTINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/NT_TIB32Tests.cs
+++ b/tests/Interop/Windows/um/winnt/NT_TIB32Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/NT_TIB64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/NT_TIB64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/OBJECTIDTests.cs
+++ b/tests/Interop/Windows/um/winnt/OBJECTIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/OSVERSIONINFOATests.cs
+++ b/tests/Interop/Windows/um/winnt/OSVERSIONINFOATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/OSVERSIONINFOEXATests.cs
+++ b/tests/Interop/Windows/um/winnt/OSVERSIONINFOEXATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/OSVERSIONINFOEXWTests.cs
+++ b/tests/Interop/Windows/um/winnt/OSVERSIONINFOEXWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/OSVERSIONINFOWTests.cs
+++ b/tests/Interop/Windows/um/winnt/OSVERSIONINFOWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PACKEDEVENTINFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/PACKEDEVENTINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PERFORMANCE_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/PERFORMANCE_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_ACTION_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_ACTION_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_IDLE_RESILIENCYTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_IDLE_RESILIENCYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_MONITOR_INVOCATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_MONITOR_INVOCATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_PLATFORM_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_PLATFORM_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICESTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_SESSION_CONNECTTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_SESSION_CONNECTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_SESSION_RIT_STATETests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_SESSION_RIT_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_SESSION_TIMEOUTSTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_SESSION_TIMEOUTSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_SESSION_WINLOGONTests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_SESSION_WINLOGONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/POWER_USER_PRESENCETests.cs
+++ b/tests/Interop/Windows/um/winnt/POWER_USER_PRESENCETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_IDLESTATE_EVENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_IDLESTATE_EVENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_IDLE_ACCOUNTINGTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_IDLE_ACCOUNTINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_IDLE_ACCOUNTING_EXTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_IDLE_ACCOUNTING_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_IDLE_STATE_ACCOUNTINGTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_IDLE_STATE_ACCOUNTINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_IDLE_STATE_ACCOUNTING_EXTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_IDLE_STATE_ACCOUNTING_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_IDLE_STATE_BUCKET_EXTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_IDLE_STATE_BUCKET_EXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_PERFSTATE_DOMAIN_EVENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_PERFSTATE_DOMAIN_EVENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_PERFSTATE_EVENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_PERFSTATE_EVENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_THERMALCHANGE_EVENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_THERMALCHANGE_EVENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_THERMAL_POLICY_EVENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_THERMAL_POLICY_EVENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_WMI_IDLE_STATESTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_WMI_IDLE_STATESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_WMI_IDLE_STATETests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_WMI_IDLE_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_WMI_LEGACY_PERFSTATETests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_WMI_LEGACY_PERFSTATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_WMI_PERF_STATESTests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_WMI_PERF_STATESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PPM_WMI_PERF_STATETests.cs
+++ b/tests/Interop/Windows/um/winnt/PPM_WMI_PERF_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PRIVILEGE_SETTests.cs
+++ b/tests/Interop/Windows/um/winnt/PRIVILEGE_SETTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESSOR_IDLESTATE_INFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESSOR_IDLESTATE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESSOR_IDLESTATE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESSOR_IDLESTATE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESSOR_NUMBERTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESSOR_NUMBERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESSOR_PERFSTATE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESSOR_PERFSTATE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESSOR_POWER_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESSOR_POWER_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESSOR_POWER_POLICY_INFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESSOR_POWER_POLICY_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_ASLR_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_ASLR_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_BINARY_SIGNATURE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_BINARY_SIGNATURE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_CHILD_PROCESS_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_CHILD_PROCESS_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_DEP_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_DEP_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_DYNAMIC_CODE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_DYNAMIC_CODE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_FONT_DISABLE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_FONT_DISABLE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_IMAGE_LOAD_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_IMAGE_LOAD_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_USER_SHADOW_STACK_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/PROCESS_MITIGATION_USER_SHADOW_STACK_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/RATE_QUOTA_LIMITTests.cs
+++ b/tests/Interop/Windows/um/winnt/RATE_QUOTA_LIMITTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/REARRANGE_FILE_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/REARRANGE_FILE_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/REPARSE_GUID_DATA_BUFFERTests.cs
+++ b/tests/Interop/Windows/um/winnt/REPARSE_GUID_DATA_BUFFERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/RESOURCEMANAGER_BASIC_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/RESOURCEMANAGER_BASIC_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/RESUME_PERFORMANCETests.cs
+++ b/tests/Interop/Windows/um/winnt/RESUME_PERFORMANCETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCOPE_TABLE_AMD64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/SCOPE_TABLE_AMD64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCOPE_TABLE_ARM64Tests.cs
+++ b/tests/Interop/Windows/um/winnt/SCOPE_TABLE_ARM64Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCOPE_TABLE_ARMTests.cs
+++ b/tests/Interop/Windows/um/winnt/SCOPE_TABLE_ARMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCRUB_DATA_INPUTTests.cs
+++ b/tests/Interop/Windows/um/winnt/SCRUB_DATA_INPUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCRUB_DATA_OUTPUTTests.cs
+++ b/tests/Interop/Windows/um/winnt/SCRUB_DATA_OUTPUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCRUB_PARITY_EXTENTTests.cs
+++ b/tests/Interop/Windows/um/winnt/SCRUB_PARITY_EXTENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SCRUB_PARITY_EXTENT_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/SCRUB_PARITY_EXTENT_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SECURITY_DESCRIPTOR_RELATIVETests.cs
+++ b/tests/Interop/Windows/um/winnt/SECURITY_DESCRIPTOR_RELATIVETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SECURITY_OBJECT_AI_PARAMSTests.cs
+++ b/tests/Interop/Windows/um/winnt/SECURITY_OBJECT_AI_PARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SECURITY_QUALITY_OF_SERVICETests.cs
+++ b/tests/Interop/Windows/um/winnt/SECURITY_QUALITY_OF_SERVICETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SET_POWER_SETTING_VALUETests.cs
+++ b/tests/Interop/Windows/um/winnt/SET_POWER_SETTING_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SE_SIDTests.cs
+++ b/tests/Interop/Windows/um/winnt/SE_SIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SHARED_VIRTUAL_DISK_SUPPORTTests.cs
+++ b/tests/Interop/Windows/um/winnt/SHARED_VIRTUAL_DISK_SUPPORTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SHUFFLE_FILE_DATATests.cs
+++ b/tests/Interop/Windows/um/winnt/SHUFFLE_FILE_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SIDTests.cs
+++ b/tests/Interop/Windows/um/winnt/SIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SID_IDENTIFIER_AUTHORITYTests.cs
+++ b/tests/Interop/Windows/um/winnt/SID_IDENTIFIER_AUTHORITYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SILOOBJECT_BASIC_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/SILOOBJECT_BASIC_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SUPPORTED_OS_INFOTests.cs
+++ b/tests/Interop/Windows/um/winnt/SUPPORTED_OS_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_ACCESS_FILTER_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_ACCESS_FILTER_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_CALLBACK_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_CALLBACK_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_CALLBACK_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_CALLBACK_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_ALARM_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_CALLBACK_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_CALLBACK_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_CALLBACK_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_CALLBACK_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_OBJECT_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_AUDIT_OBJECT_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_BATTERY_STATETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_BATTERY_STATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_CPU_SET_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_CPU_SET_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_MANDATORY_LABEL_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_MANDATORY_LABEL_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_POWER_CAPABILITIESTests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_POWER_CAPABILITIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_POWER_LEVELTests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_POWER_LEVELTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_POWER_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_POWER_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_PROCESS_TRUST_LABEL_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_PROCESS_TRUST_LABEL_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_RESOURCE_ATTRIBUTE_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_RESOURCE_ATTRIBUTE_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/SYSTEM_SCOPED_POLICY_ID_ACETests.cs
+++ b/tests/Interop/Windows/um/winnt/SYSTEM_SCOPED_POLICY_ID_ACETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_CREATE_PARTITIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_CREATE_PARTITIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_ERASETests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_ERASETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_GET_DRIVE_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_GET_DRIVE_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_GET_MEDIA_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_GET_MEDIA_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_GET_POSITIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_GET_POSITIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_PREPARETests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_PREPARETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_SET_DRIVE_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_SET_DRIVE_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_SET_MEDIA_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_SET_MEDIA_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_SET_POSITIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_SET_POSITIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TAPE_WRITE_MARKSTests.cs
+++ b/tests/Interop/Windows/um/winnt/TAPE_WRITE_MARKSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_AUDIT_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_AUDIT_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_CONTROLTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_CONTROLTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_ELEVATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_ELEVATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_MANDATORY_POLICYTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_MANDATORY_POLICYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_ORIGINTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_ORIGINTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_PRIVILEGESTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_PRIVILEGESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_SOURCETests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_SOURCETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TOKEN_STATISTICSTests.cs
+++ b/tests/Interop/Windows/um/winnt/TOKEN_STATISTICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_BASIC_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_BASIC_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_LOGPATH_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_LOGPATH_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_LOG_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_LOG_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_OLDEST_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_OLDEST_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_RECOVERY_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTIONMANAGER_RECOVERY_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_BASIC_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_BASIC_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_ENLISTMENTS_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_ENLISTMENTS_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_ENLISTMENT_PAIRTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_ENLISTMENT_PAIRTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_LIST_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_LIST_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_LIST_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_LIST_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_PROPERTIES_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_PROPERTIES_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/ULARGE_INTEGERTests.cs
+++ b/tests/Interop/Windows/um/winnt/ULARGE_INTEGERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/WOW64_ARCHITECTURE_INFORMATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/WOW64_ARCHITECTURE_INFORMATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/WOW64_CONTEXTTests.cs
+++ b/tests/Interop/Windows/um/winnt/WOW64_CONTEXTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/WOW64_DESCRIPTOR_TABLE_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/WOW64_DESCRIPTOR_TABLE_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/WOW64_FLOATING_SAVE_AREATests.cs
+++ b/tests/Interop/Windows/um/winnt/WOW64_FLOATING_SAVE_AREATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/WOW64_LDT_ENTRYTests.cs
+++ b/tests/Interop/Windows/um/winnt/WOW64_LDT_ENTRYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/XSAVE_AREATests.cs
+++ b/tests/Interop/Windows/um/winnt/XSAVE_AREATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/XSAVE_AREA_HEADERTests.cs
+++ b/tests/Interop/Windows/um/winnt/XSAVE_AREA_HEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/XSAVE_CET_U_FORMATTests.cs
+++ b/tests/Interop/Windows/um/winnt/XSAVE_CET_U_FORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/XSAVE_FORMATTests.cs
+++ b/tests/Interop/Windows/um/winnt/XSAVE_FORMATTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/XSTATE_CONFIGURATIONTests.cs
+++ b/tests/Interop/Windows/um/winnt/XSTATE_CONFIGURATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winnt/XSTATE_FEATURETests.cs
+++ b/tests/Interop/Windows/um/winnt/XSTATE_FEATURETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wintrust/CAT_MEMBERINFO2Tests.cs
+++ b/tests/Interop/Windows/um/wintrust/CAT_MEMBERINFO2Tests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wintrust/INTENT_TO_SEAL_ATTRIBUTETests.cs
+++ b/tests/Interop/Windows/um/wintrust/INTENT_TO_SEAL_ATTRIBUTETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wintrust/SPC_FINANCIAL_CRITERIATests.cs
+++ b/tests/Interop/Windows/um/wintrust/SPC_FINANCIAL_CRITERIATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wintrust/SPC_SIGINFOTests.cs
+++ b/tests/Interop/Windows/um/wintrust/SPC_SIGINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/wintrust/WIN_CERTIFICATETests.cs
+++ b/tests/Interop/Windows/um/wintrust/WIN_CERTIFICATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/ACCELTests.cs
+++ b/tests/Interop/Windows/um/winuser/ACCELTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/ACCESSTIMEOUTTests.cs
+++ b/tests/Interop/Windows/um/winuser/ACCESSTIMEOUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/ALTTABINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/ALTTABINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/ANIMATIONINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/ANIMATIONINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/AUDIODESCRIPTIONTests.cs
+++ b/tests/Interop/Windows/um/winuser/AUDIODESCRIPTIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/CHANGEFILTERSTRUCTTests.cs
+++ b/tests/Interop/Windows/um/winuser/CHANGEFILTERSTRUCTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/CURSORSHAPETests.cs
+++ b/tests/Interop/Windows/um/winuser/CURSORSHAPETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/DLGITEMTEMPLATETests.cs
+++ b/tests/Interop/Windows/um/winuser/DLGITEMTEMPLATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/DLGTEMPLATETests.cs
+++ b/tests/Interop/Windows/um/winuser/DLGTEMPLATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/DRAWTEXTPARAMSTests.cs
+++ b/tests/Interop/Windows/um/winuser/DRAWTEXTPARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/FILTERKEYSTests.cs
+++ b/tests/Interop/Windows/um/winuser/FILTERKEYSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/GESTURECONFIGTests.cs
+++ b/tests/Interop/Windows/um/winuser/GESTURECONFIGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/HARDWAREINPUTTests.cs
+++ b/tests/Interop/Windows/um/winuser/HARDWAREINPUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/HELPWININFOATests.cs
+++ b/tests/Interop/Windows/um/winuser/HELPWININFOATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/HELPWININFOWTests.cs
+++ b/tests/Interop/Windows/um/winuser/HELPWININFOWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/ICONMETRICSATests.cs
+++ b/tests/Interop/Windows/um/winuser/ICONMETRICSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/ICONMETRICSWTests.cs
+++ b/tests/Interop/Windows/um/winuser/ICONMETRICSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/INPUT_INJECTION_VALUETests.cs
+++ b/tests/Interop/Windows/um/winuser/INPUT_INJECTION_VALUETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/INPUT_MESSAGE_SOURCETests.cs
+++ b/tests/Interop/Windows/um/winuser/INPUT_MESSAGE_SOURCETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/INPUT_TRANSFORMTests.cs
+++ b/tests/Interop/Windows/um/winuser/INPUT_TRANSFORMTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/LASTINPUTINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/LASTINPUTINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MENUITEMTEMPLATEHEADERTests.cs
+++ b/tests/Interop/Windows/um/winuser/MENUITEMTEMPLATEHEADERTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MENUITEMTEMPLATETests.cs
+++ b/tests/Interop/Windows/um/winuser/MENUITEMTEMPLATETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MINIMIZEDMETRICSTests.cs
+++ b/tests/Interop/Windows/um/winuser/MINIMIZEDMETRICSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MINMAXINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/MINMAXINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MONITORINFOEXATests.cs
+++ b/tests/Interop/Windows/um/winuser/MONITORINFOEXATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MONITORINFOEXWTests.cs
+++ b/tests/Interop/Windows/um/winuser/MONITORINFOEXWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MONITORINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/MONITORINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MOUSEKEYSTests.cs
+++ b/tests/Interop/Windows/um/winuser/MOUSEKEYSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MULTIKEYHELPATests.cs
+++ b/tests/Interop/Windows/um/winuser/MULTIKEYHELPATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/MULTIKEYHELPWTests.cs
+++ b/tests/Interop/Windows/um/winuser/MULTIKEYHELPWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/NONCLIENTMETRICSATests.cs
+++ b/tests/Interop/Windows/um/winuser/NONCLIENTMETRICSATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/NONCLIENTMETRICSWTests.cs
+++ b/tests/Interop/Windows/um/winuser/NONCLIENTMETRICSWTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/POINTER_DEVICE_CURSOR_INFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/POINTER_DEVICE_CURSOR_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/POINTER_DEVICE_PROPERTYTests.cs
+++ b/tests/Interop/Windows/um/winuser/POINTER_DEVICE_PROPERTYTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/POWERBROADCAST_SETTINGTests.cs
+++ b/tests/Interop/Windows/um/winuser/POWERBROADCAST_SETTINGTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RAWHIDTests.cs
+++ b/tests/Interop/Windows/um/winuser/RAWHIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RAWKEYBOARDTests.cs
+++ b/tests/Interop/Windows/um/winuser/RAWKEYBOARDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RAWMOUSETests.cs
+++ b/tests/Interop/Windows/um/winuser/RAWMOUSETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RID_DEVICE_INFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/RID_DEVICE_INFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RID_DEVICE_INFO_HIDTests.cs
+++ b/tests/Interop/Windows/um/winuser/RID_DEVICE_INFO_HIDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RID_DEVICE_INFO_KEYBOARDTests.cs
+++ b/tests/Interop/Windows/um/winuser/RID_DEVICE_INFO_KEYBOARDTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/RID_DEVICE_INFO_MOUSETests.cs
+++ b/tests/Interop/Windows/um/winuser/RID_DEVICE_INFO_MOUSETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/SCROLLBARINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/SCROLLBARINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/SCROLLINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/SCROLLINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/STICKYKEYSTests.cs
+++ b/tests/Interop/Windows/um/winuser/STICKYKEYSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/STYLESTRUCTTests.cs
+++ b/tests/Interop/Windows/um/winuser/STYLESTRUCTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TITLEBARINFOEXTests.cs
+++ b/tests/Interop/Windows/um/winuser/TITLEBARINFOEXTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TITLEBARINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/TITLEBARINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TOGGLEKEYSTests.cs
+++ b/tests/Interop/Windows/um/winuser/TOGGLEKEYSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TOUCH_HIT_TESTING_INPUTTests.cs
+++ b/tests/Interop/Windows/um/winuser/TOUCH_HIT_TESTING_INPUTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TOUCH_HIT_TESTING_PROXIMITY_EVALUATIONTests.cs
+++ b/tests/Interop/Windows/um/winuser/TOUCH_HIT_TESTING_PROXIMITY_EVALUATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TPMPARAMSTests.cs
+++ b/tests/Interop/Windows/um/winuser/TPMPARAMSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/TouchPredictionParametersTests.cs
+++ b/tests/Interop/Windows/um/winuser/TouchPredictionParametersTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/USAGE_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/winuser/USAGE_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/USEROBJECTFLAGSTests.cs
+++ b/tests/Interop/Windows/um/winuser/USEROBJECTFLAGSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/WINDOWINFOTests.cs
+++ b/tests/Interop/Windows/um/winuser/WINDOWINFOTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/WINDOWPLACEMENTTests.cs
+++ b/tests/Interop/Windows/um/winuser/WINDOWPLACEMENTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/winuser/WTSSESSION_NOTIFICATIONTests.cs
+++ b/tests/Interop/Windows/um/winuser/WTSSESSION_NOTIFICATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/x3daudio/X3DAUDIO_CONETests.cs
+++ b/tests/Interop/Windows/um/x3daudio/X3DAUDIO_CONETests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/x3daudio/X3DAUDIO_DISTANCE_CURVE_POINTTests.cs
+++ b/tests/Interop/Windows/um/x3daudio/X3DAUDIO_DISTANCE_CURVE_POINTTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xapo/XAPO_REGISTRATION_PROPERTIESTests.cs
+++ b/tests/Interop/Windows/um/xapo/XAPO_REGISTRATION_PROPERTIESTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xapofx/FXECHO_INITDATATests.cs
+++ b/tests/Interop/Windows/um/xapofx/FXECHO_INITDATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xapofx/FXECHO_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xapofx/FXECHO_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xapofx/FXEQ_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xapofx/FXEQ_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xapofx/FXMASTERINGLIMITER_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xapofx/FXMASTERINGLIMITER_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xapofx/FXREVERB_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xapofx/FXREVERB_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xaudio2/IXAudio2EngineCallbackTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/IXAudio2EngineCallbackTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/xaudio2/IXAudio2MasteringVoiceTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/IXAudio2MasteringVoiceTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/xaudio2/IXAudio2SourceVoiceTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/IXAudio2SourceVoiceTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/xaudio2/IXAudio2SubmixVoiceTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/IXAudio2SubmixVoiceTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/xaudio2/IXAudio2VoiceCallbackTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/IXAudio2VoiceCallbackTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/xaudio2/IXAudio2VoiceTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/IXAudio2VoiceTests.cs
@@ -6,7 +6,6 @@
 using NUnit.Framework;
 using System;
 using System.Runtime.InteropServices;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {

--- a/tests/Interop/Windows/um/xaudio2/XAUDIO2_DEBUG_CONFIGURATIONTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/XAUDIO2_DEBUG_CONFIGURATIONTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xaudio2/XAUDIO2_FILTER_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/XAUDIO2_FILTER_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xaudio2/XAUDIO2_PERFORMANCE_DATATests.cs
+++ b/tests/Interop/Windows/um/xaudio2/XAUDIO2_PERFORMANCE_DATATests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xaudio2/XAUDIO2_VOICE_DETAILSTests.cs
+++ b/tests/Interop/Windows/um/xaudio2/XAUDIO2_VOICE_DETAILSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xaudio2fx/XAUDIO2FX_REVERB_I3DL2_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xaudio2fx/XAUDIO2FX_REVERB_I3DL2_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests

--- a/tests/Interop/Windows/um/xaudio2fx/XAUDIO2FX_REVERB_PARAMETERSTests.cs
+++ b/tests/Interop/Windows/um/xaudio2fx/XAUDIO2FX_REVERB_PARAMETERSTests.cs
@@ -4,7 +4,6 @@
 // Original source is Copyright © Microsoft. All rights reserved.
 
 using NUnit.Framework;
-using System;
 using System.Runtime.InteropServices;
 
 namespace TerraFX.Interop.UnitTests


### PR DESCRIPTION
As per the title this ensures the new interop sanity tests are generated by defaullt.