### PR TITLE
Add back additional types to CoreWindow.h

### DIFF
--- a/generation/winrt/CoreWindow/generate.rsp
+++ b/generation/winrt/CoreWindow/generate.rsp
@@ -1,8 +1,14 @@
 @../../settings.rsp
 @../../remap.rsp
 --exclude
-ICoreWindowAdapterInterop
-ICoreWindowComponentInterop
+HWND_UserFree
+HWND_UserFree64
+HWND_UserMarshal
+HWND_UserMarshal64
+HWND_UserSize
+HWND_UserSize64
+HWND_UserUnmarshal
+HWND_UserUnmarshal64
 --file
 winrt-CoreWindow.h
 --output
@@ -13,6 +19,8 @@ winrt-CoreWindow.h
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/winrt/CoreWindow.h
 --with-attribute
 ICoreInputInterop=Guid("40BFE3E3-B75A-4479-AC96-475365749BB8")
+ICoreWindowAdapterInterop=Guid("7A5B6FD1-CD73-4B6C-9CF4-2E869EAF470A")
+ICoreWindowComponentInterop=Guid("0576AB31-A310-4C40-BA31-FD37E0298DFA")
 ICoreWindowInterop=Guid("45D64A29-A63E-4CB6-B498-5781D298CB4F")
 --with-librarypath
 *=Windows.UI

--- a/generation/winrt/CoreWindow/generate.rsp
+++ b/generation/winrt/CoreWindow/generate.rsp
@@ -1,14 +1,5 @@
 @../../settings.rsp
 @../../remap.rsp
---exclude
-HWND_UserFree
-HWND_UserFree64
-HWND_UserMarshal
-HWND_UserMarshal64
-HWND_UserSize
-HWND_UserSize64
-HWND_UserUnmarshal
-HWND_UserUnmarshal64
 --file
 winrt-CoreWindow.h
 --output

--- a/sources/Interop/Windows/winrt/CoreWindow/ICoreWindowAdapterInterop.cs
+++ b/sources/Interop/Windows/winrt/CoreWindow/ICoreWindowAdapterInterop.cs
@@ -1,0 +1,89 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/CoreWindow.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("7A5B6FD1-CD73-4B6C-9CF4-2E869EAF470A")]
+    public unsafe partial struct ICoreWindowAdapterInterop
+    {
+        public void** lpVtbl;
+
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, Guid*, void**, int>)(lpVtbl[0]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, uint>)(lpVtbl[1]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, uint>)(lpVtbl[2]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, uint*, Guid**, int>)(lpVtbl[3]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IntPtr*, int>)(lpVtbl[4]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, TrustLevel*, int>)(lpVtbl[5]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int get_ApplicationViewClientAdapter([NativeTypeName("IUnknown **")] IUnknown** value)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IUnknown**, int>)(lpVtbl[6]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), value);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int get_CoreApplicationViewClientAdapter([NativeTypeName("IUnknown **")] IUnknown** value)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IUnknown**, int>)(lpVtbl[7]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), value);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int get_HoloViewClientAdapter([NativeTypeName("IUnknown **")] IUnknown** value)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IUnknown**, int>)(lpVtbl[8]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), value);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int get_SystemNavigationClientAdapter([NativeTypeName("IUnknown **")] IUnknown** value)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IUnknown**, int>)(lpVtbl[9]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), value);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int get_TitleBarClientAdapter([NativeTypeName("IUnknown **")] IUnknown** value)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IUnknown**, int>)(lpVtbl[10]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), value);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int SetWindowClientAdapter([NativeTypeName("IUnknown *")] IUnknown* value)
+        {
+            return ((delegate* stdcall<ICoreWindowAdapterInterop*, IUnknown*, int>)(lpVtbl[11]))((ICoreWindowAdapterInterop*)Unsafe.AsPointer(ref this), value);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/CoreWindow/ICoreWindowComponentInterop.cs
+++ b/sources/Interop/Windows/winrt/CoreWindow/ICoreWindowComponentInterop.cs
@@ -1,0 +1,47 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/CoreWindow.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("0576AB31-A310-4C40-BA31-FD37E0298DFA")]
+    public unsafe partial struct ICoreWindowComponentInterop
+    {
+        public void** lpVtbl;
+
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* stdcall<ICoreWindowComponentInterop*, Guid*, void**, int>)(lpVtbl[0]))((ICoreWindowComponentInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* stdcall<ICoreWindowComponentInterop*, uint>)(lpVtbl[1]))((ICoreWindowComponentInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* stdcall<ICoreWindowComponentInterop*, uint>)(lpVtbl[2]))((ICoreWindowComponentInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int ConfigureComponentInput([NativeTypeName("UINT32")] uint hostViewInstanceId, [NativeTypeName("HWND")] IntPtr hwndHost, [NativeTypeName("IUnknown *")] IUnknown* inputSourceVisual)
+        {
+            return ((delegate* stdcall<ICoreWindowComponentInterop*, uint, IntPtr, IUnknown*, int>)(lpVtbl[3]))((ICoreWindowComponentInterop*)Unsafe.AsPointer(ref this), hostViewInstanceId, hwndHost, inputSourceVisual);
+        }
+
+        [return: NativeTypeName("HRESULT")]
+        public int GetViewInstanceId([NativeTypeName("UINT32 *")] uint* componentViewInstanceId)
+        {
+            return ((delegate* stdcall<ICoreWindowComponentInterop*, uint*, int>)(lpVtbl[4]))((ICoreWindowComponentInterop*)Unsafe.AsPointer(ref this), componentViewInstanceId);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/CoreWindow/Windows.Manual.cs
+++ b/sources/Interop/Windows/winrt/CoreWindow/Windows.Manual.cs
@@ -11,6 +11,10 @@ namespace TerraFX.Interop
     {
         public static readonly Guid IID_ICoreWindowInterop = new Guid(0x45D64A29, 0xA63E, 0x4CB6, 0xB4, 0x98, 0x57, 0x81, 0xD2, 0x98, 0xCB, 0x4F);
 
+        public static readonly Guid IID_ICoreWindowAdapterInterop = new Guid(0X7A5B6FD1, 0XCD73, 0X4B6C, 0X9C, 0XF4, 0X2E, 0X86, 0X9E, 0XAF, 0X47, 0X0A);
+
+        public static readonly Guid IID_ICoreWindowComponentInterop = new Guid(0X0576AB31, 0XA310, 0X4C40, 0XBA, 0X31, 0XFD, 0X37, 0XE0, 0X29, 0X8D, 0XFA);
+
         public static readonly Guid IID_ICoreInputInterop = new Guid(0x40BFE3E3, 0xB75A, 0x4479, 0xAC, 0x96, 0x47, 0x53, 0x65, 0x74, 0x9B, 0xB8);
     }
 }

--- a/tests/Interop/Windows/winrt/CoreWindow/ICoreWindowAdapterInteropTests.cs
+++ b/tests/Interop/Windows/winrt/CoreWindow/ICoreWindowAdapterInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/CoreWindow.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="ICoreWindowAdapterInterop" /> struct.</summary>
+    public static unsafe class ICoreWindowAdapterInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="ICoreWindowAdapterInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(ICoreWindowAdapterInterop).GUID, Is.EqualTo(IID_ICoreWindowAdapterInterop));
+        }
+
+        /// <summary>Validates that the <see cref="ICoreWindowAdapterInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<ICoreWindowAdapterInterop>(), Is.EqualTo(sizeof(ICoreWindowAdapterInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="ICoreWindowAdapterInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(ICoreWindowAdapterInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="ICoreWindowAdapterInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(ICoreWindowAdapterInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(ICoreWindowAdapterInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/winrt/CoreWindow/ICoreWindowComponentInteropTests.cs
+++ b/tests/Interop/Windows/winrt/CoreWindow/ICoreWindowComponentInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/CoreWindow.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="ICoreWindowComponentInterop" /> struct.</summary>
+    public static unsafe class ICoreWindowComponentInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="ICoreWindowComponentInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(ICoreWindowComponentInterop).GUID, Is.EqualTo(IID_ICoreWindowComponentInterop));
+        }
+
+        /// <summary>Validates that the <see cref="ICoreWindowComponentInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<ICoreWindowComponentInterop>(), Is.EqualTo(sizeof(ICoreWindowComponentInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="ICoreWindowComponentInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(ICoreWindowComponentInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="ICoreWindowComponentInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(ICoreWindowComponentInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(ICoreWindowComponentInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add back some types that were initially excluded in the original PR https://github.com/terrafx/terrafx.interop.windows/pull/96.