### PR TITLE
Fix the casing of the artifacts path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
       with:
         dotnet-version: '3.1.x'
         source-url: https://nuget.pkg.github.com/terrafx/index.json
-    - run: dotnet nuget push ./artifacts/pkg/release/*.nupkg
+    - run: dotnet nuget push ./artifacts/pkg/Release/*.nupkg


### PR DESCRIPTION
Unix is case sensitive and expects `Release`, not `release`.