### PR TITLE
Move the NUGET_AUTH_TOKEN environment variable so dotnet can access it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     needs: [ windows, unix ]
-    env:
-      NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/download-artifact@v2
       with:
@@ -62,4 +60,6 @@ jobs:
       with:
         dotnet-version: '3.1.x'
         source-url: https://nuget.pkg.github.com/terrafx/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: dotnet nuget push ./artifacts/pkg/Release/*.nupkg


### PR DESCRIPTION
As per the example on https://github.com/marketplace/actions/setup-net-core-sdk