### PR TITLE
Updating to use the new NuGet Feed URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
         os: [ windows ]
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+        source-url: https://pkgs.terrafx.dev/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: ./scripts/cibuild.cmd -configuration ${{ matrix.configuration }} -architecture ${{ matrix.architecture }}
       shell: cmd
     - uses: actions/upload-artifact@v2
@@ -36,6 +42,12 @@ jobs:
         os: [ macos, ubuntu ]
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+        source-url: https://pkgs.terrafx.dev/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: ./scripts/cibuild.sh --configuration ${{ matrix.configuration }} --architecture ${{ matrix.architecture }}
       shell: bash
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
-        source-url: https://nuget.pkg.github.com/terrafx/index.json
+        source-url: https://pkgs.terrafx.dev/index.json
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: dotnet nuget push ./artifacts/pkg/Release/*.nupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,7 +66,7 @@
     <RepositoryType>git</RepositoryType>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
-      https://pkgs.terrafx.dev/nuget/v3/index.json;
+      https://pkgs.terrafx.dev/index.json;
     </RestoreSources>
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ Interop bindings for Windows.
 ![ci](https://github.com/terrafx/terrafx.interop.windows/workflows/ci/badge.svg?branch=main&event=push)
 [![Discord](https://img.shields.io/discord/593547387457372212.svg?label=Discord&style=plastic)](https://discord.terrafx.dev/)
 
+Packages are available at: https://github.com/orgs/terrafx/packages or via the NuGet Feed URL: https://pkgs.terrafx.dev/index.json
+
 ## Table of Contents
 
 * [Code of Conduct](#code-of-conduct)


### PR DESCRIPTION
This resolves https://github.com/terrafx/terrafx.interop.windows/issues/110