### PR TITLE
Add more headers for Windows Runtime Library interop

### DIFF
--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1442,6 +1442,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UserConsentVerifierInterop"
 		generation\um\UserConsentVerifierInterop\um-UserConsentVerifierInterop.h = generation\um\UserConsentVerifierInterop\um-UserConsentVerifierInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SpatialInteractionManagerInterop", "SpatialInteractionManagerInterop", "{83265220-D2EA-41B1-9070-BE8B0FAC057B}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\SpatialInteractionManagerInterop\generate.rsp = generation\um\SpatialInteractionManagerInterop\generate.rsp
+		generation\um\SpatialInteractionManagerInterop\header.txt = generation\um\SpatialInteractionManagerInterop\header.txt
+		generation\um\SpatialInteractionManagerInterop\um-SpatialInteractionManagerInterop.h = generation\um\SpatialInteractionManagerInterop\um-SpatialInteractionManagerInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1670,6 +1677,7 @@ Global
 		{38537C10-5F03-48A7-8954-46D60E02F7A6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{351FAB7E-63E2-40CC-90C5-4FA71F8D4515} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{3A3689A4-6139-480D-B856-91C0FFF58DB6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{83265220-D2EA-41B1-9070-BE8B0FAC057B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1358,6 +1358,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "uuids", "uuids", "{FAC93A2C
 		generation\shared\uuids\shared-uuids.h = generation\shared\uuids\shared-uuids.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "inputpaneinterop", "inputpaneinterop", "{503E9930-C718-4453-86BA-D56D4D4A3C5A}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\inputpaneinterop\generate.rsp = generation\um\inputpaneinterop\generate.rsp
+		generation\um\inputpaneinterop\header.txt = generation\um\inputpaneinterop\header.txt
+		generation\um\inputpaneinterop\um-inputpaneinterop.h = generation\um\inputpaneinterop\um-inputpaneinterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1574,6 +1581,7 @@ Global
 		{4AE3D7A2-B327-4C8F-B417-93F695C595B7} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{76F42C09-F092-4E69-AF05-76C93E92DF51} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{FAC93A2C-2D6B-4055-8C7E-955E581288C0} = {F9716DD9-2967-4295-AC71-F1FD5A9EEFEF}
+		{503E9930-C718-4453-86BA-D56D4D4A3C5A} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1435,6 +1435,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RadialControllerInterop", "
 		generation\um\RadialControllerInterop\um-RadialControllerInterop.h = generation\um\RadialControllerInterop\um-RadialControllerInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UserConsentVerifierInterop", "UserConsentVerifierInterop", "{3A3689A4-6139-480D-B856-91C0FFF58DB6}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\UserConsentVerifierInterop\generate.rsp = generation\um\UserConsentVerifierInterop\generate.rsp
+		generation\um\UserConsentVerifierInterop\header.txt = generation\um\UserConsentVerifierInterop\header.txt
+		generation\um\UserConsentVerifierInterop\um-UserConsentVerifierInterop.h = generation\um\UserConsentVerifierInterop\um-UserConsentVerifierInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1662,6 +1669,7 @@ Global
 		{BE044B47-35EF-4C44-823A-0ECDA4E13F21} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{38537C10-5F03-48A7-8954-46D60E02F7A6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{351FAB7E-63E2-40CC-90C5-4FA71F8D4515} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{3A3689A4-6139-480D-B856-91C0FFF58DB6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1491,6 +1491,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "accountssettingspaneinterop
 		generation\um\accountssettingspaneinterop\um-accountssettingspaneinterop.h = generation\um\accountssettingspaneinterop\um-accountssettingspaneinterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "windows.ui.xaml.hosting.desktopwindowxamlsource", "windows.ui.xaml.hosting.desktopwindowxamlsource", "{AD0959E5-765F-4670-BD34-3D03C72813C7}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\windows.ui.xaml.hosting.desktopwindowxamlsource\generate.rsp = generation\um\windows.ui.xaml.hosting.desktopwindowxamlsource\generate.rsp
+		generation\um\windows.ui.xaml.hosting.desktopwindowxamlsource\header.txt = generation\um\windows.ui.xaml.hosting.desktopwindowxamlsource\header.txt
+		generation\um\windows.ui.xaml.hosting.desktopwindowxamlsource\um-windows.ui.xaml.hosting.desktopwindowxamlsource.h = generation\um\windows.ui.xaml.hosting.desktopwindowxamlsource\um-windows.ui.xaml.hosting.desktopwindowxamlsource.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1726,6 +1733,7 @@ Global
 		{CD7FBCD8-0D9D-4452-9059-A882209D9903} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{95CB59A8-9E9C-483B-B5A7-0A19EE6B8734} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{8132BF5E-738F-458B-9778-23C3737547C6} = {D9638FEE-50A4-44FF-B1F6-72E59548490B}
+		{AD0959E5-765F-4670-BD34-3D03C72813C7} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1365,6 +1365,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "inputpaneinterop", "inputpa
 		generation\um\inputpaneinterop\um-inputpaneinterop.h = generation\um\inputpaneinterop\um-inputpaneinterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PlayToManagerInterop", "PlayToManagerInterop", "{38DC4FDF-3CD5-4CFC-A503-D6B583589C1B}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\PlayToManagerInterop\generate.rsp = generation\um\PlayToManagerInterop\generate.rsp
+		generation\um\PlayToManagerInterop\header.txt = generation\um\PlayToManagerInterop\header.txt
+		generation\um\PlayToManagerInterop\um-PlayToManagerInterop.h = generation\um\PlayToManagerInterop\um-PlayToManagerInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1582,6 +1589,7 @@ Global
 		{76F42C09-F092-4E69-AF05-76C93E92DF51} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{FAC93A2C-2D6B-4055-8C7E-955E581288C0} = {F9716DD9-2967-4295-AC71-F1FD5A9EEFEF}
 		{503E9930-C718-4453-86BA-D56D4D4A3C5A} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{38DC4FDF-3CD5-4CFC-A503-D6B583589C1B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1477,6 +1477,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "appserviceinterop", "appser
 		generation\um\appserviceinterop\um-appserviceinterop.h = generation\um\appserviceinterop\um-appserviceinterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "useractivityinterop", "useractivityinterop", "{95CB59A8-9E9C-483B-B5A7-0A19EE6B8734}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\useractivityinterop\generate.rsp = generation\um\useractivityinterop\generate.rsp
+		generation\um\useractivityinterop\header.txt = generation\um\useractivityinterop\header.txt
+		generation\um\useractivityinterop\um-useractivityinterop.h = generation\um\useractivityinterop\um-useractivityinterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1710,6 +1717,7 @@ Global
 		{B269955C-B08B-41F1-B299-292FC63820D2} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{8A99FF33-1ACF-4304-85E7-D4994DDB70EF} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{CD7FBCD8-0D9D-4452-9059-A882209D9903} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{95CB59A8-9E9C-483B-B5A7-0A19EE6B8734} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1428,6 +1428,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HolographicSpaceInterop", "
 		generation\um\HolographicSpaceInterop\um-HolographicSpaceInterop.h = generation\um\HolographicSpaceInterop\um-HolographicSpaceInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RadialControllerInterop", "RadialControllerInterop", "{351FAB7E-63E2-40CC-90C5-4FA71F8D4515}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\RadialControllerInterop\generate.rsp = generation\um\RadialControllerInterop\generate.rsp
+		generation\um\RadialControllerInterop\header.txt = generation\um\RadialControllerInterop\header.txt
+		generation\um\RadialControllerInterop\um-RadialControllerInterop.h = generation\um\RadialControllerInterop\um-RadialControllerInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1654,6 +1661,7 @@ Global
 		{EB34A9E0-960B-4DE9-8972-176A8E68EDB4} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{BE044B47-35EF-4C44-823A-0ECDA4E13F21} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{38537C10-5F03-48A7-8954-46D60E02F7A6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{351FAB7E-63E2-40CC-90C5-4FA71F8D4515} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1421,6 +1421,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UIViewSettingsInterop", "UI
 		generation\um\UIViewSettingsInterop\um-UIViewSettingsInterop.h = generation\um\UIViewSettingsInterop\um-UIViewSettingsInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HolographicSpaceInterop", "HolographicSpaceInterop", "{38537C10-5F03-48A7-8954-46D60E02F7A6}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\HolographicSpaceInterop\generate.rsp = generation\um\HolographicSpaceInterop\generate.rsp
+		generation\um\HolographicSpaceInterop\header.txt = generation\um\HolographicSpaceInterop\header.txt
+		generation\um\HolographicSpaceInterop\um-HolographicSpaceInterop.h = generation\um\HolographicSpaceInterop\um-HolographicSpaceInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1646,6 +1653,7 @@ Global
 		{B7C02BDE-CBF4-4636-AD6E-698868684179} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{EB34A9E0-960B-4DE9-8972-176A8E68EDB4} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{BE044B47-35EF-4C44-823A-0ECDA4E13F21} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{38537C10-5F03-48A7-8954-46D60E02F7A6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1470,6 +1470,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dragdropinterop", "dragdrop
 		generation\um\dragdropinterop\um-dragdropinterop.h = generation\um\dragdropinterop\um-dragdropinterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "appserviceinterop", "appserviceinterop", "{CD7FBCD8-0D9D-4452-9059-A882209D9903}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\appserviceinterop\generate.rsp = generation\um\appserviceinterop\generate.rsp
+		generation\um\appserviceinterop\header.txt = generation\um\appserviceinterop\header.txt
+		generation\um\appserviceinterop\um-appserviceinterop.h = generation\um\appserviceinterop\um-appserviceinterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1702,6 +1709,7 @@ Global
 		{5E6BF298-F552-4844-8D97-7542D12D5602} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{B269955C-B08B-41F1-B299-292FC63820D2} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{8A99FF33-1ACF-4304-85E7-D4994DDB70EF} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{CD7FBCD8-0D9D-4452-9059-A882209D9903} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1372,6 +1372,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PlayToManagerInterop", "Pla
 		generation\um\PlayToManagerInterop\um-PlayToManagerInterop.h = generation\um\PlayToManagerInterop\um-PlayToManagerInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PrintManagerInterop", "PrintManagerInterop", "{163B6E05-B1B1-468C-AACA-761B9C75A833}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\PrintManagerInterop\generate.rsp = generation\um\PrintManagerInterop\generate.rsp
+		generation\um\PrintManagerInterop\header.txt = generation\um\PrintManagerInterop\header.txt
+		generation\um\PrintManagerInterop\um-PrintManagerInterop.h = generation\um\PrintManagerInterop\um-PrintManagerInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1590,6 +1597,7 @@ Global
 		{FAC93A2C-2D6B-4055-8C7E-955E581288C0} = {F9716DD9-2967-4295-AC71-F1FD5A9EEFEF}
 		{503E9930-C718-4453-86BA-D56D4D4A3C5A} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{38DC4FDF-3CD5-4CFC-A503-D6B583589C1B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{163B6E05-B1B1-468C-AACA-761B9C75A833} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1379,6 +1379,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PrintManagerInterop", "Prin
 		generation\um\PrintManagerInterop\um-PrintManagerInterop.h = generation\um\PrintManagerInterop\um-PrintManagerInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "remotesystemadditionalinfo", "remotesystemadditionalinfo", "{0E059E07-8732-495D-8503-161ECCB6E344}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\remotesystemadditionalinfo\generate.rsp = generation\um\remotesystemadditionalinfo\generate.rsp
+		generation\um\remotesystemadditionalinfo\header.txt = generation\um\remotesystemadditionalinfo\header.txt
+		generation\um\remotesystemadditionalinfo\um-remotesystemadditionalinfo.h = generation\um\remotesystemadditionalinfo\um-remotesystemadditionalinfo.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1598,6 +1605,7 @@ Global
 		{503E9930-C718-4453-86BA-D56D4D4A3C5A} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{38DC4FDF-3CD5-4CFC-A503-D6B583589C1B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{163B6E05-B1B1-468C-AACA-761B9C75A833} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{0E059E07-8732-495D-8503-161ECCB6E344} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1463,6 +1463,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "efswrtinterop", "efswrtinte
 		generation\um\efswrtinterop\um-efswrtinterop.h = generation\um\efswrtinterop\um-efswrtinterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dragdropinterop", "dragdropinterop", "{8A99FF33-1ACF-4304-85E7-D4994DDB70EF}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\dragdropinterop\generate.rsp = generation\um\dragdropinterop\generate.rsp
+		generation\um\dragdropinterop\header.txt = generation\um\dragdropinterop\header.txt
+		generation\um\dragdropinterop\um-dragdropinterop.h = generation\um\dragdropinterop\um-dragdropinterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1694,6 +1701,7 @@ Global
 		{83265220-D2EA-41B1-9070-BE8B0FAC057B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{5E6BF298-F552-4844-8D97-7542D12D5602} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{B269955C-B08B-41F1-B299-292FC63820D2} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{8A99FF33-1ACF-4304-85E7-D4994DDB70EF} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1400,6 +1400,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebAuthenticationCoreManage
 		generation\um\WebAuthenticationCoreManagerInterop\um-WebAuthenticationCoreManagerInterop.h = generation\um\WebAuthenticationCoreManagerInterop\um-WebAuthenticationCoreManagerInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Windows.Graphics.Capture.Interop", "Windows.Graphics.Capture.Interop", "{B7C02BDE-CBF4-4636-AD6E-698868684179}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\Windows.Graphics.Capture.Interop\generate.rsp = generation\um\Windows.Graphics.Capture.Interop\generate.rsp
+		generation\um\Windows.Graphics.Capture.Interop\header.txt = generation\um\Windows.Graphics.Capture.Interop\header.txt
+		generation\um\Windows.Graphics.Capture.Interop\um-Windows.Graphics.Capture.Interop.h = generation\um\Windows.Graphics.Capture.Interop\um-Windows.Graphics.Capture.Interop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1622,6 +1629,7 @@ Global
 		{0E059E07-8732-495D-8503-161ECCB6E344} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{AE92327C-303A-4D01-9887-964D56B188EE} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{1239793D-E8BE-4350-9392-BB88D78E0D6E} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{B7C02BDE-CBF4-4636-AD6E-698868684179} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1407,6 +1407,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Windows.Graphics.Capture.In
 		generation\um\Windows.Graphics.Capture.Interop\um-Windows.Graphics.Capture.Interop.h = generation\um\Windows.Graphics.Capture.Interop\um-Windows.Graphics.Capture.Interop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Print3DManagerInterop", "Print3DManagerInterop", "{EB34A9E0-960B-4DE9-8972-176A8E68EDB4}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\Print3DManagerInterop\generate.rsp = generation\um\Print3DManagerInterop\generate.rsp
+		generation\um\Print3DManagerInterop\header.txt = generation\um\Print3DManagerInterop\header.txt
+		generation\um\Print3DManagerInterop\um-Print3DManagerInterop.h = generation\um\Print3DManagerInterop\um-Print3DManagerInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1630,6 +1637,7 @@ Global
 		{AE92327C-303A-4D01-9887-964D56B188EE} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{1239793D-E8BE-4350-9392-BB88D78E0D6E} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{B7C02BDE-CBF4-4636-AD6E-698868684179} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{EB34A9E0-960B-4DE9-8972-176A8E68EDB4} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1484,6 +1484,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "useractivityinterop", "user
 		generation\um\useractivityinterop\um-useractivityinterop.h = generation\um\useractivityinterop\um-useractivityinterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "accountssettingspaneinterop", "accountssettingspaneinterop", "{8132BF5E-738F-458B-9778-23C3737547C6}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\accountssettingspaneinterop\generate.rsp = generation\um\accountssettingspaneinterop\generate.rsp
+		generation\um\accountssettingspaneinterop\header.txt = generation\um\accountssettingspaneinterop\header.txt
+		generation\um\accountssettingspaneinterop\um-accountssettingspaneinterop.h = generation\um\accountssettingspaneinterop\um-accountssettingspaneinterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1718,6 +1725,7 @@ Global
 		{8A99FF33-1ACF-4304-85E7-D4994DDB70EF} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{CD7FBCD8-0D9D-4452-9059-A882209D9903} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{95CB59A8-9E9C-483B-B5A7-0A19EE6B8734} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{8132BF5E-738F-458B-9778-23C3737547C6} = {D9638FEE-50A4-44FF-B1F6-72E59548490B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1386,6 +1386,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "remotesystemadditionalinfo"
 		generation\um\remotesystemadditionalinfo\um-remotesystemadditionalinfo.h = generation\um\remotesystemadditionalinfo\um-remotesystemadditionalinfo.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RemoteSystemsInterop", "RemoteSystemsInterop", "{AE92327C-303A-4D01-9887-964D56B188EE}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\RemoteSystemsInterop\generate.rsp = generation\um\RemoteSystemsInterop\generate.rsp
+		generation\um\RemoteSystemsInterop\header.txt = generation\um\RemoteSystemsInterop\header.txt
+		generation\um\RemoteSystemsInterop\um-RemoteSystemsInterop.h = generation\um\RemoteSystemsInterop\um-RemoteSystemsInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1606,6 +1613,7 @@ Global
 		{38DC4FDF-3CD5-4CFC-A503-D6B583589C1B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{163B6E05-B1B1-468C-AACA-761B9C75A833} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{0E059E07-8732-495D-8503-161ECCB6E344} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{AE92327C-303A-4D01-9887-964D56B188EE} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1456,6 +1456,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SystemMediaTransportControl
 		generation\um\SystemMediaTransportControlsInterop\um-SystemMediaTransportControlsInterop.h = generation\um\SystemMediaTransportControlsInterop\um-SystemMediaTransportControlsInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "efswrtinterop", "efswrtinterop", "{B269955C-B08B-41F1-B299-292FC63820D2}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\efswrtinterop\generate.rsp = generation\um\efswrtinterop\generate.rsp
+		generation\um\efswrtinterop\header.txt = generation\um\efswrtinterop\header.txt
+		generation\um\efswrtinterop\um-efswrtinterop.h = generation\um\efswrtinterop\um-efswrtinterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1686,6 +1693,7 @@ Global
 		{3A3689A4-6139-480D-B856-91C0FFF58DB6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{83265220-D2EA-41B1-9070-BE8B0FAC057B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{5E6BF298-F552-4844-8D97-7542D12D5602} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{B269955C-B08B-41F1-B299-292FC63820D2} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1449,6 +1449,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SpatialInteractionManagerIn
 		generation\um\SpatialInteractionManagerInterop\um-SpatialInteractionManagerInterop.h = generation\um\SpatialInteractionManagerInterop\um-SpatialInteractionManagerInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SystemMediaTransportControlsInterop", "SystemMediaTransportControlsInterop", "{5E6BF298-F552-4844-8D97-7542D12D5602}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\SystemMediaTransportControlsInterop\generate.rsp = generation\um\SystemMediaTransportControlsInterop\generate.rsp
+		generation\um\SystemMediaTransportControlsInterop\header.txt = generation\um\SystemMediaTransportControlsInterop\header.txt
+		generation\um\SystemMediaTransportControlsInterop\um-SystemMediaTransportControlsInterop.h = generation\um\SystemMediaTransportControlsInterop\um-SystemMediaTransportControlsInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1678,6 +1685,7 @@ Global
 		{351FAB7E-63E2-40CC-90C5-4FA71F8D4515} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{3A3689A4-6139-480D-B856-91C0FFF58DB6} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{83265220-D2EA-41B1-9070-BE8B0FAC057B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{5E6BF298-F552-4844-8D97-7542D12D5602} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1414,6 +1414,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Print3DManagerInterop", "Pr
 		generation\um\Print3DManagerInterop\um-Print3DManagerInterop.h = generation\um\Print3DManagerInterop\um-Print3DManagerInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UIViewSettingsInterop", "UIViewSettingsInterop", "{BE044B47-35EF-4C44-823A-0ECDA4E13F21}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\UIViewSettingsInterop\generate.rsp = generation\um\UIViewSettingsInterop\generate.rsp
+		generation\um\UIViewSettingsInterop\header.txt = generation\um\UIViewSettingsInterop\header.txt
+		generation\um\UIViewSettingsInterop\um-UIViewSettingsInterop.h = generation\um\UIViewSettingsInterop\um-UIViewSettingsInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1638,6 +1645,7 @@ Global
 		{1239793D-E8BE-4350-9392-BB88D78E0D6E} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{B7C02BDE-CBF4-4636-AD6E-698868684179} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{EB34A9E0-960B-4DE9-8972-176A8E68EDB4} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{BE044B47-35EF-4C44-823A-0ECDA4E13F21} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -1393,6 +1393,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RemoteSystemsInterop", "Rem
 		generation\um\RemoteSystemsInterop\um-RemoteSystemsInterop.h = generation\um\RemoteSystemsInterop\um-RemoteSystemsInterop.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebAuthenticationCoreManagerInterop", "WebAuthenticationCoreManagerInterop", "{1239793D-E8BE-4350-9392-BB88D78E0D6E}"
+	ProjectSection(SolutionItems) = preProject
+		generation\um\WebAuthenticationCoreManagerInterop\generate.rsp = generation\um\WebAuthenticationCoreManagerInterop\generate.rsp
+		generation\um\WebAuthenticationCoreManagerInterop\header.txt = generation\um\WebAuthenticationCoreManagerInterop\header.txt
+		generation\um\WebAuthenticationCoreManagerInterop\um-WebAuthenticationCoreManagerInterop.h = generation\um\WebAuthenticationCoreManagerInterop\um-WebAuthenticationCoreManagerInterop.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1614,6 +1621,7 @@ Global
 		{163B6E05-B1B1-468C-AACA-761B9C75A833} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{0E059E07-8732-495D-8503-161ECCB6E344} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{AE92327C-303A-4D01-9887-964D56B188EE} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{1239793D-E8BE-4350-9392-BB88D78E0D6E} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/generation/um/HolographicSpaceInterop/generate.rsp
+++ b/generation/um/HolographicSpaceInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-HolographicSpaceInterop.h
+--output
+../../../sources/Interop/Windows/um/HolographicSpaceInterop
+--test-output
+../../../tests/Interop/Windows/um/HolographicSpaceInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/HolographicSpaceInterop.h

--- a/generation/um/HolographicSpaceInterop/header.txt
+++ b/generation/um/HolographicSpaceInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/HolographicSpaceInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/HolographicSpaceInterop/um-HolographicSpaceInterop.h
+++ b/generation/um/HolographicSpaceInterop/um-HolographicSpaceInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <HolographicSpaceInterop.h>

--- a/generation/um/PlayToManagerInterop/generate.rsp
+++ b/generation/um/PlayToManagerInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-PlayToManagerInterop.h
+--output
+../../../sources/Interop/Windows/um/PlayToManagerInterop
+--test-output
+../../../tests/Interop/Windows/um/PlayToManagerInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/PlayToManagerInterop.h

--- a/generation/um/PlayToManagerInterop/header.txt
+++ b/generation/um/PlayToManagerInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PlayToManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/PlayToManagerInterop/um-PlayToManagerInterop.h
+++ b/generation/um/PlayToManagerInterop/um-PlayToManagerInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <PlayToManagerInterop.h>

--- a/generation/um/Print3DManagerInterop/generate.rsp
+++ b/generation/um/Print3DManagerInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-Print3DManagerInterop.h
+--output
+../../../sources/Interop/Windows/um/Print3DManagerInterop
+--test-output
+../../../tests/Interop/Windows/um/Print3DManagerInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/Print3DManagerInterop.h

--- a/generation/um/Print3DManagerInterop/header.txt
+++ b/generation/um/Print3DManagerInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Print3DManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/Print3DManagerInterop/um-Print3DManagerInterop.h
+++ b/generation/um/Print3DManagerInterop/um-Print3DManagerInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <Print3DManagerInterop.h>

--- a/generation/um/PrintManagerInterop/generate.rsp
+++ b/generation/um/PrintManagerInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-PrintManagerInterop.h
+--output
+../../../sources/Interop/Windows/um/PrintManagerInterop
+--test-output
+../../../tests/Interop/Windows/um/PrintManagerInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/PrintManagerInterop.h

--- a/generation/um/PrintManagerInterop/header.txt
+++ b/generation/um/PrintManagerInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PrintManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/PrintManagerInterop/um-PrintManagerInterop.h
+++ b/generation/um/PrintManagerInterop/um-PrintManagerInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <PrintManagerInterop.h>

--- a/generation/um/RadialControllerInterop/generate.rsp
+++ b/generation/um/RadialControllerInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-RadialControllerInterop.h
+--output
+../../../sources/Interop/Windows/um/RadialControllerInterop
+--test-output
+../../../tests/Interop/Windows/um/RadialControllerInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/RadialControllerInterop.h

--- a/generation/um/RadialControllerInterop/header.txt
+++ b/generation/um/RadialControllerInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/RadialControllerInterop/um-RadialControllerInterop.h
+++ b/generation/um/RadialControllerInterop/um-RadialControllerInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <RadialControllerInterop.h>

--- a/generation/um/RemoteSystemsInterop/generate.rsp
+++ b/generation/um/RemoteSystemsInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-RemoteSystemsInterop.h
+--output
+../../../sources/Interop/Windows/um/RemoteSystemsInterop
+--test-output
+../../../tests/Interop/Windows/um/RemoteSystemsInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/RemoteSystemsInterop.h

--- a/generation/um/RemoteSystemsInterop/header.txt
+++ b/generation/um/RemoteSystemsInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RemoteSystemsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/RemoteSystemsInterop/um-RemoteSystemsInterop.h
+++ b/generation/um/RemoteSystemsInterop/um-RemoteSystemsInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <RemoteSystemsInterop.h>

--- a/generation/um/SpatialInteractionManagerInterop/generate.rsp
+++ b/generation/um/SpatialInteractionManagerInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-SpatialInteractionManagerInterop.h
+--output
+../../../sources/Interop/Windows/um/SpatialInteractionManagerInterop
+--test-output
+../../../tests/Interop/Windows/um/SpatialInteractionManagerInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/SpatialInteractionManagerInterop.h

--- a/generation/um/SpatialInteractionManagerInterop/header.txt
+++ b/generation/um/SpatialInteractionManagerInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SpatialInteractionManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/SpatialInteractionManagerInterop/um-SpatialInteractionManagerInterop.h
+++ b/generation/um/SpatialInteractionManagerInterop/um-SpatialInteractionManagerInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <SpatialInteractionManagerInterop.h>

--- a/generation/um/SystemMediaTransportControlsInterop/generate.rsp
+++ b/generation/um/SystemMediaTransportControlsInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-SystemMediaTransportControlsInterop.h
+--output
+../../../sources/Interop/Windows/um/SystemMediaTransportControlsInterop
+--test-output
+../../../tests/Interop/Windows/um/SystemMediaTransportControlsInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/SystemMediaTransportControlsInterop.h

--- a/generation/um/SystemMediaTransportControlsInterop/header.txt
+++ b/generation/um/SystemMediaTransportControlsInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SystemMediaTransportControlsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/SystemMediaTransportControlsInterop/um-SystemMediaTransportControlsInterop.h
+++ b/generation/um/SystemMediaTransportControlsInterop/um-SystemMediaTransportControlsInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <SystemMediaTransportControlsInterop.h>

--- a/generation/um/UIViewSettingsInterop/generate.rsp
+++ b/generation/um/UIViewSettingsInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-UIViewSettingsInterop.h
+--output
+../../../sources/Interop/Windows/um/UIViewSettingsInterop
+--test-output
+../../../tests/Interop/Windows/um/UIViewSettingsInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/UIViewSettingsInterop.h

--- a/generation/um/UIViewSettingsInterop/header.txt
+++ b/generation/um/UIViewSettingsInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UIViewSettingsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/UIViewSettingsInterop/um-UIViewSettingsInterop.h
+++ b/generation/um/UIViewSettingsInterop/um-UIViewSettingsInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <UIViewSettingsInterop.h>

--- a/generation/um/UserConsentVerifierInterop/generate.rsp
+++ b/generation/um/UserConsentVerifierInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-UserConsentVerifierInterop.h
+--output
+../../../sources/Interop/Windows/um/UserConsentVerifierInterop
+--test-output
+../../../tests/Interop/Windows/um/UserConsentVerifierInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/UserConsentVerifierInterop.h

--- a/generation/um/UserConsentVerifierInterop/header.txt
+++ b/generation/um/UserConsentVerifierInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UserConsentVerifierInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/UserConsentVerifierInterop/um-UserConsentVerifierInterop.h
+++ b/generation/um/UserConsentVerifierInterop/um-UserConsentVerifierInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <UserConsentVerifierInterop.h>

--- a/generation/um/WebAuthenticationCoreManagerInterop/generate.rsp
+++ b/generation/um/WebAuthenticationCoreManagerInterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-WebAuthenticationCoreManagerInterop.h
+--output
+../../../sources/Interop/Windows/um/WebAuthenticationCoreManagerInterop
+--test-output
+../../../tests/Interop/Windows/um/WebAuthenticationCoreManagerInterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/WebAuthenticationCoreManagerInterop.h

--- a/generation/um/WebAuthenticationCoreManagerInterop/header.txt
+++ b/generation/um/WebAuthenticationCoreManagerInterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/WebAuthenticationCoreManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/WebAuthenticationCoreManagerInterop/um-WebAuthenticationCoreManagerInterop.h
+++ b/generation/um/WebAuthenticationCoreManagerInterop/um-WebAuthenticationCoreManagerInterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <WebAuthenticationCoreManagerInterop.h>

--- a/generation/um/Windows.Graphics.Capture.Interop/generate.rsp
+++ b/generation/um/Windows.Graphics.Capture.Interop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-Windows.Graphics.Capture.Interop.h
+--output
+../../../sources/Interop/Windows/um/Windows.Graphics.Capture.Interop
+--test-output
+../../../tests/Interop/Windows/um/Windows.Graphics.Capture.Interop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/Windows.Graphics.Capture.Interop.h

--- a/generation/um/Windows.Graphics.Capture.Interop/header.txt
+++ b/generation/um/Windows.Graphics.Capture.Interop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Windows.Graphics.Capture.Interop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/Windows.Graphics.Capture.Interop/um-Windows.Graphics.Capture.Interop.h
+++ b/generation/um/Windows.Graphics.Capture.Interop/um-Windows.Graphics.Capture.Interop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <Windows.Graphics.Capture.Interop.h>

--- a/generation/um/accountssettingspaneinterop/generate.rsp
+++ b/generation/um/accountssettingspaneinterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-accountssettingspaneinterop.h
+--output
+../../../sources/Interop/Windows/um/accountssettingspaneinterop
+--test-output
+../../../tests/Interop/Windows/um/accountssettingspaneinterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/accountssettingspaneinterop.h

--- a/generation/um/accountssettingspaneinterop/header.txt
+++ b/generation/um/accountssettingspaneinterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/accountssettingspaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/accountssettingspaneinterop/um-accountssettingspaneinterop.h
+++ b/generation/um/accountssettingspaneinterop/um-accountssettingspaneinterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <accountssettingspaneinterop.h>

--- a/generation/um/appserviceinterop/generate.rsp
+++ b/generation/um/appserviceinterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-appserviceinterop.h
+--output
+../../../sources/Interop/Windows/um/appserviceinterop
+--test-output
+../../../tests/Interop/Windows/um/appserviceinterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/appserviceinterop.h

--- a/generation/um/appserviceinterop/header.txt
+++ b/generation/um/appserviceinterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/appserviceinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/appserviceinterop/um-appserviceinterop.h
+++ b/generation/um/appserviceinterop/um-appserviceinterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <appserviceinterop.h>

--- a/generation/um/dragdropinterop/generate.rsp
+++ b/generation/um/dragdropinterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-dragdropinterop.h
+--output
+../../../sources/Interop/Windows/um/dragdropinterop
+--test-output
+../../../tests/Interop/Windows/um/dragdropinterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/dragdropinterop.h

--- a/generation/um/dragdropinterop/header.txt
+++ b/generation/um/dragdropinterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/dragdropinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/dragdropinterop/um-dragdropinterop.h
+++ b/generation/um/dragdropinterop/um-dragdropinterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <dragdropinterop.h>

--- a/generation/um/efswrtinterop/generate.rsp
+++ b/generation/um/efswrtinterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-efswrtinterop.h
+--output
+../../../sources/Interop/Windows/um/efswrtinterop
+--test-output
+../../../tests/Interop/Windows/um/efswrtinterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/efswrtinterop.h

--- a/generation/um/efswrtinterop/header.txt
+++ b/generation/um/efswrtinterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/efswrtinterop/um-efswrtinterop.h
+++ b/generation/um/efswrtinterop/um-efswrtinterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <efswrtinterop.h>

--- a/generation/um/inputpaneinterop/generate.rsp
+++ b/generation/um/inputpaneinterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-inputpaneinterop.h
+--output
+../../../sources/Interop/Windows/um/inputpaneinterop
+--test-output
+../../../tests/Interop/Windows/um/inputpaneinterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/inputpaneinterop.h

--- a/generation/um/inputpaneinterop/header.txt
+++ b/generation/um/inputpaneinterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/inputpaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/inputpaneinterop/um-inputpaneinterop.h
+++ b/generation/um/inputpaneinterop/um-inputpaneinterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <inputpaneinterop.h>

--- a/generation/um/remotesystemadditionalinfo/generate.rsp
+++ b/generation/um/remotesystemadditionalinfo/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-remotesystemadditionalinfo.h
+--output
+../../../sources/Interop/Windows/um/remotesystemadditionalinfo
+--test-output
+../../../tests/Interop/Windows/um/remotesystemadditionalinfo
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/remotesystemadditionalinfo.h

--- a/generation/um/remotesystemadditionalinfo/header.txt
+++ b/generation/um/remotesystemadditionalinfo/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/remotesystemadditionalinfo.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/remotesystemadditionalinfo/um-remotesystemadditionalinfo.h
+++ b/generation/um/remotesystemadditionalinfo/um-remotesystemadditionalinfo.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <remotesystemadditionalinfo.h>

--- a/generation/um/useractivityinterop/generate.rsp
+++ b/generation/um/useractivityinterop/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-useractivityinterop.h
+--output
+../../../sources/Interop/Windows/um/useractivityinterop
+--test-output
+../../../tests/Interop/Windows/um/useractivityinterop
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/useractivityinterop.h

--- a/generation/um/useractivityinterop/header.txt
+++ b/generation/um/useractivityinterop/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/useractivityinterop/um-useractivityinterop.h
+++ b/generation/um/useractivityinterop/um-useractivityinterop.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <useractivityinterop.h>

--- a/generation/um/windows.ui.xaml.hosting.desktopwindowxamlsource/generate.rsp
+++ b/generation/um/windows.ui.xaml.hosting.desktopwindowxamlsource/generate.rsp
@@ -1,0 +1,10 @@
+@../../settings.rsp
+@../../remap.rsp
+--file
+um-windows.ui.xaml.hosting.desktopwindowxamlsource.h
+--output
+../../../sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource
+--test-output
+../../../tests/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/windows.ui.xaml.hosting.desktopwindowxamlsource.h

--- a/generation/um/windows.ui.xaml.hosting.desktopwindowxamlsource/header.txt
+++ b/generation/um/windows.ui.xaml.hosting.desktopwindowxamlsource/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/windows.ui.xaml.hosting.desktopwindowxamlsource.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/um/windows.ui.xaml.hosting.desktopwindowxamlsource/um-windows.ui.xaml.hosting.desktopwindowxamlsource.h
+++ b/generation/um/windows.ui.xaml.hosting.desktopwindowxamlsource/um-windows.ui.xaml.hosting.desktopwindowxamlsource.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>

--- a/sources/Interop/Windows/um/HolographicSpaceInterop/IHolographicSpaceInterop.cs
+++ b/sources/Interop/Windows/um/HolographicSpaceInterop/IHolographicSpaceInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/HolographicSpaceInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("5C4EE536-6A98-4B86-A170-587013D6FD4B")]
+    [NativeTypeName("struct IHolographicSpaceInterop : IInspectable")]
+    public unsafe partial struct IHolographicSpaceInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, Guid*, void**, int>)(lpVtbl[0]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, uint>)(lpVtbl[1]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, uint>)(lpVtbl[2]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, IntPtr*, int>)(lpVtbl[4]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, TrustLevel*, int>)(lpVtbl[5]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int CreateForWindow([NativeTypeName("HWND")] IntPtr window, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** holographicSpace)
+        {
+            return ((delegate* unmanaged<IHolographicSpaceInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IHolographicSpaceInterop*)Unsafe.AsPointer(ref this), window, riid, holographicSpace);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/HolographicSpaceInterop/Windows.cs
+++ b/sources/Interop/Windows/um/HolographicSpaceInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/HolographicSpaceInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IHolographicSpaceInterop = new Guid(0x5C4EE536, 0x6A98, 0x4B86, 0xA1, 0x70, 0x58, 0x70, 0x13, 0xD6, 0xFD, 0x4B);
+    }
+}

--- a/sources/Interop/Windows/um/PlayToManagerInterop/IPlayToManagerInterop.cs
+++ b/sources/Interop/Windows/um/PlayToManagerInterop/IPlayToManagerInterop.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PlayToManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("24394699-1F2C-4EB3-8CD7-0EC1DA42A540")]
+    [NativeTypeName("struct IPlayToManagerInterop : IInspectable")]
+    public unsafe partial struct IPlayToManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, uint>)(lpVtbl[1]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, uint>)(lpVtbl[2]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** playToManager)
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this), appWindow, riid, playToManager);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int ShowPlayToUIForWindow([NativeTypeName("HWND")] IntPtr appWindow)
+        {
+            return ((delegate* unmanaged<IPlayToManagerInterop*, IntPtr, int>)(lpVtbl[7]))((IPlayToManagerInterop*)Unsafe.AsPointer(ref this), appWindow);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/PlayToManagerInterop/Windows.cs
+++ b/sources/Interop/Windows/um/PlayToManagerInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PlayToManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IPlayToManagerInterop = new Guid(0x24394699, 0x1F2C, 0x4EB3, 0x8C, 0xD7, 0x0E, 0xC1, 0xDA, 0x42, 0xA5, 0x40);
+    }
+}

--- a/sources/Interop/Windows/um/Print3DManagerInterop/IPrinting3DManagerInterop.cs
+++ b/sources/Interop/Windows/um/Print3DManagerInterop/IPrinting3DManagerInterop.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Print3DManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("9CA31010-1484-4587-B26B-DDDF9F9CAECD")]
+    [NativeTypeName("struct IPrinting3DManagerInterop : IInspectable")]
+    public unsafe partial struct IPrinting3DManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, uint>)(lpVtbl[1]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, uint>)(lpVtbl[2]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** printManager)
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this), appWindow, riid, printManager);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int ShowPrintUIForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IPrinting3DManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[7]))((IPrinting3DManagerInterop*)Unsafe.AsPointer(ref this), appWindow, riid, asyncOperation);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/Print3DManagerInterop/Windows.cs
+++ b/sources/Interop/Windows/um/Print3DManagerInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Print3DManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IPrinting3DManagerInterop = new Guid(0x9CA31010, 0x1484, 0x4587, 0xB2, 0x6B, 0xDD, 0xDF, 0x9F, 0x9C, 0xAE, 0xCD);
+    }
+}

--- a/sources/Interop/Windows/um/PrintManagerInterop/IPrintManagerInterop.cs
+++ b/sources/Interop/Windows/um/PrintManagerInterop/IPrintManagerInterop.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PrintManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("C5435A42-8D43-4E7B-A68A-EF311E392087")]
+    [NativeTypeName("struct IPrintManagerInterop : IInspectable")]
+    public unsafe partial struct IPrintManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, uint>)(lpVtbl[1]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, uint>)(lpVtbl[2]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** printManager)
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this), appWindow, riid, printManager);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int ShowPrintUIForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IPrintManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[7]))((IPrintManagerInterop*)Unsafe.AsPointer(ref this), appWindow, riid, asyncOperation);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/PrintManagerInterop/Windows.cs
+++ b/sources/Interop/Windows/um/PrintManagerInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PrintManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IPrintManagerInterop = new Guid(0xC5435A42, 0x8D43, 0x4E7B, 0xA6, 0x8A, 0xEF, 0x31, 0x1E, 0x39, 0x20, 0x87);
+    }
+}

--- a/sources/Interop/Windows/um/RadialControllerInterop/IRadialControllerConfigurationInterop.cs
+++ b/sources/Interop/Windows/um/RadialControllerInterop/IRadialControllerConfigurationInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("787CDAAC-3186-476D-87E4-B9374A7B9970")]
+    [NativeTypeName("struct IRadialControllerConfigurationInterop : IInspectable")]
+    public unsafe partial struct IRadialControllerConfigurationInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, Guid*, void**, int>)(lpVtbl[0]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, uint>)(lpVtbl[1]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, uint>)(lpVtbl[2]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, IntPtr*, int>)(lpVtbl[4]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, TrustLevel*, int>)(lpVtbl[5]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr hwnd, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv)
+        {
+            return ((delegate* unmanaged<IRadialControllerConfigurationInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IRadialControllerConfigurationInterop*)Unsafe.AsPointer(ref this), hwnd, riid, ppv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/RadialControllerInterop/IRadialControllerIndependentInputSourceInterop.cs
+++ b/sources/Interop/Windows/um/RadialControllerInterop/IRadialControllerIndependentInputSourceInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("3D577EFF-4CEE-11E6-B535-001BDC06AB3B")]
+    [NativeTypeName("struct IRadialControllerIndependentInputSourceInterop : IInspectable")]
+    public unsafe partial struct IRadialControllerIndependentInputSourceInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, Guid*, void**, int>)(lpVtbl[0]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, uint>)(lpVtbl[1]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, uint>)(lpVtbl[2]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, IntPtr*, int>)(lpVtbl[4]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, TrustLevel*, int>)(lpVtbl[5]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int CreateForWindow([NativeTypeName("HWND")] IntPtr hwnd, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv)
+        {
+            return ((delegate* unmanaged<IRadialControllerIndependentInputSourceInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IRadialControllerIndependentInputSourceInterop*)Unsafe.AsPointer(ref this), hwnd, riid, ppv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/RadialControllerInterop/IRadialControllerInterop.cs
+++ b/sources/Interop/Windows/um/RadialControllerInterop/IRadialControllerInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("1B0535C9-57AD-45C1-9D79-AD5C34360513")]
+    [NativeTypeName("struct IRadialControllerInterop : IInspectable")]
+    public unsafe partial struct IRadialControllerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, uint>)(lpVtbl[1]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, uint>)(lpVtbl[2]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, IntPtr*, int>)(lpVtbl[4]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int CreateForWindow([NativeTypeName("HWND")] IntPtr hwnd, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv)
+        {
+            return ((delegate* unmanaged<IRadialControllerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IRadialControllerInterop*)Unsafe.AsPointer(ref this), hwnd, riid, ppv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/RadialControllerInterop/Windows.cs
+++ b/sources/Interop/Windows/um/RadialControllerInterop/Windows.cs
@@ -1,0 +1,18 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IRadialControllerInterop = new Guid(0x1B0535C9, 0x57AD, 0x45C1, 0x9D, 0x79, 0xAD, 0x5C, 0x34, 0x36, 0x05, 0x13);
+
+        public static readonly Guid IID_IRadialControllerConfigurationInterop = new Guid(0x787CDAAC, 0x3186, 0x476D, 0x87, 0xE4, 0xB9, 0x37, 0x4A, 0x7B, 0x99, 0x70);
+
+        public static readonly Guid IID_IRadialControllerIndependentInputSourceInterop = new Guid(0x3D577EFF, 0x4CEE, 0x11E6, 0xB5, 0x35, 0x00, 0x1B, 0xDC, 0x06, 0xAB, 0x3B);
+    }
+}

--- a/sources/Interop/Windows/um/RemoteSystemsInterop/ICorrelationVectorInformation.cs
+++ b/sources/Interop/Windows/um/RemoteSystemsInterop/ICorrelationVectorInformation.cs
@@ -1,0 +1,81 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RemoteSystemsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("83C78B3C-D88B-4950-AA6E-22B8D22AABD3")]
+    [NativeTypeName("struct ICorrelationVectorInformation : IInspectable")]
+    public unsafe partial struct ICorrelationVectorInformation
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, Guid*, void**, int>)(lpVtbl[0]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, uint>)(lpVtbl[1]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, uint>)(lpVtbl[2]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, uint*, Guid**, int>)(lpVtbl[3]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, IntPtr*, int>)(lpVtbl[4]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, TrustLevel*, int>)(lpVtbl[5]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_LastCorrelationVectorForThread([NativeTypeName("HSTRING *")] IntPtr* cv)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, IntPtr*, int>)(lpVtbl[6]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), cv);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_NextCorrelationVectorForThread([NativeTypeName("HSTRING *")] IntPtr* cv)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, IntPtr*, int>)(lpVtbl[7]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), cv);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int put_NextCorrelationVectorForThread([NativeTypeName("HSTRING")] IntPtr cv)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorInformation*, IntPtr, int>)(lpVtbl[8]))((ICorrelationVectorInformation*)Unsafe.AsPointer(ref this), cv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/RemoteSystemsInterop/Windows.cs
+++ b/sources/Interop/Windows/um/RemoteSystemsInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RemoteSystemsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_ICorrelationVectorInformation = new Guid(0x83C78B3C, 0xD88B, 0x4950, 0xAA, 0x6E, 0x22, 0xB8, 0xD2, 0x2A, 0xAB, 0xD3);
+    }
+}

--- a/sources/Interop/Windows/um/SpatialInteractionManagerInterop/ISpatialInteractionManagerInterop.cs
+++ b/sources/Interop/Windows/um/SpatialInteractionManagerInterop/ISpatialInteractionManagerInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SpatialInteractionManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("5C4EE536-6A98-4B86-A170-587013D6FD4B")]
+    [NativeTypeName("struct ISpatialInteractionManagerInterop : IInspectable")]
+    public unsafe partial struct ISpatialInteractionManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, uint>)(lpVtbl[1]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, uint>)(lpVtbl[2]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr window, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** spatialInteractionManager)
+        {
+            return ((delegate* unmanaged<ISpatialInteractionManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((ISpatialInteractionManagerInterop*)Unsafe.AsPointer(ref this), window, riid, spatialInteractionManager);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/SpatialInteractionManagerInterop/Windows.cs
+++ b/sources/Interop/Windows/um/SpatialInteractionManagerInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SpatialInteractionManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_ISpatialInteractionManagerInterop = new Guid(0x5C4EE536, 0x6A98, 0x4B86, 0xA1, 0x70, 0x58, 0x70, 0x13, 0xD6, 0xFD, 0x4B);
+    }
+}

--- a/sources/Interop/Windows/um/SystemMediaTransportControlsInterop/ISystemMediaTransportControlsInterop.cs
+++ b/sources/Interop/Windows/um/SystemMediaTransportControlsInterop/ISystemMediaTransportControlsInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SystemMediaTransportControlsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("DDB0472D-C911-4A1F-86D9-DC3D71A95F5A")]
+    [NativeTypeName("struct ISystemMediaTransportControlsInterop : IInspectable")]
+    public unsafe partial struct ISystemMediaTransportControlsInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, Guid*, void**, int>)(lpVtbl[0]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, uint>)(lpVtbl[1]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, uint>)(lpVtbl[2]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, uint*, Guid**, int>)(lpVtbl[3]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, IntPtr*, int>)(lpVtbl[4]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, TrustLevel*, int>)(lpVtbl[5]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** mediaTransportControl)
+        {
+            return ((delegate* unmanaged<ISystemMediaTransportControlsInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((ISystemMediaTransportControlsInterop*)Unsafe.AsPointer(ref this), appWindow, riid, mediaTransportControl);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/SystemMediaTransportControlsInterop/Windows.cs
+++ b/sources/Interop/Windows/um/SystemMediaTransportControlsInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SystemMediaTransportControlsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_ISystemMediaTransportControlsInterop = new Guid(0xDDB0472D, 0xC911, 0x4A1F, 0x86, 0xD9, 0xDC, 0x3D, 0x71, 0xA9, 0x5F, 0x5A);
+    }
+}

--- a/sources/Interop/Windows/um/UIViewSettingsInterop/IUIViewSettingsInterop.cs
+++ b/sources/Interop/Windows/um/UIViewSettingsInterop/IUIViewSettingsInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UIViewSettingsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("3694DBF9-8F68-44BE-8FF5-195C98EDE8A6")]
+    [NativeTypeName("struct IUIViewSettingsInterop : IInspectable")]
+    public unsafe partial struct IUIViewSettingsInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, Guid*, void**, int>)(lpVtbl[0]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, uint>)(lpVtbl[1]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, uint>)(lpVtbl[2]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, IntPtr*, int>)(lpVtbl[4]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, TrustLevel*, int>)(lpVtbl[5]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr hwnd, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv)
+        {
+            return ((delegate* unmanaged<IUIViewSettingsInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IUIViewSettingsInterop*)Unsafe.AsPointer(ref this), hwnd, riid, ppv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/UIViewSettingsInterop/Windows.cs
+++ b/sources/Interop/Windows/um/UIViewSettingsInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UIViewSettingsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IUIViewSettingsInterop = new Guid(0x3694DBF9, 0x8F68, 0x44BE, 0x8F, 0xF5, 0x19, 0x5C, 0x98, 0xED, 0xE8, 0xA6);
+    }
+}

--- a/sources/Interop/Windows/um/UserConsentVerifierInterop/IUserConsentVerifierInterop.cs
+++ b/sources/Interop/Windows/um/UserConsentVerifierInterop/IUserConsentVerifierInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UserConsentVerifierInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("39E050C3-4E74-441A-8DC0-B81104DF949C")]
+    [NativeTypeName("struct IUserConsentVerifierInterop : IInspectable")]
+    public unsafe partial struct IUserConsentVerifierInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, Guid*, void**, int>)(lpVtbl[0]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, uint>)(lpVtbl[1]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, uint>)(lpVtbl[2]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, IntPtr*, int>)(lpVtbl[4]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, TrustLevel*, int>)(lpVtbl[5]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestVerificationForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr message, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IUserConsentVerifierInterop*, IntPtr, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IUserConsentVerifierInterop*)Unsafe.AsPointer(ref this), appWindow, message, riid, asyncOperation);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/UserConsentVerifierInterop/Windows.cs
+++ b/sources/Interop/Windows/um/UserConsentVerifierInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UserConsentVerifierInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IUserConsentVerifierInterop = new Guid(0x39E050C3, 0x4E74, 0x441A, 0x8D, 0xC0, 0xB8, 0x11, 0x04, 0xDF, 0x94, 0x9C);
+    }
+}

--- a/sources/Interop/Windows/um/WebAuthenticationCoreManagerInterop/IWebAuthenticationCoreManagerInterop.cs
+++ b/sources/Interop/Windows/um/WebAuthenticationCoreManagerInterop/IWebAuthenticationCoreManagerInterop.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/WebAuthenticationCoreManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("F4B8E804-811E-4436-B69C-44CB67B72084")]
+    [NativeTypeName("struct IWebAuthenticationCoreManagerInterop : IInspectable")]
+    public unsafe partial struct IWebAuthenticationCoreManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, uint>)(lpVtbl[1]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, uint>)(lpVtbl[2]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestTokenForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("IInspectable *")] IInspectable* request, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncInfo)
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, IntPtr, IInspectable*, Guid*, void**, int>)(lpVtbl[6]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this), appWindow, request, riid, asyncInfo);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestTokenWithWebAccountForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("IInspectable *")] IInspectable* request, [NativeTypeName("IInspectable *")] IInspectable* webAccount, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncInfo)
+        {
+            return ((delegate* unmanaged<IWebAuthenticationCoreManagerInterop*, IntPtr, IInspectable*, IInspectable*, Guid*, void**, int>)(lpVtbl[7]))((IWebAuthenticationCoreManagerInterop*)Unsafe.AsPointer(ref this), appWindow, request, webAccount, riid, asyncInfo);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/WebAuthenticationCoreManagerInterop/Windows.cs
+++ b/sources/Interop/Windows/um/WebAuthenticationCoreManagerInterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/WebAuthenticationCoreManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IWebAuthenticationCoreManagerInterop = new Guid(0xF4B8E804, 0x811E, 0x4436, 0xB6, 0x9C, 0x44, 0xCB, 0x67, 0xB7, 0x20, 0x84);
+    }
+}

--- a/sources/Interop/Windows/um/Windows.Graphics.Capture.Interop/IGraphicsCaptureItemInterop.cs
+++ b/sources/Interop/Windows/um/Windows.Graphics.Capture.Interop/IGraphicsCaptureItemInterop.cs
@@ -1,0 +1,53 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Windows.Graphics.Capture.Interop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("3628E81B-3CAC-4C60-B7F4-23CE0E0C3356")]
+    [NativeTypeName("struct IGraphicsCaptureItemInterop : IUnknown")]
+    public unsafe partial struct IGraphicsCaptureItemInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IGraphicsCaptureItemInterop*, Guid*, void**, int>)(lpVtbl[0]))((IGraphicsCaptureItemInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IGraphicsCaptureItemInterop*, uint>)(lpVtbl[1]))((IGraphicsCaptureItemInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IGraphicsCaptureItemInterop*, uint>)(lpVtbl[2]))((IGraphicsCaptureItemInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int CreateForWindow([NativeTypeName("HWND")] IntPtr window, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** result)
+        {
+            return ((delegate* unmanaged<IGraphicsCaptureItemInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[3]))((IGraphicsCaptureItemInterop*)Unsafe.AsPointer(ref this), window, riid, result);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int CreateForMonitor([NativeTypeName("HMONITOR")] IntPtr monitor, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** result)
+        {
+            return ((delegate* unmanaged<IGraphicsCaptureItemInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[4]))((IGraphicsCaptureItemInterop*)Unsafe.AsPointer(ref this), monitor, riid, result);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/Windows.Graphics.Capture.Interop/Windows.cs
+++ b/sources/Interop/Windows/um/Windows.Graphics.Capture.Interop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Windows.Graphics.Capture.Interop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IGraphicsCaptureItemInterop = new Guid(0x3628E81B, 0x3CAC, 0x4C60, 0xB7, 0xF4, 0x23, 0xCE, 0x0E, 0x0C, 0x33, 0x56);
+    }
+}

--- a/sources/Interop/Windows/um/accountssettingspaneinterop/IAccountsSettingsPaneInterop.cs
+++ b/sources/Interop/Windows/um/accountssettingspaneinterop/IAccountsSettingsPaneInterop.cs
@@ -1,0 +1,81 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/accountssettingspaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("D3EE12AD-3865-4362-9746-B75A682DF0E6")]
+    [NativeTypeName("struct IAccountsSettingsPaneInterop : IInspectable")]
+    public unsafe partial struct IAccountsSettingsPaneInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, Guid*, void**, int>)(lpVtbl[0]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, uint>)(lpVtbl[1]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, uint>)(lpVtbl[2]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, IntPtr*, int>)(lpVtbl[4]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, TrustLevel*, int>)(lpVtbl[5]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** accountsSettingsPane)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), appWindow, riid, accountsSettingsPane);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int ShowManageAccountsForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncAction)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[7]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), appWindow, riid, asyncAction);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int ShowAddAccountForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncAction)
+        {
+            return ((delegate* unmanaged<IAccountsSettingsPaneInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[8]))((IAccountsSettingsPaneInterop*)Unsafe.AsPointer(ref this), appWindow, riid, asyncAction);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/accountssettingspaneinterop/Windows.cs
+++ b/sources/Interop/Windows/um/accountssettingspaneinterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/accountssettingspaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IAccountsSettingsPaneInterop = new Guid(0xD3EE12AD, 0x3865, 0x4362, 0x97, 0x46, 0xB7, 0x5A, 0x68, 0x2D, 0xF0, 0xE6);
+    }
+}

--- a/sources/Interop/Windows/um/appserviceinterop/IAppServiceConnectionExtendedExecution.cs
+++ b/sources/Interop/Windows/um/appserviceinterop/IAppServiceConnectionExtendedExecution.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/appserviceinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("65219584-F9CB-4AE3-81F9-A28A6CA450D9")]
+    [NativeTypeName("struct IAppServiceConnectionExtendedExecution : IUnknown")]
+    public unsafe partial struct IAppServiceConnectionExtendedExecution
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAppServiceConnectionExtendedExecution*, Guid*, void**, int>)(lpVtbl[0]))((IAppServiceConnectionExtendedExecution*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAppServiceConnectionExtendedExecution*, uint>)(lpVtbl[1]))((IAppServiceConnectionExtendedExecution*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAppServiceConnectionExtendedExecution*, uint>)(lpVtbl[2]))((IAppServiceConnectionExtendedExecution*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int OpenForExtendedExecutionAsync([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** operation)
+        {
+            return ((delegate* unmanaged<IAppServiceConnectionExtendedExecution*, Guid*, void**, int>)(lpVtbl[3]))((IAppServiceConnectionExtendedExecution*)Unsafe.AsPointer(ref this), riid, operation);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/appserviceinterop/ICorrelationVectorSource.cs
+++ b/sources/Interop/Windows/um/appserviceinterop/ICorrelationVectorSource.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/appserviceinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("152B8A3B-B9B9-4685-B56E-974847BC7545")]
+    [NativeTypeName("struct ICorrelationVectorSource : IUnknown")]
+    public unsafe partial struct ICorrelationVectorSource
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorSource*, Guid*, void**, int>)(lpVtbl[0]))((ICorrelationVectorSource*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<ICorrelationVectorSource*, uint>)(lpVtbl[1]))((ICorrelationVectorSource*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<ICorrelationVectorSource*, uint>)(lpVtbl[2]))((ICorrelationVectorSource*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_CorrelationVector([NativeTypeName("HSTRING *")] IntPtr* cv)
+        {
+            return ((delegate* unmanaged<ICorrelationVectorSource*, IntPtr*, int>)(lpVtbl[3]))((ICorrelationVectorSource*)Unsafe.AsPointer(ref this), cv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/appserviceinterop/Windows.cs
+++ b/sources/Interop/Windows/um/appserviceinterop/Windows.cs
@@ -1,0 +1,16 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/appserviceinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IAppServiceConnectionExtendedExecution = new Guid(0x65219584, 0xF9CB, 0x4AE3, 0x81, 0xF9, 0xA2, 0x8A, 0x6C, 0xA4, 0x50, 0xD9);
+
+        public static readonly Guid IID_ICorrelationVectorSource = new Guid(0x152B8A3B, 0xB9B9, 0x4685, 0xB5, 0x6E, 0x97, 0x48, 0x47, 0xBC, 0x75, 0x45);
+    }
+}

--- a/sources/Interop/Windows/um/dragdropinterop/IDragDropManagerInterop.cs
+++ b/sources/Interop/Windows/um/dragdropinterop/IDragDropManagerInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/dragdropinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("5AD8CBA7-4C01-4DAC-9074-827894292D63")]
+    [NativeTypeName("struct IDragDropManagerInterop : IInspectable")]
+    public unsafe partial struct IDragDropManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, uint>)(lpVtbl[1]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, uint>)(lpVtbl[2]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr hwnd, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv)
+        {
+            return ((delegate* unmanaged<IDragDropManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IDragDropManagerInterop*)Unsafe.AsPointer(ref this), hwnd, riid, ppv);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/dragdropinterop/Windows.cs
+++ b/sources/Interop/Windows/um/dragdropinterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/dragdropinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IDragDropManagerInterop = new Guid(0x5AD8CBA7, 0x4C01, 0x4DAC, 0x90, 0x74, 0x82, 0x78, 0x94, 0x29, 0x2D, 0x63);
+    }
+}

--- a/sources/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop.cs
+++ b/sources/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("4652651D-C1FE-4BA1-9F0A-C0F56596F721")]
+    [NativeTypeName("struct IProtectionPolicyManagerInterop : IInspectable")]
+    public unsafe partial struct IProtectionPolicyManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, uint>)(lpVtbl[1]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, uint>)(lpVtbl[2]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr targetIdentity, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, IntPtr, IntPtr, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, targetIdentity, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** result)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[7]))((IProtectionPolicyManagerInterop*)Unsafe.AsPointer(ref this), appWindow, riid, result);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop2.cs
+++ b/sources/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop2.cs
@@ -1,0 +1,95 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("157CFBE4-A78D-4156-B384-61FDAC41E686")]
+    [NativeTypeName("struct IProtectionPolicyManagerInterop2 : IInspectable")]
+    public unsafe partial struct IProtectionPolicyManagerInterop2
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, Guid*, void**, int>)(lpVtbl[0]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, uint>)(lpVtbl[1]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, uint>)(lpVtbl[2]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, uint*, Guid**, int>)(lpVtbl[3]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, IntPtr*, int>)(lpVtbl[4]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, TrustLevel*, int>)(lpVtbl[5]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessForAppWithWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr appPackageFamilyName, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, IntPtr, IntPtr, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, appPackageFamilyName, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessWithAuditingInfoForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr targetIdentity, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, IntPtr, IntPtr, IntPtr, IUnknown*, Guid*, void**, int>)(lpVtbl[7]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, targetIdentity, auditInfoUnk, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessWithMessageForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr targetIdentity, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("HSTRING")] IntPtr messageFromApp, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, IntPtr, IntPtr, IntPtr, IUnknown*, IntPtr, Guid*, void**, int>)(lpVtbl[8]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, targetIdentity, auditInfoUnk, messageFromApp, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessForAppWithAuditingInfoForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr appPackageFamilyName, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, IntPtr, IntPtr, IntPtr, IUnknown*, Guid*, void**, int>)(lpVtbl[9]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, appPackageFamilyName, auditInfoUnk, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessForAppWithMessageForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr appPackageFamilyName, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("HSTRING")] IntPtr messageFromApp, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop2*, IntPtr, IntPtr, IntPtr, IUnknown*, IntPtr, Guid*, void**, int>)(lpVtbl[10]))((IProtectionPolicyManagerInterop2*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, appPackageFamilyName, auditInfoUnk, messageFromApp, riid, asyncOperation);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop3.cs
+++ b/sources/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop3.cs
@@ -1,0 +1,102 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("C1C03933-B398-4D93-B0FD-2972ADF802C2")]
+    [NativeTypeName("struct IProtectionPolicyManagerInterop3 : IInspectable")]
+    public unsafe partial struct IProtectionPolicyManagerInterop3
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, Guid*, void**, int>)(lpVtbl[0]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, uint>)(lpVtbl[1]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, uint>)(lpVtbl[2]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, uint*, Guid**, int>)(lpVtbl[3]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr*, int>)(lpVtbl[4]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, TrustLevel*, int>)(lpVtbl[5]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessWithBehaviorForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr targetIdentity, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("HSTRING")] IntPtr messageFromApp, [NativeTypeName("UINT32")] uint behavior, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr, IntPtr, IntPtr, IUnknown*, IntPtr, uint, Guid*, void**, int>)(lpVtbl[6]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, targetIdentity, auditInfoUnk, messageFromApp, behavior, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessForAppWithBehaviorForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("HSTRING")] IntPtr sourceIdentity, [NativeTypeName("HSTRING")] IntPtr appPackageFamilyName, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("HSTRING")] IntPtr messageFromApp, [NativeTypeName("UINT32")] uint behavior, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr, IntPtr, IntPtr, IUnknown*, IntPtr, uint, Guid*, void**, int>)(lpVtbl[7]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), appWindow, sourceIdentity, appPackageFamilyName, auditInfoUnk, messageFromApp, behavior, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessToFilesForAppForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("IUnknown *")] IUnknown* sourceItemListUnk, [NativeTypeName("HSTRING")] IntPtr appPackageFamilyName, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr, IUnknown*, IntPtr, IUnknown*, Guid*, void**, int>)(lpVtbl[8]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), appWindow, sourceItemListUnk, appPackageFamilyName, auditInfoUnk, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessToFilesForAppWithMessageAndBehaviorForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("IUnknown *")] IUnknown* sourceItemListUnk, [NativeTypeName("HSTRING")] IntPtr appPackageFamilyName, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("HSTRING")] IntPtr messageFromApp, [NativeTypeName("UINT32")] uint behavior, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr, IUnknown*, IntPtr, IUnknown*, IntPtr, uint, Guid*, void**, int>)(lpVtbl[9]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), appWindow, sourceItemListUnk, appPackageFamilyName, auditInfoUnk, messageFromApp, behavior, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessToFilesForProcessForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("IUnknown *")] IUnknown* sourceItemListUnk, [NativeTypeName("UINT32")] uint processId, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr, IUnknown*, uint, IUnknown*, Guid*, void**, int>)(lpVtbl[10]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), appWindow, sourceItemListUnk, processId, auditInfoUnk, riid, asyncOperation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RequestAccessToFilesForProcessWithMessageAndBehaviorForWindowAsync([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("IUnknown *")] IUnknown* sourceItemListUnk, [NativeTypeName("UINT32")] uint processId, [NativeTypeName("IUnknown *")] IUnknown* auditInfoUnk, [NativeTypeName("HSTRING")] IntPtr messageFromApp, [NativeTypeName("UINT32")] uint behavior, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** asyncOperation)
+        {
+            return ((delegate* unmanaged<IProtectionPolicyManagerInterop3*, IntPtr, IUnknown*, uint, IUnknown*, IntPtr, uint, Guid*, void**, int>)(lpVtbl[11]))((IProtectionPolicyManagerInterop3*)Unsafe.AsPointer(ref this), appWindow, sourceItemListUnk, processId, auditInfoUnk, messageFromApp, behavior, riid, asyncOperation);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/efswrtinterop/Windows.cs
+++ b/sources/Interop/Windows/um/efswrtinterop/Windows.cs
@@ -1,0 +1,18 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IProtectionPolicyManagerInterop = new Guid(0x4652651D, 0xC1FE, 0x4BA1, 0x9F, 0x0A, 0xC0, 0xF5, 0x65, 0x96, 0xF7, 0x21);
+
+        public static readonly Guid IID_IProtectionPolicyManagerInterop2 = new Guid(0x157CFBE4, 0xA78D, 0x4156, 0xB3, 0x84, 0x61, 0xFD, 0xAC, 0x41, 0xE6, 0x86);
+
+        public static readonly Guid IID_IProtectionPolicyManagerInterop3 = new Guid(0xC1C03933, 0xB398, 0x4D93, 0xB0, 0xFD, 0x29, 0x72, 0xAD, 0xF8, 0x02, 0xC2);
+    }
+}

--- a/sources/Interop/Windows/um/inputpaneinterop/IInputPaneInterop.cs
+++ b/sources/Interop/Windows/um/inputpaneinterop/IInputPaneInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/inputpaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("75CF2C57-9195-4931-8332-F0B409E916AF")]
+    [NativeTypeName("struct IInputPaneInterop : IInspectable")]
+    public unsafe partial struct IInputPaneInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, Guid*, void**, int>)(lpVtbl[0]))((IInputPaneInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, uint>)(lpVtbl[1]))((IInputPaneInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, uint>)(lpVtbl[2]))((IInputPaneInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IInputPaneInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, IntPtr*, int>)(lpVtbl[4]))((IInputPaneInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, TrustLevel*, int>)(lpVtbl[5]))((IInputPaneInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr appWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** inputPane)
+        {
+            return ((delegate* unmanaged<IInputPaneInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IInputPaneInterop*)Unsafe.AsPointer(ref this), appWindow, riid, inputPane);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/inputpaneinterop/Windows.cs
+++ b/sources/Interop/Windows/um/inputpaneinterop/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/inputpaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IInputPaneInterop = new Guid(0x75CF2C57, 0x9195, 0x4931, 0x83, 0x32, 0xF0, 0xB4, 0x09, 0xE9, 0x16, 0xAF);
+    }
+}

--- a/sources/Interop/Windows/um/remotesystemadditionalinfo/IRemoteSystemAdditionalInfoProvider.cs
+++ b/sources/Interop/Windows/um/remotesystemadditionalinfo/IRemoteSystemAdditionalInfoProvider.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/remotesystemadditionalinfo.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("EEAA3D5F-EC63-4D27-AF38-E86B1D7292CB")]
+    [NativeTypeName("struct IRemoteSystemAdditionalInfoProvider : IUnknown")]
+    public unsafe partial struct IRemoteSystemAdditionalInfoProvider
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IRemoteSystemAdditionalInfoProvider*, Guid*, void**, int>)(lpVtbl[0]))((IRemoteSystemAdditionalInfoProvider*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IRemoteSystemAdditionalInfoProvider*, uint>)(lpVtbl[1]))((IRemoteSystemAdditionalInfoProvider*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IRemoteSystemAdditionalInfoProvider*, uint>)(lpVtbl[2]))((IRemoteSystemAdditionalInfoProvider*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetAdditionalInfo([NativeTypeName("HSTRING *")] IntPtr* deduplicationId, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** mapView)
+        {
+            return ((delegate* unmanaged<IRemoteSystemAdditionalInfoProvider*, IntPtr*, Guid*, void**, int>)(lpVtbl[3]))((IRemoteSystemAdditionalInfoProvider*)Unsafe.AsPointer(ref this), deduplicationId, riid, mapView);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/remotesystemadditionalinfo/Windows.cs
+++ b/sources/Interop/Windows/um/remotesystemadditionalinfo/Windows.cs
@@ -1,0 +1,14 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/remotesystemadditionalinfo.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IRemoteSystemAdditionalInfoProvider = new Guid(0xEEAA3D5F, 0xEC63, 0x4D27, 0xAF, 0x38, 0xE8, 0x6B, 0x1D, 0x72, 0x92, 0xCB);
+    }
+}

--- a/sources/Interop/Windows/um/useractivityinterop/IUserActivityInterop.cs
+++ b/sources/Interop/Windows/um/useractivityinterop/IUserActivityInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("1ADE314D-0E0A-40D9-824C-9A088A50059F")]
+    [NativeTypeName("struct IUserActivityInterop : IInspectable")]
+    public unsafe partial struct IUserActivityInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, Guid*, void**, int>)(lpVtbl[0]))((IUserActivityInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, uint>)(lpVtbl[1]))((IUserActivityInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, uint>)(lpVtbl[2]))((IUserActivityInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IUserActivityInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, IntPtr*, int>)(lpVtbl[4]))((IUserActivityInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, TrustLevel*, int>)(lpVtbl[5]))((IUserActivityInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int CreateSessionForWindow([NativeTypeName("HWND")] IntPtr window, [NativeTypeName("const IID &")] Guid* iid, [NativeTypeName("void **")] void** value)
+        {
+            return ((delegate* unmanaged<IUserActivityInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IUserActivityInterop*)Unsafe.AsPointer(ref this), window, iid, value);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/useractivityinterop/IUserActivityRequestManagerInterop.cs
+++ b/sources/Interop/Windows/um/useractivityinterop/IUserActivityRequestManagerInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("DD69F876-9699-4715-9095-E37EA30DFA1B")]
+    [NativeTypeName("struct IUserActivityRequestManagerInterop : IInspectable")]
+    public unsafe partial struct IUserActivityRequestManagerInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, Guid*, void**, int>)(lpVtbl[0]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, uint>)(lpVtbl[1]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, uint>)(lpVtbl[2]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, IntPtr*, int>)(lpVtbl[4]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, TrustLevel*, int>)(lpVtbl[5]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetForWindow([NativeTypeName("HWND")] IntPtr window, [NativeTypeName("const IID &")] Guid* iid, [NativeTypeName("void **")] void** value)
+        {
+            return ((delegate* unmanaged<IUserActivityRequestManagerInterop*, IntPtr, Guid*, void**, int>)(lpVtbl[6]))((IUserActivityRequestManagerInterop*)Unsafe.AsPointer(ref this), window, iid, value);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/useractivityinterop/IUserActivitySourceHostInterop.cs
+++ b/sources/Interop/Windows/um/useractivityinterop/IUserActivitySourceHostInterop.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("C15DF8BC-8844-487A-B85B-7578E0F61419")]
+    [NativeTypeName("struct IUserActivitySourceHostInterop : IInspectable")]
+    public unsafe partial struct IUserActivitySourceHostInterop
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, Guid*, void**, int>)(lpVtbl[0]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, uint>)(lpVtbl[1]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, uint>)(lpVtbl[2]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, uint*, Guid**, int>)(lpVtbl[3]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, IntPtr*, int>)(lpVtbl[4]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, TrustLevel*, int>)(lpVtbl[5]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int SetActivitySourceHost([NativeTypeName("HSTRING")] IntPtr activitySourceHost)
+        {
+            return ((delegate* unmanaged<IUserActivitySourceHostInterop*, IntPtr, int>)(lpVtbl[6]))((IUserActivitySourceHostInterop*)Unsafe.AsPointer(ref this), activitySourceHost);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/useractivityinterop/Windows.cs
+++ b/sources/Interop/Windows/um/useractivityinterop/Windows.cs
@@ -1,0 +1,18 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IUserActivityInterop = new Guid(0x1ADE314D, 0x0E0A, 0x40D9, 0x82, 0x4C, 0x9A, 0x08, 0x8A, 0x50, 0x05, 0x9F);
+
+        public static readonly Guid IID_IUserActivitySourceHostInterop = new Guid(0xC15DF8BC, 0x8844, 0x487A, 0xB8, 0x5B, 0x75, 0x78, 0xE0, 0xF6, 0x14, 0x19);
+
+        public static readonly Guid IID_IUserActivityRequestManagerInterop = new Guid(0xDD69F876, 0x9699, 0x4715, 0x90, 0x95, 0xE3, 0x7E, 0xA3, 0x0D, 0xFA, 0x1B);
+    }
+}

--- a/sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNative.cs
+++ b/sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNative.cs
@@ -1,0 +1,53 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/windows.ui.xaml.hosting.desktopwindowxamlsource.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("3CBCF1BF-2F76-4E9C-96AB-E84B37972554")]
+    [NativeTypeName("struct IDesktopWindowXamlSourceNative : IUnknown")]
+    public unsafe partial struct IDesktopWindowXamlSourceNative
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative*, Guid*, void**, int>)(lpVtbl[0]))((IDesktopWindowXamlSourceNative*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative*, uint>)(lpVtbl[1]))((IDesktopWindowXamlSourceNative*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative*, uint>)(lpVtbl[2]))((IDesktopWindowXamlSourceNative*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int AttachToWindow([NativeTypeName("HWND")] IntPtr parentWnd)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative*, IntPtr, int>)(lpVtbl[3]))((IDesktopWindowXamlSourceNative*)Unsafe.AsPointer(ref this), parentWnd);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_WindowHandle([NativeTypeName("HWND *")] IntPtr* hWnd)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative*, IntPtr*, int>)(lpVtbl[4]))((IDesktopWindowXamlSourceNative*)Unsafe.AsPointer(ref this), hWnd);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNative2.cs
+++ b/sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNative2.cs
@@ -1,0 +1,60 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/windows.ui.xaml.hosting.desktopwindowxamlsource.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("E3DCD8C7-3057-4692-99C3-7B7720AFDA31")]
+    [NativeTypeName("struct IDesktopWindowXamlSourceNative2 : IDesktopWindowXamlSourceNative")]
+    public unsafe partial struct IDesktopWindowXamlSourceNative2
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative2*, Guid*, void**, int>)(lpVtbl[0]))((IDesktopWindowXamlSourceNative2*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative2*, uint>)(lpVtbl[1]))((IDesktopWindowXamlSourceNative2*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative2*, uint>)(lpVtbl[2]))((IDesktopWindowXamlSourceNative2*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int AttachToWindow([NativeTypeName("HWND")] IntPtr parentWnd)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative2*, IntPtr, int>)(lpVtbl[3]))((IDesktopWindowXamlSourceNative2*)Unsafe.AsPointer(ref this), parentWnd);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_WindowHandle([NativeTypeName("HWND *")] IntPtr* hWnd)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative2*, IntPtr*, int>)(lpVtbl[4]))((IDesktopWindowXamlSourceNative2*)Unsafe.AsPointer(ref this), hWnd);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int PreTranslateMessage([NativeTypeName("const MSG *")] MSG* message, [NativeTypeName("BOOL *")] int* result)
+        {
+            return ((delegate* unmanaged<IDesktopWindowXamlSourceNative2*, MSG*, int*, int>)(lpVtbl[5]))((IDesktopWindowXamlSourceNative2*)Unsafe.AsPointer(ref this), message, result);
+        }
+    }
+}

--- a/sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/Windows.cs
+++ b/sources/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/Windows.cs
@@ -1,0 +1,16 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/windows.ui.xaml.hosting.desktopwindowxamlsource.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+
+namespace TerraFX.Interop
+{
+    public static partial class Windows
+    {
+        public static readonly Guid IID_IDesktopWindowXamlSourceNative = new Guid(0x3CBCF1BF, 0x2F76, 0x4E9C, 0x96, 0xAB, 0xE8, 0x4B, 0x37, 0x97, 0x25, 0x54);
+
+        public static readonly Guid IID_IDesktopWindowXamlSourceNative2 = new Guid(0xE3DCD8C7, 0x3057, 0x4692, 0x99, 0xC3, 0x7B, 0x77, 0x20, 0xAF, 0xDA, 0x31);
+    }
+}

--- a/tests/Interop/Windows/um/HolographicSpaceInterop/IHolographicSpaceInteropTests.cs
+++ b/tests/Interop/Windows/um/HolographicSpaceInterop/IHolographicSpaceInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/HolographicSpaceInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IHolographicSpaceInterop" /> struct.</summary>
+    public static unsafe class IHolographicSpaceInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IHolographicSpaceInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IHolographicSpaceInterop).GUID, Is.EqualTo(IID_IHolographicSpaceInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IHolographicSpaceInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IHolographicSpaceInterop>(), Is.EqualTo(sizeof(IHolographicSpaceInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IHolographicSpaceInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IHolographicSpaceInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IHolographicSpaceInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IHolographicSpaceInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IHolographicSpaceInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/PlayToManagerInterop/IPlayToManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/PlayToManagerInterop/IPlayToManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PlayToManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IPlayToManagerInterop" /> struct.</summary>
+    public static unsafe class IPlayToManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IPlayToManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IPlayToManagerInterop).GUID, Is.EqualTo(IID_IPlayToManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IPlayToManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IPlayToManagerInterop>(), Is.EqualTo(sizeof(IPlayToManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IPlayToManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IPlayToManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IPlayToManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IPlayToManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IPlayToManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/Print3DManagerInterop/IPrinting3DManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/Print3DManagerInterop/IPrinting3DManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Print3DManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IPrinting3DManagerInterop" /> struct.</summary>
+    public static unsafe class IPrinting3DManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IPrinting3DManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IPrinting3DManagerInterop).GUID, Is.EqualTo(IID_IPrinting3DManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IPrinting3DManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IPrinting3DManagerInterop>(), Is.EqualTo(sizeof(IPrinting3DManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IPrinting3DManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IPrinting3DManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IPrinting3DManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IPrinting3DManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IPrinting3DManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/PrintManagerInterop/IPrintManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/PrintManagerInterop/IPrintManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/PrintManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IPrintManagerInterop" /> struct.</summary>
+    public static unsafe class IPrintManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IPrintManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IPrintManagerInterop).GUID, Is.EqualTo(IID_IPrintManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IPrintManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IPrintManagerInterop>(), Is.EqualTo(sizeof(IPrintManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IPrintManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IPrintManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IPrintManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IPrintManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IPrintManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/RadialControllerInterop/IRadialControllerConfigurationInteropTests.cs
+++ b/tests/Interop/Windows/um/RadialControllerInterop/IRadialControllerConfigurationInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IRadialControllerConfigurationInterop" /> struct.</summary>
+    public static unsafe class IRadialControllerConfigurationInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IRadialControllerConfigurationInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IRadialControllerConfigurationInterop).GUID, Is.EqualTo(IID_IRadialControllerConfigurationInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerConfigurationInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IRadialControllerConfigurationInterop>(), Is.EqualTo(sizeof(IRadialControllerConfigurationInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerConfigurationInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IRadialControllerConfigurationInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerConfigurationInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IRadialControllerConfigurationInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IRadialControllerConfigurationInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/RadialControllerInterop/IRadialControllerIndependentInputSourceInteropTests.cs
+++ b/tests/Interop/Windows/um/RadialControllerInterop/IRadialControllerIndependentInputSourceInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IRadialControllerIndependentInputSourceInterop" /> struct.</summary>
+    public static unsafe class IRadialControllerIndependentInputSourceInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IRadialControllerIndependentInputSourceInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IRadialControllerIndependentInputSourceInterop).GUID, Is.EqualTo(IID_IRadialControllerIndependentInputSourceInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerIndependentInputSourceInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IRadialControllerIndependentInputSourceInterop>(), Is.EqualTo(sizeof(IRadialControllerIndependentInputSourceInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerIndependentInputSourceInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IRadialControllerIndependentInputSourceInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerIndependentInputSourceInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IRadialControllerIndependentInputSourceInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IRadialControllerIndependentInputSourceInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/RadialControllerInterop/IRadialControllerInteropTests.cs
+++ b/tests/Interop/Windows/um/RadialControllerInterop/IRadialControllerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RadialControllerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IRadialControllerInterop" /> struct.</summary>
+    public static unsafe class IRadialControllerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IRadialControllerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IRadialControllerInterop).GUID, Is.EqualTo(IID_IRadialControllerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IRadialControllerInterop>(), Is.EqualTo(sizeof(IRadialControllerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IRadialControllerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IRadialControllerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IRadialControllerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IRadialControllerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/RemoteSystemsInterop/ICorrelationVectorInformationTests.cs
+++ b/tests/Interop/Windows/um/RemoteSystemsInterop/ICorrelationVectorInformationTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/RemoteSystemsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="ICorrelationVectorInformation" /> struct.</summary>
+    public static unsafe class ICorrelationVectorInformationTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="ICorrelationVectorInformation" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(ICorrelationVectorInformation).GUID, Is.EqualTo(IID_ICorrelationVectorInformation));
+        }
+
+        /// <summary>Validates that the <see cref="ICorrelationVectorInformation" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<ICorrelationVectorInformation>(), Is.EqualTo(sizeof(ICorrelationVectorInformation)));
+        }
+
+        /// <summary>Validates that the <see cref="ICorrelationVectorInformation" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(ICorrelationVectorInformation).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="ICorrelationVectorInformation" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(ICorrelationVectorInformation), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(ICorrelationVectorInformation), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/SpatialInteractionManagerInterop/ISpatialInteractionManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/SpatialInteractionManagerInterop/ISpatialInteractionManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SpatialInteractionManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="ISpatialInteractionManagerInterop" /> struct.</summary>
+    public static unsafe class ISpatialInteractionManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="ISpatialInteractionManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(ISpatialInteractionManagerInterop).GUID, Is.EqualTo(IID_ISpatialInteractionManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="ISpatialInteractionManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<ISpatialInteractionManagerInterop>(), Is.EqualTo(sizeof(ISpatialInteractionManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="ISpatialInteractionManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(ISpatialInteractionManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="ISpatialInteractionManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(ISpatialInteractionManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(ISpatialInteractionManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/SystemMediaTransportControlsInterop/ISystemMediaTransportControlsInteropTests.cs
+++ b/tests/Interop/Windows/um/SystemMediaTransportControlsInterop/ISystemMediaTransportControlsInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/SystemMediaTransportControlsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="ISystemMediaTransportControlsInterop" /> struct.</summary>
+    public static unsafe class ISystemMediaTransportControlsInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="ISystemMediaTransportControlsInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(ISystemMediaTransportControlsInterop).GUID, Is.EqualTo(IID_ISystemMediaTransportControlsInterop));
+        }
+
+        /// <summary>Validates that the <see cref="ISystemMediaTransportControlsInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<ISystemMediaTransportControlsInterop>(), Is.EqualTo(sizeof(ISystemMediaTransportControlsInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="ISystemMediaTransportControlsInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(ISystemMediaTransportControlsInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="ISystemMediaTransportControlsInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(ISystemMediaTransportControlsInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(ISystemMediaTransportControlsInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/UIViewSettingsInterop/IUIViewSettingsInteropTests.cs
+++ b/tests/Interop/Windows/um/UIViewSettingsInterop/IUIViewSettingsInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UIViewSettingsInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IUIViewSettingsInterop" /> struct.</summary>
+    public static unsafe class IUIViewSettingsInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IUIViewSettingsInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IUIViewSettingsInterop).GUID, Is.EqualTo(IID_IUIViewSettingsInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IUIViewSettingsInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IUIViewSettingsInterop>(), Is.EqualTo(sizeof(IUIViewSettingsInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IUIViewSettingsInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IUIViewSettingsInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IUIViewSettingsInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IUIViewSettingsInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IUIViewSettingsInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/UserConsentVerifierInterop/IUserConsentVerifierInteropTests.cs
+++ b/tests/Interop/Windows/um/UserConsentVerifierInterop/IUserConsentVerifierInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/UserConsentVerifierInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IUserConsentVerifierInterop" /> struct.</summary>
+    public static unsafe class IUserConsentVerifierInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IUserConsentVerifierInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IUserConsentVerifierInterop).GUID, Is.EqualTo(IID_IUserConsentVerifierInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IUserConsentVerifierInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IUserConsentVerifierInterop>(), Is.EqualTo(sizeof(IUserConsentVerifierInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IUserConsentVerifierInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IUserConsentVerifierInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IUserConsentVerifierInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IUserConsentVerifierInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IUserConsentVerifierInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/WebAuthenticationCoreManagerInterop/IWebAuthenticationCoreManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/WebAuthenticationCoreManagerInterop/IWebAuthenticationCoreManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/WebAuthenticationCoreManagerInterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IWebAuthenticationCoreManagerInterop" /> struct.</summary>
+    public static unsafe class IWebAuthenticationCoreManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IWebAuthenticationCoreManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IWebAuthenticationCoreManagerInterop).GUID, Is.EqualTo(IID_IWebAuthenticationCoreManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IWebAuthenticationCoreManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IWebAuthenticationCoreManagerInterop>(), Is.EqualTo(sizeof(IWebAuthenticationCoreManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IWebAuthenticationCoreManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IWebAuthenticationCoreManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IWebAuthenticationCoreManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IWebAuthenticationCoreManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IWebAuthenticationCoreManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/Windows.Graphics.Capture.Interop/IGraphicsCaptureItemInteropTests.cs
+++ b/tests/Interop/Windows/um/Windows.Graphics.Capture.Interop/IGraphicsCaptureItemInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/Windows.Graphics.Capture.Interop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IGraphicsCaptureItemInterop" /> struct.</summary>
+    public static unsafe class IGraphicsCaptureItemInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IGraphicsCaptureItemInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IGraphicsCaptureItemInterop).GUID, Is.EqualTo(IID_IGraphicsCaptureItemInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IGraphicsCaptureItemInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IGraphicsCaptureItemInterop>(), Is.EqualTo(sizeof(IGraphicsCaptureItemInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IGraphicsCaptureItemInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IGraphicsCaptureItemInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IGraphicsCaptureItemInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IGraphicsCaptureItemInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IGraphicsCaptureItemInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/accountssettingspaneinterop/IAccountsSettingsPaneInteropTests.cs
+++ b/tests/Interop/Windows/um/accountssettingspaneinterop/IAccountsSettingsPaneInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/accountssettingspaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IAccountsSettingsPaneInterop" /> struct.</summary>
+    public static unsafe class IAccountsSettingsPaneInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IAccountsSettingsPaneInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IAccountsSettingsPaneInterop).GUID, Is.EqualTo(IID_IAccountsSettingsPaneInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IAccountsSettingsPaneInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IAccountsSettingsPaneInterop>(), Is.EqualTo(sizeof(IAccountsSettingsPaneInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IAccountsSettingsPaneInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IAccountsSettingsPaneInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IAccountsSettingsPaneInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IAccountsSettingsPaneInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IAccountsSettingsPaneInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/appserviceinterop/IAppServiceConnectionExtendedExecutionTests.cs
+++ b/tests/Interop/Windows/um/appserviceinterop/IAppServiceConnectionExtendedExecutionTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/appserviceinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IAppServiceConnectionExtendedExecution" /> struct.</summary>
+    public static unsafe class IAppServiceConnectionExtendedExecutionTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IAppServiceConnectionExtendedExecution" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IAppServiceConnectionExtendedExecution).GUID, Is.EqualTo(IID_IAppServiceConnectionExtendedExecution));
+        }
+
+        /// <summary>Validates that the <see cref="IAppServiceConnectionExtendedExecution" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IAppServiceConnectionExtendedExecution>(), Is.EqualTo(sizeof(IAppServiceConnectionExtendedExecution)));
+        }
+
+        /// <summary>Validates that the <see cref="IAppServiceConnectionExtendedExecution" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IAppServiceConnectionExtendedExecution).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IAppServiceConnectionExtendedExecution" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IAppServiceConnectionExtendedExecution), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IAppServiceConnectionExtendedExecution), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/appserviceinterop/ICorrelationVectorSourceTests.cs
+++ b/tests/Interop/Windows/um/appserviceinterop/ICorrelationVectorSourceTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/appserviceinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="ICorrelationVectorSource" /> struct.</summary>
+    public static unsafe class ICorrelationVectorSourceTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="ICorrelationVectorSource" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(ICorrelationVectorSource).GUID, Is.EqualTo(IID_ICorrelationVectorSource));
+        }
+
+        /// <summary>Validates that the <see cref="ICorrelationVectorSource" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<ICorrelationVectorSource>(), Is.EqualTo(sizeof(ICorrelationVectorSource)));
+        }
+
+        /// <summary>Validates that the <see cref="ICorrelationVectorSource" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(ICorrelationVectorSource).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="ICorrelationVectorSource" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(ICorrelationVectorSource), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(ICorrelationVectorSource), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/dragdropinterop/IDragDropManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/dragdropinterop/IDragDropManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/dragdropinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IDragDropManagerInterop" /> struct.</summary>
+    public static unsafe class IDragDropManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IDragDropManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IDragDropManagerInterop).GUID, Is.EqualTo(IID_IDragDropManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IDragDropManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IDragDropManagerInterop>(), Is.EqualTo(sizeof(IDragDropManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IDragDropManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IDragDropManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IDragDropManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IDragDropManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IDragDropManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop2Tests.cs
+++ b/tests/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop2Tests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IProtectionPolicyManagerInterop2" /> struct.</summary>
+    public static unsafe class IProtectionPolicyManagerInterop2Tests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IProtectionPolicyManagerInterop2" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IProtectionPolicyManagerInterop2).GUID, Is.EqualTo(IID_IProtectionPolicyManagerInterop2));
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop2" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IProtectionPolicyManagerInterop2>(), Is.EqualTo(sizeof(IProtectionPolicyManagerInterop2)));
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop2" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IProtectionPolicyManagerInterop2).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop2" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IProtectionPolicyManagerInterop2), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IProtectionPolicyManagerInterop2), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop3Tests.cs
+++ b/tests/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInterop3Tests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IProtectionPolicyManagerInterop3" /> struct.</summary>
+    public static unsafe class IProtectionPolicyManagerInterop3Tests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IProtectionPolicyManagerInterop3" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IProtectionPolicyManagerInterop3).GUID, Is.EqualTo(IID_IProtectionPolicyManagerInterop3));
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop3" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IProtectionPolicyManagerInterop3>(), Is.EqualTo(sizeof(IProtectionPolicyManagerInterop3)));
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop3" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IProtectionPolicyManagerInterop3).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop3" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IProtectionPolicyManagerInterop3), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IProtectionPolicyManagerInterop3), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/efswrtinterop/IProtectionPolicyManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/efswrtinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IProtectionPolicyManagerInterop" /> struct.</summary>
+    public static unsafe class IProtectionPolicyManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IProtectionPolicyManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IProtectionPolicyManagerInterop).GUID, Is.EqualTo(IID_IProtectionPolicyManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IProtectionPolicyManagerInterop>(), Is.EqualTo(sizeof(IProtectionPolicyManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IProtectionPolicyManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IProtectionPolicyManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IProtectionPolicyManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IProtectionPolicyManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/inputpaneinterop/IInputPaneInteropTests.cs
+++ b/tests/Interop/Windows/um/inputpaneinterop/IInputPaneInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/inputpaneinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IInputPaneInterop" /> struct.</summary>
+    public static unsafe class IInputPaneInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IInputPaneInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IInputPaneInterop).GUID, Is.EqualTo(IID_IInputPaneInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IInputPaneInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IInputPaneInterop>(), Is.EqualTo(sizeof(IInputPaneInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IInputPaneInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IInputPaneInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IInputPaneInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IInputPaneInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IInputPaneInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/remotesystemadditionalinfo/IRemoteSystemAdditionalInfoProviderTests.cs
+++ b/tests/Interop/Windows/um/remotesystemadditionalinfo/IRemoteSystemAdditionalInfoProviderTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/remotesystemadditionalinfo.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IRemoteSystemAdditionalInfoProvider" /> struct.</summary>
+    public static unsafe class IRemoteSystemAdditionalInfoProviderTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IRemoteSystemAdditionalInfoProvider" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IRemoteSystemAdditionalInfoProvider).GUID, Is.EqualTo(IID_IRemoteSystemAdditionalInfoProvider));
+        }
+
+        /// <summary>Validates that the <see cref="IRemoteSystemAdditionalInfoProvider" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IRemoteSystemAdditionalInfoProvider>(), Is.EqualTo(sizeof(IRemoteSystemAdditionalInfoProvider)));
+        }
+
+        /// <summary>Validates that the <see cref="IRemoteSystemAdditionalInfoProvider" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IRemoteSystemAdditionalInfoProvider).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IRemoteSystemAdditionalInfoProvider" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IRemoteSystemAdditionalInfoProvider), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IRemoteSystemAdditionalInfoProvider), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/useractivityinterop/IUserActivityInteropTests.cs
+++ b/tests/Interop/Windows/um/useractivityinterop/IUserActivityInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IUserActivityInterop" /> struct.</summary>
+    public static unsafe class IUserActivityInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IUserActivityInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IUserActivityInterop).GUID, Is.EqualTo(IID_IUserActivityInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivityInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IUserActivityInterop>(), Is.EqualTo(sizeof(IUserActivityInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivityInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IUserActivityInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivityInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IUserActivityInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IUserActivityInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/useractivityinterop/IUserActivityRequestManagerInteropTests.cs
+++ b/tests/Interop/Windows/um/useractivityinterop/IUserActivityRequestManagerInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IUserActivityRequestManagerInterop" /> struct.</summary>
+    public static unsafe class IUserActivityRequestManagerInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IUserActivityRequestManagerInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IUserActivityRequestManagerInterop).GUID, Is.EqualTo(IID_IUserActivityRequestManagerInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivityRequestManagerInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IUserActivityRequestManagerInterop>(), Is.EqualTo(sizeof(IUserActivityRequestManagerInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivityRequestManagerInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IUserActivityRequestManagerInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivityRequestManagerInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IUserActivityRequestManagerInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IUserActivityRequestManagerInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/useractivityinterop/IUserActivitySourceHostInteropTests.cs
+++ b/tests/Interop/Windows/um/useractivityinterop/IUserActivitySourceHostInteropTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/useractivityinterop.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IUserActivitySourceHostInterop" /> struct.</summary>
+    public static unsafe class IUserActivitySourceHostInteropTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IUserActivitySourceHostInterop" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IUserActivitySourceHostInterop).GUID, Is.EqualTo(IID_IUserActivitySourceHostInterop));
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivitySourceHostInterop" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IUserActivitySourceHostInterop>(), Is.EqualTo(sizeof(IUserActivitySourceHostInterop)));
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivitySourceHostInterop" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IUserActivitySourceHostInterop).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IUserActivitySourceHostInterop" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IUserActivitySourceHostInterop), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IUserActivitySourceHostInterop), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNative2Tests.cs
+++ b/tests/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNative2Tests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/windows.ui.xaml.hosting.desktopwindowxamlsource.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IDesktopWindowXamlSourceNative2" /> struct.</summary>
+    public static unsafe class IDesktopWindowXamlSourceNative2Tests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IDesktopWindowXamlSourceNative2" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IDesktopWindowXamlSourceNative2).GUID, Is.EqualTo(IID_IDesktopWindowXamlSourceNative2));
+        }
+
+        /// <summary>Validates that the <see cref="IDesktopWindowXamlSourceNative2" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IDesktopWindowXamlSourceNative2>(), Is.EqualTo(sizeof(IDesktopWindowXamlSourceNative2)));
+        }
+
+        /// <summary>Validates that the <see cref="IDesktopWindowXamlSourceNative2" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IDesktopWindowXamlSourceNative2).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IDesktopWindowXamlSourceNative2" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IDesktopWindowXamlSourceNative2), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IDesktopWindowXamlSourceNative2), Is.EqualTo(4));
+            }
+        }
+    }
+}

--- a/tests/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNativeTests.cs
+++ b/tests/Interop/Windows/um/windows.ui.xaml.hosting.desktopwindowxamlsource/IDesktopWindowXamlSourceNativeTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/windows.ui.xaml.hosting.desktopwindowxamlsource.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.UnitTests
+{
+    /// <summary>Provides validation of the <see cref="IDesktopWindowXamlSourceNative" /> struct.</summary>
+    public static unsafe class IDesktopWindowXamlSourceNativeTests
+    {
+        /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IDesktopWindowXamlSourceNative" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(IDesktopWindowXamlSourceNative).GUID, Is.EqualTo(IID_IDesktopWindowXamlSourceNative));
+        }
+
+        /// <summary>Validates that the <see cref="IDesktopWindowXamlSourceNative" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<IDesktopWindowXamlSourceNative>(), Is.EqualTo(sizeof(IDesktopWindowXamlSourceNative)));
+        }
+
+        /// <summary>Validates that the <see cref="IDesktopWindowXamlSourceNative" /> struct has the right <see cref="LayoutKind" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(IDesktopWindowXamlSourceNative).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref="IDesktopWindowXamlSourceNative" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.That(sizeof(IDesktopWindowXamlSourceNative), Is.EqualTo(8));
+            }
+            else
+            {
+                Assert.That(sizeof(IDesktopWindowXamlSourceNative), Is.EqualTo(4));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds bindings for 20 headers which extend the functionality of various Windows Runtime types in the SDK. Most of these headers define only one COM interface, and a majority of those interfaces only define one function. Each header has been added in a separate commit to help ease code review.