### PR TITLE
Fix library paths for some libraries

### DIFF
--- a/generation/um/windows.data.pdf.interop/generate.rsp
+++ b/generation/um/windows.data.pdf.interop/generate.rsp
@@ -11,4 +11,4 @@ um-windows.data.pdf.interop.h
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/windows.data.pdf.interop.h
 --with-librarypath
-*=Windows.Data.Pdf
+*=Windows.Data.Pdf.dll

--- a/generation/um/xapofx/generate.rsp
+++ b/generation/um/xapofx/generate.rsp
@@ -16,4 +16,4 @@ um-xapofx.h
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xapofx.h
 --with-librarypath
-*=Windows.Media.Audio
+*=Windows.Media.Audio.dll

--- a/generation/um/xaudio2fx/generate.rsp
+++ b/generation/um/xaudio2fx/generate.rsp
@@ -16,4 +16,4 @@ um-xaudio2fx.h
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um/xaudio2fx.h
 --with-librarypath
-*=Windows.Media.Audio
+*=Windows.Media.Audio.dll

--- a/generation/winrt/CoreWindow/generate.rsp
+++ b/generation/winrt/CoreWindow/generate.rsp
@@ -9,4 +9,4 @@ winrt-CoreWindow.h
 --traverse
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/winrt/CoreWindow.h
 --with-librarypath
-*=Windows.UI
+*=Windows.UI.dll

--- a/sources/Interop/Windows/um/windows.data.pdf.interop/Windows.cs
+++ b/sources/Interop/Windows/um/windows.data.pdf.interop/Windows.cs
@@ -10,7 +10,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        [DllImport("Windows.Data.Pdf", ExactSpelling = true)]
+        [DllImport("Windows.Data.Pdf.dll", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int PdfCreateRenderer([NativeTypeName("IDXGIDevice *")] IDXGIDevice* pDevice, [NativeTypeName("IPdfRendererNative **")] IPdfRendererNative** ppRenderer);
 

--- a/sources/Interop/Windows/um/xapofx/Windows.cs
+++ b/sources/Interop/Windows/um/xapofx/Windows.cs
@@ -10,7 +10,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        [DllImport("Windows.Media.Audio", ExactSpelling = true)]
+        [DllImport("Windows.Media.Audio.dll", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int CreateFX([NativeTypeName("const IID &")] Guid* clsid, [NativeTypeName("IUnknown **")] IUnknown** pEffect, [NativeTypeName("const void *")] void* pInitDat = null, [NativeTypeName("UINT32")] uint InitDataByteSize = 0);
 

--- a/sources/Interop/Windows/um/xaudio2fx/Windows.cs
+++ b/sources/Interop/Windows/um/xaudio2fx/Windows.cs
@@ -10,11 +10,11 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        [DllImport("Windows.Media.Audio", ExactSpelling = true)]
+        [DllImport("Windows.Media.Audio.dll", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int CreateAudioVolumeMeter([NativeTypeName("IUnknown **")] IUnknown** ppApo);
 
-        [DllImport("Windows.Media.Audio", ExactSpelling = true)]
+        [DllImport("Windows.Media.Audio.dll", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int CreateAudioReverb([NativeTypeName("IUnknown **")] IUnknown** ppApo);
 

--- a/sources/Interop/Windows/winrt/CoreWindow/Windows.cs
+++ b/sources/Interop/Windows/winrt/CoreWindow/Windows.cs
@@ -10,11 +10,11 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        [DllImport("Windows.UI", ExactSpelling = true)]
+        [DllImport("Windows.UI.dll", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int CreateControlInput([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv);
 
-        [DllImport("Windows.UI", ExactSpelling = true)]
+        [DllImport("Windows.UI.dll", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int CreateControlInputEx([NativeTypeName("IUnknown *")] IUnknown* pCoreWindow, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppv);
 


### PR DESCRIPTION
The probing algorithm used by the .NET runtime would not append `.dll` to these library paths, since they already contain a `.`. To work around this, the `.dll` extension must be manually added.