### PR TITLE
Port windows.foundation.collections.h

### DIFF
--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncActionProgressHandler`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncActionProgressHandler`1.Manual.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("6D844858-0CFF-4590-AE89-95A5A5C8B4B8")]
+    public unsafe partial struct IAsyncActionProgressHandler<TProgress>
+        where TProgress : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncActionProgressHandler<TProgress>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncActionProgressHandler<TProgress>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncActionProgressHandler<TProgress>*, uint>)(lpVtbl[1]))((IAsyncActionProgressHandler<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncActionProgressHandler<TProgress>*, uint>)(lpVtbl[2]))((IAsyncActionProgressHandler<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IAsyncActionWithProgress<TProgress_logical> *")] IAsyncActionWithProgress<TProgress>* asyncInfo, [NativeTypeName("TProgress_abi")] TProgress progressInfo)
+        {
+            return ((delegate* unmanaged<IAsyncActionProgressHandler<TProgress>*, IAsyncActionWithProgress<TProgress>*, TProgress, int>)(lpVtbl[3]))((IAsyncActionProgressHandler<TProgress>*)Unsafe.AsPointer(ref this), asyncInfo, progressInfo);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncActionWithProgressCompletedHandler`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncActionWithProgressCompletedHandler`1.Manual.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("9C029F91-CC84-44FD-AC26-0A6C4E555281")]
+    public unsafe partial struct IAsyncActionWithProgressCompletedHandler<TProgress>
+        where TProgress : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgressCompletedHandler<TProgress>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncActionWithProgressCompletedHandler<TProgress>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgressCompletedHandler<TProgress>*, uint>)(lpVtbl[1]))((IAsyncActionWithProgressCompletedHandler<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgressCompletedHandler<TProgress>*, uint>)(lpVtbl[2]))((IAsyncActionWithProgressCompletedHandler<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IAsyncActionWithProgress<TProgress_logical> *")] IAsyncActionWithProgress<TProgress>* asyncInfo, [NativeTypeName("Windows::Foundation::AsyncStatus")] AsyncStatus status)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgressCompletedHandler<TProgress>*, IAsyncActionWithProgress<TProgress>*, AsyncStatus, int>)(lpVtbl[3]))((IAsyncActionWithProgressCompletedHandler<TProgress>*)Unsafe.AsPointer(ref this), asyncInfo, status);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncActionWithProgress`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncActionWithProgress`1.Manual.cs
@@ -1,0 +1,95 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("1F6DB258-E803-48A1-9546-EB7353398884")]
+    public unsafe partial struct IAsyncActionWithProgress<TProgress>
+        where TProgress : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, uint>)(lpVtbl[1]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, uint>)(lpVtbl[2]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, uint*, Guid**, int>)(lpVtbl[3]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, IntPtr*, int>)(lpVtbl[4]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, TrustLevel*, int>)(lpVtbl[5]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int put_Progress([NativeTypeName("IAsyncActionWithProgressCompletedHandler<TProgress_logical> *")] IAsyncActionWithProgressCompletedHandler<TProgress>* handler)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, IAsyncActionWithProgressCompletedHandler<TProgress>*, int>)(lpVtbl[6]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Progress([NativeTypeName("IAsyncActionWithProgressCompletedHandler<TProgress_logical> **")] IAsyncActionWithProgressCompletedHandler<TProgress>** handler)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, IAsyncActionWithProgressCompletedHandler<TProgress>**, int>)(lpVtbl[7]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int put_Completed([NativeTypeName("IAsyncActionWithProgressCompletedHandler<TProgress_logical> *")] IAsyncActionWithProgressCompletedHandler<TProgress>* handler)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, IAsyncActionWithProgressCompletedHandler<TProgress>*, int>)(lpVtbl[8]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Completed([NativeTypeName("IAsyncActionWithProgressCompletedHandler<TProgress_logical> **")] IAsyncActionWithProgressCompletedHandler<TProgress>** handler)
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, IAsyncActionWithProgressCompletedHandler<TProgress>**, int>)(lpVtbl[9]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetResults()
+        {
+            return ((delegate* unmanaged<IAsyncActionWithProgress<TProgress>*, int>)(lpVtbl[10]))((IAsyncActionWithProgress<TProgress>*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationCompletedHandler`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationCompletedHandler`1.Manual.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("FCDCF02C-E5D8-4478-915A-4D90B74B83A5")]
+    public unsafe partial struct IAsyncOperationCompletedHandler<TResult>
+        where TResult : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncOperationCompletedHandler<TResult>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncOperationCompletedHandler<TResult>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncOperationCompletedHandler<TResult>*, uint>)(lpVtbl[1]))((IAsyncOperationCompletedHandler<TResult>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncOperationCompletedHandler<TResult>*, uint>)(lpVtbl[2]))((IAsyncOperationCompletedHandler<TResult>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IAsyncOperation<TResult_logical> *")] IAsyncOperation<TResult>* asyncInfo, [NativeTypeName("Windows::Foundation::AsyncStatus")] AsyncStatus status)
+        {
+            return ((delegate* unmanaged<IAsyncOperationCompletedHandler<TResult>*, IAsyncOperation<TResult>*, AsyncStatus, int>)(lpVtbl[3]))((IAsyncOperationCompletedHandler<TResult>*)Unsafe.AsPointer(ref this), asyncInfo, status);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationProgressHandler`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationProgressHandler`2.Manual.cs
@@ -1,0 +1,47 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("55690902-0AAB-421A-8778-F8CE5026D758")]
+    public unsafe partial struct IAsyncOperationProgressHandler<TResult, TProgress>
+        where TResult : unmanaged
+        where TProgress : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncOperationProgressHandler<TResult, TProgress>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncOperationProgressHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncOperationProgressHandler<TResult, TProgress>*, uint>)(lpVtbl[1]))((IAsyncOperationProgressHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncOperationProgressHandler<TResult, TProgress>*, uint>)(lpVtbl[2]))((IAsyncOperationProgressHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IAsyncOperationWithProgress<TResult_logical, TProgress_logical> *")] IAsyncOperationWithProgress<TResult, TProgress>* asyncInfo, [NativeTypeName("TProgress_abi")] TProgress progressInfo)
+        {
+            return ((delegate* unmanaged<IAsyncOperationProgressHandler<TResult, TProgress>*, IAsyncOperationWithProgress<TResult, TProgress>*, TProgress, int>)(lpVtbl[3]))((IAsyncOperationProgressHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this), asyncInfo, progressInfo);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationWithProgressCompletedHandler`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationWithProgressCompletedHandler`2.Manual.cs
@@ -1,0 +1,47 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("E85DF41D-6AA7-46E3-A8E2-F009D840C627")]
+    public unsafe partial struct IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>
+        where TResult : unmanaged
+        where TProgress : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*, uint>)(lpVtbl[1]))((IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*, uint>)(lpVtbl[2]))((IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IAsyncOperationWithProgress<TResult_logical, TProgress_logical> *")] IAsyncOperationWithProgress<TResult, TProgress>* asyncInfo, [NativeTypeName("Windows::Foundation::AsyncStatus")] AsyncStatus status)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*, IAsyncOperationWithProgress<TResult, TProgress>*, AsyncStatus, int>)(lpVtbl[3]))((IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*)Unsafe.AsPointer(ref this), asyncInfo, status);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationWithProgress`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperationWithProgress`2.Manual.cs
@@ -1,0 +1,96 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("B5D036D7-E297-498F-BA60-0289E76E23DD")]
+    public unsafe partial struct IAsyncOperationWithProgress<TResult, TProgress>
+        where TResult : unmanaged
+        where TProgress : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, uint>)(lpVtbl[1]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, uint>)(lpVtbl[2]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, uint*, Guid**, int>)(lpVtbl[3]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, IntPtr*, int>)(lpVtbl[4]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, TrustLevel*, int>)(lpVtbl[5]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int put_Progress([NativeTypeName("IAsyncOperationProgressHandler<TResult_logical, TProgress_logical> *")] IAsyncOperationProgressHandler<TResult, TProgress>* handler)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, IAsyncOperationProgressHandler<TResult, TProgress>*, int>)(lpVtbl[6]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Progress([NativeTypeName("IAsyncOperationProgressHandler<TResult_logical, TProgress_logical> **")] IAsyncOperationProgressHandler<TResult, TProgress>** handler)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, IAsyncOperationProgressHandler<TResult, TProgress>**, int>)(lpVtbl[7]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int put_Completed([NativeTypeName("IAsyncOperationWithProgressCompletedHandler<TResult_logical, TProgress_logical> *")] IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>* handler)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>*, int>)(lpVtbl[8]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Completed([NativeTypeName("IAsyncOperationWithProgressCompletedHandler<TResult_logical, TProgress_logical> **")] IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>** handler)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, IAsyncOperationWithProgressCompletedHandler<TResult, TProgress>**, int>)(lpVtbl[9]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetResults([NativeTypeName("TResult_abi *")] TResult* results)
+        {
+            return ((delegate* unmanaged<IAsyncOperationWithProgress<TResult, TProgress>*, TResult*, int>)(lpVtbl[10]))((IAsyncOperationWithProgress<TResult, TProgress>*)Unsafe.AsPointer(ref this), results);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperation`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IAsyncOperation`1.Manual.cs
@@ -1,0 +1,81 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("9FC2B0BB-E446-44E2-AA61-9CAB8F636AF2")]
+    public unsafe partial struct IAsyncOperation<TResult>
+        where TResult : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, Guid*, void**, int>)(lpVtbl[0]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, uint>)(lpVtbl[1]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, uint>)(lpVtbl[2]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, uint*, Guid**, int>)(lpVtbl[3]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, IntPtr*, int>)(lpVtbl[4]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, TrustLevel*, int>)(lpVtbl[5]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int put_Completed([NativeTypeName("IAsyncOperationCompletedHandler<TResult_logical> *")] IAsyncOperationCompletedHandler<TResult>* handler)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, IAsyncOperationCompletedHandler<TResult>*, int>)(lpVtbl[6]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Completed([NativeTypeName("IAsyncOperationCompletedHandler<TResult_logical> **")] IAsyncOperationCompletedHandler<TResult>** handler)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, IAsyncOperationCompletedHandler<TResult>**, int>)(lpVtbl[7]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), handler);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetResults([NativeTypeName("TResult_abi *")] TResult* results)
+        {
+            return ((delegate* unmanaged<IAsyncOperation<TResult>*, TResult*, int>)(lpVtbl[8]))((IAsyncOperation<TResult>*)Unsafe.AsPointer(ref this), results);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IEventHandler`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IEventHandler`1.Manual.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("9DE1C535-6AE1-11E0-84E1-18A905BCC53F")]
+    public unsafe partial struct IEventHandler<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IEventHandler<T>*, Guid*, void**, int>)(lpVtbl[0]))((IEventHandler<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IEventHandler<T>*, uint>)(lpVtbl[1]))((IEventHandler<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IEventHandler<T>*, uint>)(lpVtbl[2]))((IEventHandler<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IInspectable *")] IInspectable* sender, [NativeTypeName("T_abi")] T args)
+        {
+            return ((delegate* unmanaged<IEventHandler<T>*, IInspectable*, T, int>)(lpVtbl[3]))((IEventHandler<T>*)Unsafe.AsPointer(ref this), sender, args);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IIterator`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IIterator`1.Manual.cs
@@ -1,0 +1,88 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]
+    public unsafe partial struct IIterator<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, Guid*, void**, int>)(lpVtbl[0]))((IIterator<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IIterator<T>*, uint>)(lpVtbl[1]))((IIterator<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IIterator<T>*, uint>)(lpVtbl[2]))((IIterator<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, uint*, Guid**, int>)(lpVtbl[3]))((IIterator<T>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, IntPtr*, int>)(lpVtbl[4]))((IIterator<T>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, TrustLevel*, int>)(lpVtbl[5]))((IIterator<T>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Current([NativeTypeName("T_abi *")] T* current)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, T*, int>)(lpVtbl[6]))((IIterator<T>*)Unsafe.AsPointer(ref this), current);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_HasCurrent([NativeTypeName("boolean *")] byte* hasCurrent)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, byte*, int>)(lpVtbl[7]))((IIterator<T>*)Unsafe.AsPointer(ref this), hasCurrent);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int MoveNext([NativeTypeName("boolean *")] byte* hasCurrent)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, byte*, int>)(lpVtbl[8]))((IIterator<T>*)Unsafe.AsPointer(ref this), hasCurrent);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetMany([NativeTypeName("unsigned")] uint capacity, [NativeTypeName("T_abi *")] T* value, [NativeTypeName("unsigned *")] uint* actual)
+        {
+            return ((delegate* unmanaged<IIterator<T>*, uint, T*, uint*, int>)(lpVtbl[9]))((IIterator<T>*)Unsafe.AsPointer(ref this), capacity, value, actual);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IKeyValuePair`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IKeyValuePair`2.Manual.cs
@@ -1,0 +1,75 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("02B51929-C1C4-4A7E-8940-0312B5C18500")]
+    public unsafe partial struct IKeyValuePair<K, V>
+        where K : unmanaged
+        where V : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, Guid*, void**, int>)(lpVtbl[0]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, uint>)(lpVtbl[1]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, uint>)(lpVtbl[2]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, uint*, Guid**, int>)(lpVtbl[3]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, IntPtr*, int>)(lpVtbl[4]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, TrustLevel*, int>)(lpVtbl[5]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Key([NativeTypeName("K_abi *")] K* key)
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, K*, int>)(lpVtbl[6]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this), key);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Value([NativeTypeName("V_abi *")] V* value)
+        {
+            return ((delegate* unmanaged<IKeyValuePair<K, V>*, V*, int>)(lpVtbl[7]))((IKeyValuePair<K, V>*)Unsafe.AsPointer(ref this), value);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IMapChangedEventArgs`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IMapChangedEventArgs`1.Manual.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("9939F4DF-050A-4C0F-AA60-77075F9C4777")]
+    public unsafe partial struct IMapChangedEventArgs<K>
+        where K : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, Guid*, void**, int>)(lpVtbl[0]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, uint>)(lpVtbl[1]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, uint>)(lpVtbl[2]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, uint*, Guid**, int>)(lpVtbl[3]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, IntPtr*, int>)(lpVtbl[4]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, TrustLevel*, int>)(lpVtbl[5]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_CollectionChange([NativeTypeName("CollectionChange *")] CollectionChange* value)
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, CollectionChange*, int>)(lpVtbl[6]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this), value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Key([NativeTypeName("K_abi *")] K* value)
+        {
+            return ((delegate* unmanaged<IMapChangedEventArgs<K>*, K*, int>)(lpVtbl[7]))((IMapChangedEventArgs<K>*)Unsafe.AsPointer(ref this), value);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IMapView`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IMapView`2.Manual.cs
@@ -1,0 +1,89 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("E480CE40-A338-4ADA-ADCF-272272E48CB9")]
+    public unsafe partial struct IMapView<K, V>
+        where K : unmanaged
+        where V : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, Guid*, void**, int>)(lpVtbl[0]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, uint>)(lpVtbl[1]))((IMapView<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, uint>)(lpVtbl[2]))((IMapView<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, uint*, Guid**, int>)(lpVtbl[3]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, IntPtr*, int>)(lpVtbl[4]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, TrustLevel*, int>)(lpVtbl[5]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Lookup([NativeTypeName("K_abi")] K key, [NativeTypeName("V_abi *")] V* value)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, K, V*, int>)(lpVtbl[6]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), key, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Size([NativeTypeName("unsigned int *")] uint* size)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, uint*, int>)(lpVtbl[7]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int HasKey([NativeTypeName("T_abi")] K key, [NativeTypeName("boolean *")] byte* found)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, K, byte*, int>)(lpVtbl[8]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), key, found);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Split([NativeTypeName("IMapView<K_logical, V_logical> **")] IMapView<K, V>** firstPartition, [NativeTypeName("IMapView<K_logical, V_logical> **")] IMapView<K, V>** secondPartition)
+        {
+            return ((delegate* unmanaged<IMapView<K, V>*, IMapView<K, V>**, IMapView<K, V>**, int>)(lpVtbl[9]))((IMapView<K, V>*)Unsafe.AsPointer(ref this), firstPartition, secondPartition);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IMap`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IMap`2.Manual.cs
@@ -1,0 +1,111 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
+    public unsafe partial struct IMap<K ,V>
+        where K : unmanaged
+        where V : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, Guid*, void**, int>)(lpVtbl[0]))((IMap<K, V>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, uint>)(lpVtbl[1]))((IMap<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, uint>)(lpVtbl[2]))((IMap<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, uint*, Guid**, int>)(lpVtbl[3]))((IMap<K, V>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, IntPtr*, int>)(lpVtbl[4]))((IMap<K, V>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, TrustLevel*, int>)(lpVtbl[5]))((IMap<K, V>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Lookup([NativeTypeName("K_abi")] K key, [NativeTypeName("V_abi *")] V* value)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, K, V*, int>)(lpVtbl[6]))((IMap<K, V>*)Unsafe.AsPointer(ref this), key, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Size([NativeTypeName("unsigned int *")] uint* size)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, uint*, int>)(lpVtbl[7]))((IMap<K, V>*)Unsafe.AsPointer(ref this), size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int HasKey([NativeTypeName("T_abi")] K key, [NativeTypeName("boolean *")] byte* found)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, K, byte*, int>)(lpVtbl[8]))((IMap<K, V>*)Unsafe.AsPointer(ref this), key, found);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetView([NativeTypeName("IMapView<K_logical, V_logical> **")] IMapView<K, V>** view)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, IMapView<K, V>**, int>)(lpVtbl[9]))((IMap<K, V>*)Unsafe.AsPointer(ref this), view);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Insert([NativeTypeName("unsigned int *")] uint* size)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, uint*, int>)(lpVtbl[10]))((IMap<K, V>*)Unsafe.AsPointer(ref this), size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Remove([NativeTypeName("K_abi")] K key, [NativeTypeName("V_abi")] V value, [NativeTypeName("boolean *")] byte* replaced)
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, K, V, byte*, int>)(lpVtbl[11]))((IMap<K, V>*)Unsafe.AsPointer(ref this), key, value, replaced);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Clear()
+        {
+            return ((delegate* unmanaged<IMap<K, V>*, int>)(lpVtbl[12]))((IMap<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IObservableMap`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IObservableMap`2.Manual.cs
@@ -1,0 +1,75 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("65DF2BF5-BF39-41B5-AEBC-5A9D865E472B")]
+    public unsafe partial struct IObservableMap<K, V>
+        where K : unmanaged
+        where V : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, Guid*, void**, int>)(lpVtbl[0]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, uint>)(lpVtbl[1]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, uint>)(lpVtbl[2]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, uint*, Guid**, int>)(lpVtbl[3]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, IntPtr*, int>)(lpVtbl[4]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, TrustLevel*, int>)(lpVtbl[5]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int add_MapChanged([NativeTypeName("MapChangedEventHandler<K_logical, V_logical> *")] MapChangedEventHandler<K, V>* handler, [NativeTypeName("EventRegistrationToken *")] EventRegistrationToken* token)
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, MapChangedEventHandler<K, V>*, EventRegistrationToken*, int>)(lpVtbl[6]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this), handler, token);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int remove_MapChanged(EventRegistrationToken token)
+        {
+            return ((delegate* unmanaged<IObservableMap<K, V>*, EventRegistrationToken, int>)(lpVtbl[7]))((IObservableMap<K, V>*)Unsafe.AsPointer(ref this), token);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IObservableVector`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IObservableVector`1.Manual.cs
@@ -1,0 +1,74 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("5917EB53-50B4-4A0D-B309-65862B3F1DBC")]
+    public unsafe partial struct IObservableVector<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, Guid*, void**, int>)(lpVtbl[0]))((IObservableVector<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, uint>)(lpVtbl[1]))((IObservableVector<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, uint>)(lpVtbl[2]))((IObservableVector<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, uint*, Guid**, int>)(lpVtbl[3]))((IObservableVector<T>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, IntPtr*, int>)(lpVtbl[4]))((IObservableVector<T>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, TrustLevel*, int>)(lpVtbl[5]))((IObservableVector<T>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int add_VectorChanged([NativeTypeName("VectorChangedEventHandler<T_logical> *")] VectorChangedEventHandler<T>* handler, [NativeTypeName("EventRegistrationToken *")] EventRegistrationToken* token)
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, VectorChangedEventHandler<T>*, EventRegistrationToken*, int>)(lpVtbl[6]))((IObservableVector<T>*)Unsafe.AsPointer(ref this), handler, token);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int remove_VectorChanged(EventRegistrationToken token)
+        {
+            return ((delegate* unmanaged<IObservableVector<T>*, EventRegistrationToken, int>)(lpVtbl[7]))((IObservableVector<T>*)Unsafe.AsPointer(ref this), token);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IReferenceArray`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IReferenceArray`1.Manual.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("61C17706-2D65-11E0-9AE8-D48564015472")]
+    public unsafe partial struct IReferenceArray<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, Guid*, void**, int>)(lpVtbl[0]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, uint>)(lpVtbl[1]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, uint>)(lpVtbl[2]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, uint*, Guid**, int>)(lpVtbl[3]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, IntPtr*, int>)(lpVtbl[4]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, TrustLevel*, int>)(lpVtbl[5]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Value([NativeTypeName("UINT32 *")] uint* length, [NativeTypeName("T_abi **")] T** value)
+        {
+            return ((delegate* unmanaged<IReferenceArray<T>*, uint*, T**, int>)(lpVtbl[6]))((IReferenceArray<T>*)Unsafe.AsPointer(ref this), length, value);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IReference`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IReference`1.Manual.cs
@@ -1,0 +1,67 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("61C17706-2D65-11E0-9AE8-D48564015472")]
+    public unsafe partial struct IReference<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IReference<T>*, Guid*, void**, int>)(lpVtbl[0]))((IReference<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IReference<T>*, uint>)(lpVtbl[1]))((IReference<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IReference<T>*, uint>)(lpVtbl[2]))((IReference<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IReference<T>*, uint*, Guid**, int>)(lpVtbl[3]))((IReference<T>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IReference<T>*, IntPtr*, int>)(lpVtbl[4]))((IReference<T>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IReference<T>*, TrustLevel*, int>)(lpVtbl[5]))((IReference<T>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Value([NativeTypeName("T_abi *")] T* value)
+        {
+            return ((delegate* unmanaged<IReference<T>*, T*, int>)(lpVtbl[6]))((IReference<T>*)Unsafe.AsPointer(ref this), value);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/ITypedEventHandler`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/ITypedEventHandler`2.Manual.cs
@@ -1,0 +1,47 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("9DE1C534-6AE1-11E0-84E1-18A905BCC53F")]
+    public unsafe partial struct ITypedEventHandler<TSender, TArgs>
+        where TSender : unmanaged
+        where TArgs : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<ITypedEventHandler<TSender, TArgs>*, Guid*, void**, int>)(lpVtbl[0]))((ITypedEventHandler<TSender, TArgs>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<ITypedEventHandler<TSender, TArgs>*, uint>)(lpVtbl[1]))((ITypedEventHandler<TSender, TArgs>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<ITypedEventHandler<TSender, TArgs>*, uint>)(lpVtbl[2]))((ITypedEventHandler<TSender, TArgs>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("TSender_abi")] TSender sender, [NativeTypeName("TArgs_abi")] TArgs args)
+        {
+            return ((delegate* unmanaged<ITypedEventHandler<TSender, TArgs>*, TSender, TArgs, int>)(lpVtbl[3]))((ITypedEventHandler<TSender, TArgs>*)Unsafe.AsPointer(ref this), sender, args);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IVectorView`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IVectorView`1.Manual.cs
@@ -1,0 +1,88 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")]
+    public unsafe partial struct IVectorView<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, Guid*, void**, int>)(lpVtbl[0]))((IVectorView<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, uint>)(lpVtbl[1]))((IVectorView<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, uint>)(lpVtbl[2]))((IVectorView<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, uint*, Guid**, int>)(lpVtbl[3]))((IVectorView<T>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, IntPtr*, int>)(lpVtbl[4]))((IVectorView<T>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, TrustLevel*, int>)(lpVtbl[5]))((IVectorView<T>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetAt([NativeTypeName("unsigned")] uint index, [NativeTypeName("T_abi *")] T* item)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, uint, T*, int>)(lpVtbl[6]))((IVectorView<T>*)Unsafe.AsPointer(ref this), index, item);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Size([NativeTypeName("unsigned *")] uint* size)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, uint*, int>)(lpVtbl[7]))((IVectorView<T>*)Unsafe.AsPointer(ref this), size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int IndexOf([NativeTypeName("T_abi")] T value, [NativeTypeName("unsigned *")] uint* index, [NativeTypeName("boolean *")] byte* found)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, T, uint*, byte*, int>)(lpVtbl[8]))((IVectorView<T>*)Unsafe.AsPointer(ref this), value, index, found);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetMany([NativeTypeName("unsigned")] uint startIndex, [NativeTypeName("unsigned")] uint capacity, [NativeTypeName("T_abi *")] T* value, [NativeTypeName("unsigned *")] uint* actual)
+        {
+            return ((delegate* unmanaged<IVectorView<T>*, uint, uint, T*, uint*, int>)(lpVtbl[9]))((IVectorView<T>*)Unsafe.AsPointer(ref this), startIndex, capacity, value, actual);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/IVector`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/IVector`1.Manual.cs
@@ -1,0 +1,144 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("913337E9-11A1-4345-A3A2-4E7F956E222D")]
+    public unsafe partial struct IVector<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<IVector<T>*, Guid*, void**, int>)(lpVtbl[0]))((IVector<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint>)(lpVtbl[1]))((IVector<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint>)(lpVtbl[2]))((IVector<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetIids([NativeTypeName("ULONG *")] uint* iidCount, [NativeTypeName("IID **")] Guid** iids)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint*, Guid**, int>)(lpVtbl[3]))((IVector<T>*)Unsafe.AsPointer(ref this), iidCount, iids);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetRuntimeClassName([NativeTypeName("HSTRING *")] IntPtr* className)
+        {
+            return ((delegate* unmanaged<IVector<T>*, IntPtr*, int>)(lpVtbl[4]))((IVector<T>*)Unsafe.AsPointer(ref this), className);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetTrustLevel([NativeTypeName("TrustLevel *")] TrustLevel* trustLevel)
+        {
+            return ((delegate* unmanaged<IVector<T>*, TrustLevel*, int>)(lpVtbl[5]))((IVector<T>*)Unsafe.AsPointer(ref this), trustLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetAt([NativeTypeName("unsigned")] uint index, [NativeTypeName("T_abi *")] T* item)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint, T*, int>)(lpVtbl[6]))((IVector<T>*)Unsafe.AsPointer(ref this), index, item);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int get_Size([NativeTypeName("unsigned *")] uint* size)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint*, int>)(lpVtbl[7]))((IVector<T>*)Unsafe.AsPointer(ref this), size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetView([NativeTypeName("IVectorView<T_logical> **")] IVectorView<T>** view)
+        {
+            return ((delegate* unmanaged<IVector<T>*, IVectorView<T>**, int>)(lpVtbl[8]))((IVector<T>*)Unsafe.AsPointer(ref this), view);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int IndexOf([NativeTypeName("T_abi")] T value, [NativeTypeName("unsigned *")] uint* index, [NativeTypeName("boolean *")] byte* found)
+        {
+            return ((delegate* unmanaged<IVector<T>*, T, uint*, byte*, int>)(lpVtbl[9]))((IVector<T>*)Unsafe.AsPointer(ref this), value, index, found);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int SetAt([NativeTypeName("unsigned")] uint index, [NativeTypeName("T_abi")] T item)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint, T, int>)(lpVtbl[10]))((IVector<T>*)Unsafe.AsPointer(ref this), index, item);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int InsertAt([NativeTypeName("unsigned")] uint index, [NativeTypeName("T_abi")] T item)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint, T, int>)(lpVtbl[11]))((IVector<T>*)Unsafe.AsPointer(ref this), index, item);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RemoveAt([NativeTypeName("unsigned")] uint index)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint, int>)(lpVtbl[12]))((IVector<T>*)Unsafe.AsPointer(ref this), index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Append([NativeTypeName("T_abi")] T item)
+        {
+            return ((delegate* unmanaged<IVector<T>*, T, int>)(lpVtbl[13]))((IVector<T>*)Unsafe.AsPointer(ref this), item);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int RemoveAtEnd()
+        {
+            return ((delegate* unmanaged<IVector<T>*, int>)(lpVtbl[14]))((IVector<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Clear()
+        {
+            return ((delegate* unmanaged<IVector<T>*, int>)(lpVtbl[15]))((IVector<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int GetMany([NativeTypeName("unsigned")] uint startIndex, [NativeTypeName("unsigned")] uint capacity, [NativeTypeName("T_abi *")] T* value, [NativeTypeName("unsigned *")] uint* actual)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint, uint, T*, uint*, int>)(lpVtbl[16]))((IVector<T>*)Unsafe.AsPointer(ref this), startIndex, capacity, value, actual);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int ReplaceAll([NativeTypeName("unsigned")] uint count, [NativeTypeName("T_abi *")] T* value)
+        {
+            return ((delegate* unmanaged<IVector<T>*, uint, T*, int>)(lpVtbl[17]))((IVector<T>*)Unsafe.AsPointer(ref this), count, value);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/MapChangedEventHandler`2.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/MapChangedEventHandler`2.Manual.cs
@@ -1,0 +1,47 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("179517F3-94EE-41F8-BDDC-768A895544F3")]
+    public unsafe partial struct MapChangedEventHandler<K, V>
+        where K : unmanaged
+        where V : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<MapChangedEventHandler<K, V>*, Guid*, void**, int>)(lpVtbl[0]))((MapChangedEventHandler<K, V>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<MapChangedEventHandler<K, V>*, uint>)(lpVtbl[1]))((MapChangedEventHandler<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<MapChangedEventHandler<K, V>*, uint>)(lpVtbl[2]))((MapChangedEventHandler<K, V>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IObservableMap<K_logical, V_logical> *")] IObservableMap<K, V>* sender, [NativeTypeName("IMapChangedEventArgs<K_logical> *")] IMapChangedEventArgs<K>* e)
+        {
+            return ((delegate* unmanaged<MapChangedEventHandler<K, V>*, IObservableMap<K, V>*, IMapChangedEventArgs<K>*, int>)(lpVtbl[3]))((MapChangedEventHandler<K, V>*)Unsafe.AsPointer(ref this), sender, e);
+        }
+    }
+}

--- a/sources/Interop/Windows/winrt/windows.foundation.collections/VectorChangedEventHandler`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/windows.foundation.collections/VectorChangedEventHandler`1.Manual.cs
@@ -1,0 +1,46 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/windows.foundation.collections.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    [Guid("0C051752-9FBF-4C70-AA0C-0E4C82D9A761")]
+    public unsafe partial struct VectorChangedEventHandler<T>
+        where T : unmanaged
+    {
+        public void** lpVtbl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int QueryInterface([NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("void **")] void** ppvObject)
+        {
+            return ((delegate* unmanaged<VectorChangedEventHandler<T>*, Guid*, void**, int>)(lpVtbl[0]))((VectorChangedEventHandler<T>*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<VectorChangedEventHandler<T>*, uint>)(lpVtbl[1]))((VectorChangedEventHandler<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged<VectorChangedEventHandler<T>*, uint>)(lpVtbl[2]))((VectorChangedEventHandler<T>*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NativeTypeName("HRESULT")]
+        public int Invoke([NativeTypeName("IObservableVector<T_logical> *")] IObservableVector<T>* sender, IVectorChangedEventArgs* e)
+        {
+            return ((delegate* unmanaged<VectorChangedEventHandler<T>*, IObservableVector<T>*, IVectorChangedEventArgs*, int>)(lpVtbl[3]))((VectorChangedEventHandler<T>*)Unsafe.AsPointer(ref this), sender, e);
+        }
+    }
+}


### PR DESCRIPTION
Manually ports the `winrt\windows.foundation.collections.h` file to TerraFX.Interop.Windows.

This file contains the definition for every parameterized interface and delegate defined for the Windows Runtime (even ones that aren't related to collections). Since only the system can define parameterized types, manually porting them is feasible and provides maximum fidelity for the entire set of parameterized types in WinRT. (It is unlikely that new parameterized interfaces will ever be added.) 

The header looks to be written manually, and uses some template logic that can not be easily auto-translated to C#. Each parameterized type is exposed to consumers like so:
```cpp
template <class T> 
struct IEventHandler
        : IEventHandler_impl<T>
        , Windows::Foundation::Collections::detail::not_yet_specialized<IEventHandler<T>>
{
};
```
  This type itself is not relevant for C#, since it only serves to improve diagnostic scenarios when the type is misused. The interesting parts are defined in `IEventHandler_impl`:
```cpp
template <class T>
struct IEventHandler_impl : IUnknown
{
    private:
        typedef typename Windows::Foundation::Internal::GetAbiType<T>::type     T_abi;
        typedef typename Windows::Foundation::Internal::GetLogicalType<T>::type T_logical;
    public:
      // ...
        typedef T                                                               T_complex;
        virtual HRESULT STDMETHODCALLTYPE Invoke( _In_ IInspectable *sender, _In_ T_abi args) = 0;
};
```

The `T_abi`, `T_logical`, and `T_complex` typedefs are again computed using some template logic that is not feasible to use in C#. The comment I omitted from the above excerpt explains the purpose of each of those typedefs, but the only relevant one for invoking WinRT APIs is `T_abi`, as it represents the actual type used when passing values into functions at the ABI level. The other ones seem to exist to facilitate a better programming experience with regards to how the MIDLRT tool operates with parameterized interfaces. (You can take a look at the template specializations it generates in files like `windows.ui.core.h` for further clarity.)

These interfaces were manually ported with a lot of copy and paste & find and replace. Please be extra careful when reviewing to make sure that things like vtable slot numbers, IIDs, and function signatures are actually correct.