### PR TITLE
Add __uuidof type inference

### DIFF
--- a/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
@@ -22,7 +22,6 @@ namespace TerraFX.Interop
             return new UuidOfType(UUID<T>.RIID);
         }
         
-        {
         /// <summary>Retrieves the GUID of of a specified type.</summary>
         /// <param name="value">A pointer to a value of type <typeparamref name="T"/>.</param>
         /// <typeparam name="T">The type to retrieve the GUID for.</typeparam>

--- a/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
@@ -12,6 +12,17 @@ namespace TerraFX.Interop
     public static partial class Windows
     {
         /// <summary>Retrieves the GUID of of a specified type.</summary>
+        /// <param name="value">A value of type <typeparamref name="T"/>.</param>
+        /// <typeparam name="T">The type to retrieve the GUID for.</typeparam>
+        /// <returns>A <see cref="UuidOfType"/> value wrapping a pointer to the GUID data for the input type. This value can be either converted to a <see cref="Guid"/> pointer, or implicitly assigned to a <see cref="Guid"/> value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe UuidOfType __uuidof<T>(T value) // for type inference similar to C++'s __uuidof
+            where T : unmanaged
+        {
+            return new UuidOfType(UUID<T>.RIID);
+        }
+
+        /// <summary>Retrieves the GUID of of a specified type.</summary>
         /// <typeparam name="T">The type to retrieve the GUID for.</typeparam>
         /// <returns>A <see cref="UuidOfType"/> value wrapping a pointer to the GUID data for the input type. This value can be either converted to a <see cref="Guid"/> pointer, or implicitly assigned to a <see cref="Guid"/> value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
@@ -21,6 +21,18 @@ namespace TerraFX.Interop
         {
             return new UuidOfType(UUID<T>.RIID);
         }
+        
+        {
+        /// <summary>Retrieves the GUID of of a specified type.</summary>
+        /// <param name="value">A pointer to a value of type <typeparamref name="T"/>.</param>
+        /// <typeparam name="T">The type to retrieve the GUID for.</typeparam>
+        /// <returns>A <see cref="UuidOfType"/> value wrapping a pointer to the GUID data for the input type. This value can be either converted to a <see cref="Guid"/> pointer, or implicitly assigned to a <see cref="Guid"/> value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe UuidOfType __uuidof<T>(T* value) // for type inference similar to C++'s __uuidof
+            where T : unmanaged
+        {
+            return new UuidOfType(UUID<T>.RIID);
+        }
 
         /// <summary>Retrieves the GUID of of a specified type.</summary>
         /// <typeparam name="T">The type to retrieve the GUID for.</typeparam>

--- a/tests/Interop/Windows/shared/uuids/__uuidofTests.cs
+++ b/tests/Interop/Windows/shared/uuids/__uuidofTests.cs
@@ -9,10 +9,10 @@ using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.UnitTests
 {
-    /// <summary>Provides validation of the <see cref="__uuidof{T}"/> API.</summary>
+    /// <summary>Provides validation of the <see cref="__uuidof{T}()"/> API.</summary>
     public static unsafe class __uuidofTests
     {
-        /// <summary>Validates the <see cref="__uuidof{T}" /> pointer conversion.</summary>
+        /// <summary>Validates the <see cref="__uuidof{T}()" /> pointer conversion.</summary>
         [Test]
         public static void PointerTest()
         {
@@ -25,7 +25,7 @@ namespace TerraFX.Interop.UnitTests
             Assert.That(guid, Is.EqualTo(IID_IInspectable));
         }
 
-        /// <summary>Validates the <see cref="__uuidof{T}" /> <see cref="Guid"/> conversion.</summary>
+        /// <summary>Validates the <see cref="__uuidof{T}()" /> <see cref="Guid"/> conversion.</summary>
         [Test]
         public static void ValueTest()
         {


### PR DESCRIPTION
Matches C++ definition better, allows something like
```cs
IUnknown* pUnk = null;
Guid iid = __uuidof(*pUnk);
```