### PR TITLE
Fix D3DCompile DllImport library

### DIFF
--- a/generation/um/d3dcompiler/generate.rsp
+++ b/generation/um/d3dcompiler/generate.rsp
@@ -15,4 +15,3 @@ C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um\d3dcompiler.inl
 D3DCOMPILER_STRIP_FLAGS=Flags
 --with-librarypath
 *=D3DCompiler_47
-D3DCompile=D3DCompiler

--- a/sources/Interop/Windows/um/d3dcompiler/Windows.cs
+++ b/sources/Interop/Windows/um/d3dcompiler/Windows.cs
@@ -18,7 +18,7 @@ namespace TerraFX.Interop
         [return: NativeTypeName("HRESULT")]
         public static extern int D3DWriteBlobToFile([NativeTypeName("ID3DBlob *")] ID3DBlob* pBlob, [NativeTypeName("LPCWSTR")] ushort* pFileName, [NativeTypeName("BOOL")] int bOverwrite);
 
-        [DllImport("D3DCompiler", ExactSpelling = true)]
+        [DllImport("D3DCompiler_47", ExactSpelling = true)]
         [return: NativeTypeName("HRESULT")]
         public static extern int D3DCompile([NativeTypeName("LPCVOID")] void* pSrcData, [NativeTypeName("SIZE_T")] nuint SrcDataSize, [NativeTypeName("LPCSTR")] sbyte* pSourceName, [NativeTypeName("const D3D_SHADER_MACRO *")] D3D_SHADER_MACRO* pDefines, [NativeTypeName("ID3DInclude *")] ID3DInclude* pInclude, [NativeTypeName("LPCSTR")] sbyte* pEntrypoint, [NativeTypeName("LPCSTR")] sbyte* pTarget, [NativeTypeName("UINT")] uint Flags1, [NativeTypeName("UINT")] uint Flags2, [NativeTypeName("ID3DBlob **")] ID3DBlob** ppCode, [NativeTypeName("ID3DBlob **")] ID3DBlob** ppErrorMsgs);
 


### PR DESCRIPTION
When trying to use `D3DCompile`, I ran into

```
Exception thrown: 'System.DllNotFoundException' in System.Private.CoreLib.dll
An unhandled exception of type 'System.DllNotFoundException' occurred in System.Private.CoreLib.dll
Unable to load DLL 'D3DCompiler' or one of its dependencies: The specified module could not be found. (0x8007007E)
```

I noticed your samples (which are cool, by the way) all use `D3DCompileFromFile`, so thinking this method may not have been tested before.

The line I removed appeared in https://github.com/terrafx/terrafx.interop.windows/commit/a379f833dfb8e7ce24558d739e088bc2bfe5137d which is a commit with a lot of changes, but without any specific mention regarding this, so wondering whether that's a bug?

Tried to regenerate the binding locally to test my patch but it failed
```
.\build.cmd -generate
Parameter set cannot be resolved using the specified named parameters.
System.Management.Automation.ParameterBindingException: Parameter set cannot be resolved using the specified named parameters.
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
at Generate, C:\Users\Martin\Projects\tmp\terrafx.interop.windows\scripts\build.ps1: line 40
at <ScriptBlock>, terrafx.interop.windows\scripts\build.ps1: line 142
at <ScriptBlock>, <No file>: line 1
```

I do believe that the DllImport library name should be `D3DCompiler_47` (like the others), instead of

```
[DllImport("D3DCompiler", ExactSpelling = true)]
        [return: NativeTypeName("HRESULT")]
        public static extern int D3DCompile([NativeTypeName("LPCVOID")] void* pSrcData, [NativeTypeName("SIZE_T")] nuint SrcDataSize, [NativeTypeName("LPCSTR")] sbyte* pSourceName, [NativeTypeName("const D3D_SHADER_MACRO *")] D3D_SHADER_MACRO* pDefines, [NativeTypeName("ID3DInclude *")] ID3DInclude* pInclude, [NativeTypeName("LPCSTR")] sbyte* pEntrypoint, [NativeTypeName("LPCSTR")] sbyte* pTarget, [NativeTypeName("UINT")] uint Flags1, [NativeTypeName("UINT")] uint Flags2, [NativeTypeName("ID3DBlob **")] ID3DBlob** ppCode, [NativeTypeName("ID3DBlob **")] ID3DBlob** ppErrorMsgs);
```

Keep up the good work!