### PR TITLE
Updating the samples to render on idle and display basic FPS information

### DIFF
--- a/samples/DirectX/D3D11/HelloWindow11.cs
+++ b/samples/DirectX/D3D11/HelloWindow11.cs
@@ -1,5 +1,7 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
+
 namespace TerraFX.Samples.DirectX.D3D11
 {
     public unsafe class HelloWindow11 : DX11Sample
@@ -8,7 +10,7 @@ namespace TerraFX.Samples.DirectX.D3D11
         {
         }
 
-        public override void OnUpdate()
+        public override void OnUpdate(TimeSpan delta)
         {
         }
 

--- a/samples/DirectX/D3D12/HelloConstBuffer12.cs
+++ b/samples/DirectX/D3D12/HelloConstBuffer12.cs
@@ -3,6 +3,7 @@
 // Ported from D3D12HelloConstBuffor in https://github.com/Microsoft/DirectX-Graphics-Samples
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
+using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using TerraFX.Interop;
@@ -36,7 +37,7 @@ namespace TerraFX.Samples.DirectX.D3D12
         {
         }
 
-        public override void OnUpdate()
+        public override void OnUpdate(TimeSpan delta)
         {
             const float TranslationSpeed = 0.005f;
             const float OffsetBounds = 1.25f;

--- a/samples/DirectX/D3D12/HelloWindow12.cs
+++ b/samples/DirectX/D3D12/HelloWindow12.cs
@@ -3,6 +3,8 @@
 // Ported from D3D12HelloWindow.h in https://github.com/Microsoft/DirectX-Graphics-Samples
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
+using System;
+
 namespace TerraFX.Samples.DirectX.D3D12
 {
     public unsafe class HelloWindow12 : DX12Sample
@@ -15,7 +17,7 @@ namespace TerraFX.Samples.DirectX.D3D12
         {
         }
 
-        public override void OnUpdate()
+        public override void OnUpdate(TimeSpan delta)
         {
         }
     }

--- a/samples/WinForms/DXPanel.cs
+++ b/samples/WinForms/DXPanel.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using System.Windows.Forms;
 using TerraFX.Samples.DirectX;
 using static TerraFX.Interop.DXGI_FORMAT;
-using static TerraFX.Interop.Windows;
 
 namespace TerraFX.Samples.WinForms
 {
@@ -91,19 +90,6 @@ namespace TerraFX.Samples.WinForms
         private void DXPanel_KeyDown(object sender, KeyEventArgs eventArgs)
         {
             _dxSample?.OnKeyDown(eventArgs.KeyValue);
-        }
-
-        protected override void WndProc(ref Message m)
-        {
-            if ((m.Msg == WM_PAINT) && (_dxSample is not null))
-            {
-                _dxSample.OnUpdate();
-                _dxSample.OnRender();
-            }
-            else
-            {
-                base.WndProc(ref m);
-            }
         }
     }
 }

--- a/samples/WinForms/MainForm.Designer.cs
+++ b/samples/WinForms/MainForm.Designer.cs
@@ -100,7 +100,7 @@ namespace TerraFX.Samples.WinForms
             this.button1.TabIndex = 0;
             this.button1.Text = "Background Color";
             this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.button1.Click += new System.EventHandler(this.backgroundColorButton_Click);
             // 
             // _dxPanel
             // 

--- a/samples/WinForms/MainForm.cs
+++ b/samples/WinForms/MainForm.cs
@@ -8,6 +8,8 @@ namespace TerraFX.Samples.WinForms
 {
     public partial class MainForm : Form
     {
+        private uint _lastFramesPerSecond;
+
         public MainForm()
         {
             InitializeComponent();
@@ -16,6 +18,34 @@ namespace TerraFX.Samples.WinForms
         private void MainForm_Load(object sender, EventArgs eventArgs)
         {
             _samplesListBox.Items.AddRange(DXSample.Samples);
+            Application.Idle += Application_Idle;
+        }
+
+        private void Application_Idle(object? sender, EventArgs e)
+        {
+            var dxSample = _dxPanel.DXSample;
+
+            if (dxSample is null)
+            {
+                return;
+            }
+
+            var delta = dxSample.OnBeginFrame();
+            dxSample.OnUpdate(delta);
+
+            var framesPerSecond = dxSample.FramesPerSecond;
+
+            if (framesPerSecond != _lastFramesPerSecond)
+            {
+                Text = $"{dxSample.Name} ({framesPerSecond} fps)";
+                _lastFramesPerSecond = framesPerSecond;
+            }
+
+            if (dxSample.IsWindowVisible)
+            {
+                dxSample.OnRender();
+                _dxPanel.Invalidate();
+            }
         }
 
         private void samplesListBox_SelectedIndexChanged(object sender, EventArgs eventArgs)
@@ -24,7 +54,7 @@ namespace TerraFX.Samples.WinForms
             _dxPanel.DXSample = _samplesListBox.SelectedItem as DXSample;
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void backgroundColorButton_Click(object sender, EventArgs e)
         {
             if (colorDialog1.ShowDialog(this) == DialogResult.OK)
             {


### PR DESCRIPTION
This allows full rendering speed, rather than simply rendering on paint or invalidate.

There is an opportunity to properly use the delta in `ConstBuffer` or other samples so we move per time, rather than per frame.