### PR TITLE
Ensuring transparent struct wrappers are used in manual defines and port shared/windowsx.h

### DIFF
--- a/sources/Interop/.editorconfig
+++ b/sources/Interop/.editorconfig
@@ -29,7 +29,10 @@ dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.severit
 #    disable certain parent style options since they are not applicable to interop
 ###############################################################################
 csharp_style_expression_bodied_methods = when_on_single_line:none
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 csharp_style_prefer_pattern_matching = true:none

--- a/sources/Interop/Windows/Windows.cs
+++ b/sources/Interop/Windows/Windows.cs
@@ -12,10 +12,7 @@ namespace TerraFX.Interop
         /// <summary>Raised whenever a native library is loaded by TerraFX.Interop.Windows. Handlers can be added to this event to customize how libraries are loaded, and they will be used first whenever a new native library is being resolved.</summary>
         public static event DllImportResolver? ResolveLibrary;
 
-        /// <summary>Initializes the DLL resolver for the current assembly.</summary>
-        /// <returns>Just <see langword="null"/>, this method is only used to skip the static constructor and keep this type as <see langword="beforefieldinit"/>.</returns>
-        [ModuleInitializer]
-        internal static void SetDllImportResolver()
+        static Windows()
         {
             NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), OnDllImport);
         }

--- a/sources/Interop/Windows/Windows.cs
+++ b/sources/Interop/Windows/Windows.cs
@@ -1,0 +1,64 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    public static unsafe partial class Windows
+    {
+        /// <summary>Raised whenever a native library is loaded by TerraFX.Interop.Windows. Handlers can be added to this event to customize how libraries are loaded, and they will be used first whenever a new native library is being resolved.</summary>
+        public static event DllImportResolver? ResolveLibrary;
+
+        /// <summary>Initializes the DLL resolver for the current assembly.</summary>
+        /// <returns>Just <see langword="null"/>, this method is only used to skip the static constructor and keep this type as <see langword="beforefieldinit"/>.</returns>
+        [ModuleInitializer]
+        internal static void SetDllImportResolver()
+        {
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), OnDllImport);
+        }
+
+        /// <summary>The default <see cref="DllImportResolver"/> for TerraFX.Interop.Windows.</summary>
+        /// <inheritdoc cref="DllImportResolver"/>
+        private static IntPtr OnDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            if (TryResolveLibrary(libraryName, assembly, searchPath, out IntPtr nativeLibrary))
+            {
+                return nativeLibrary;
+            }
+
+            return NativeLibrary.Load(libraryName, assembly, searchPath);
+        }
+
+        /// <summary>Tries to resolve a native library using the handlers for the <see cref="ResolveLibrary"/> event.</summary>
+        /// <param name="libraryName">The native library to resolve.</param>
+        /// <param name="assembly">The assembly requesting the resolution.</param>
+        /// <param name="searchPath">The <see cref="DllImportSearchPath"/> value on the P/Invoke or assembly, or <see langword="null"/>.</param>
+        /// <param name="nativeLibrary">The loaded library, if one was resolved.</param>
+        /// <returns>Whether or not the requested library was successfully loaded.</returns>
+        private static bool TryResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath, out IntPtr nativeLibrary)
+        {
+            var resolveLibrary = ResolveLibrary;
+
+            if (resolveLibrary != null)
+            {
+                var resolvers = resolveLibrary.GetInvocationList();
+
+                foreach (DllImportResolver resolver in resolvers)
+                {
+                    nativeLibrary = resolver(libraryName, assembly, searchPath);
+
+                    if (nativeLibrary != IntPtr.Zero)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            nativeLibrary = IntPtr.Zero;
+            return false;
+        }
+    }
+}

--- a/sources/Interop/Windows/other/d3dx12/D3D12_CLEAR_VALUE.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_CLEAR_VALUE.Manual.cs
@@ -4,6 +4,7 @@
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
 using System;
+using System.Runtime.CompilerServices;
 using static TerraFX.Interop.DXGI_FORMAT;
 
 namespace TerraFX.Interop
@@ -12,7 +13,7 @@ namespace TerraFX.Interop
     {
         public D3D12_CLEAR_VALUE(DXGI_FORMAT format, [NativeTypeName("const FLOAT [4]")] float* color)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             Format = format;
             Anonymous.Color[0] = color[0];
@@ -31,7 +32,9 @@ namespace TerraFX.Interop
         public static bool operator ==([NativeTypeName("const D3D12_CLEAR_VALUE &")] in D3D12_CLEAR_VALUE a, [NativeTypeName("const D3D12_CLEAR_VALUE &")] in D3D12_CLEAR_VALUE b)
         {
             if (a.Format != b.Format)
+            {
                 return false;
+            }
 
             if (a.Format == DXGI_FORMAT_D24_UNORM_S8_UINT || a.Format == DXGI_FORMAT_D16_UNORM || a.Format == DXGI_FORMAT_D32_FLOAT || a.Format == DXGI_FORMAT_D32_FLOAT_S8X24_UINT)
             {
@@ -44,9 +47,7 @@ namespace TerraFX.Interop
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_CLEAR_VALUE &")] in D3D12_CLEAR_VALUE a, [NativeTypeName("const D3D12_CLEAR_VALUE &")] in D3D12_CLEAR_VALUE b)
-        {
-            return !(a == b);
-        }
+            => !(a == b);
 
         public override bool Equals(object? obj) => (obj is D3D12_CLEAR_VALUE other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_CPU_DESCRIPTOR_HANDLE.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_CPU_DESCRIPTOR_HANDLE.Manual.cs
@@ -34,14 +34,10 @@ namespace TerraFX.Interop
         }
 
         public static bool operator ==([NativeTypeName("const D3D12_CPU_DESCRIPTOR_HANDLE &")] in D3D12_CPU_DESCRIPTOR_HANDLE l, [NativeTypeName("const D3D12_CPU_DESCRIPTOR_HANDLE &")] in D3D12_CPU_DESCRIPTOR_HANDLE r)
-        {
-            return (l.ptr == r.ptr);
-        }
+            => (l.ptr == r.ptr);
 
         public static bool operator !=([NativeTypeName("const D3D12_CPU_DESCRIPTOR_HANDLE &")] in D3D12_CPU_DESCRIPTOR_HANDLE l, [NativeTypeName("const D3D12_CPU_DESCRIPTOR_HANDLE &")] in D3D12_CPU_DESCRIPTOR_HANDLE r)
-        {
-            return (l.ptr != r.ptr);
-        }
+            => (l.ptr != r.ptr);
 
         public void InitOffsetted([NativeTypeName("const D3D12_CPU_DESCRIPTOR_HANDLE &")] in D3D12_CPU_DESCRIPTOR_HANDLE @base, int offsetScaledByIncrementSize)
         {

--- a/sources/Interop/Windows/other/d3dx12/D3D12_GPU_DESCRIPTOR_HANDLE.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_GPU_DESCRIPTOR_HANDLE.Manual.cs
@@ -34,14 +34,10 @@ namespace TerraFX.Interop
         }
 
         public static bool operator ==([NativeTypeName("const D3D12_GPU_DESCRIPTOR_HANDLE &")] in D3D12_GPU_DESCRIPTOR_HANDLE l, [NativeTypeName("const D3D12_GPU_DESCRIPTOR_HANDLE &")] in D3D12_GPU_DESCRIPTOR_HANDLE r)
-        {
-            return (l.ptr == r.ptr);
-        }
+            => (l.ptr == r.ptr);
 
         public static bool operator !=([NativeTypeName("const D3D12_GPU_DESCRIPTOR_HANDLE &")] in D3D12_GPU_DESCRIPTOR_HANDLE l, [NativeTypeName("const D3D12_GPU_DESCRIPTOR_HANDLE &")] in D3D12_GPU_DESCRIPTOR_HANDLE r)
-        {
-            return (l.ptr != r.ptr);
-        }
+            => (l.ptr != r.ptr);
 
         public void InitOffsetted([NativeTypeName("const D3D12_GPU_DESCRIPTOR_HANDLE &")] in D3D12_GPU_DESCRIPTOR_HANDLE @base, int offsetScaledByIncrementSize)
         {

--- a/sources/Interop/Windows/other/d3dx12/D3D12_HEAP_DESC.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_HEAP_DESC.Manual.cs
@@ -58,23 +58,18 @@ namespace TerraFX.Interop
             Flags = flags;
         }
 
-        public bool IsCPUAccessible
-        {
-            get
-            {
-                return Properties.IsCPUAccessible;
-            }
-        }
+        public bool IsCPUAccessible => Properties.IsCPUAccessible;
 
         public static bool operator ==([NativeTypeName("const D3D12_HEAP_DESC &")] in D3D12_HEAP_DESC l, [NativeTypeName("const D3D12_HEAP_DESC &")] in D3D12_HEAP_DESC r)
         {
-            return l.SizeInBytes == r.SizeInBytes && l.Properties == r.Properties && l.Alignment == r.Alignment && l.Flags == r.Flags;
+            return (l.SizeInBytes == r.SizeInBytes)
+                && (l.Properties == r.Properties)
+                && (l.Alignment == r.Alignment)
+                && (l.Flags == r.Flags);
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_HEAP_DESC &")] in D3D12_HEAP_DESC l, [NativeTypeName("const D3D12_HEAP_DESC &")] in D3D12_HEAP_DESC r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is D3D12_HEAP_DESC other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_HEAP_PROPERTIES.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_HEAP_PROPERTIES.Manual.cs
@@ -34,19 +34,23 @@ namespace TerraFX.Interop
         {
             get
             {
-                return Type == D3D12_HEAP_TYPE_UPLOAD || Type == D3D12_HEAP_TYPE_READBACK || (Type == D3D12_HEAP_TYPE_CUSTOM && (CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE || CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_BACK));
+                return (Type == D3D12_HEAP_TYPE_UPLOAD)
+                    || (Type == D3D12_HEAP_TYPE_READBACK)
+                    || ((Type == D3D12_HEAP_TYPE_CUSTOM) && ((CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE) || (CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_BACK)));
             }
         }
 
         public static bool operator ==([NativeTypeName("const D3D12_HEAP_PROPERTIES &")] in D3D12_HEAP_PROPERTIES l, [NativeTypeName("const D3D12_HEAP_PROPERTIES &")] in D3D12_HEAP_PROPERTIES r)
         {
-            return l.Type == r.Type && l.CPUPageProperty == r.CPUPageProperty && l.MemoryPoolPreference == r.MemoryPoolPreference && l.CreationNodeMask == r.CreationNodeMask && l.VisibleNodeMask == r.VisibleNodeMask;
+            return (l.Type == r.Type)
+                && (l.CPUPageProperty == r.CPUPageProperty)
+                && (l.MemoryPoolPreference == r.MemoryPoolPreference)
+                && (l.CreationNodeMask == r.CreationNodeMask)
+                && (l.VisibleNodeMask == r.VisibleNodeMask);
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_HEAP_PROPERTIES &")] in D3D12_HEAP_PROPERTIES l, [NativeTypeName("const D3D12_HEAP_PROPERTIES &")] in D3D12_HEAP_PROPERTIES r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is D3D12_HEAP_PROPERTIES other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_BEGINNING_ACCESS.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_BEGINNING_ACCESS.Manual.cs
@@ -13,18 +13,20 @@ namespace TerraFX.Interop
         public static bool operator ==([NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS a, [NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS b)
         {
             if (a.Type != b.Type)
+            {
                 return false;
+            }
 
             if (a.Type == D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR && !(a.Anonymous.Clear == b.Anonymous.Clear))
+            {
                 return false;
+            }
 
             return true;
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS a, [NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS b)
-        {
-            return !(a == b);
-        }
+            => !(a == b);
 
         public override bool Equals(object? obj) => (obj is D3D12_RENDER_PASS_BEGINNING_ACCESS other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS.Manual.cs
@@ -10,14 +10,10 @@ namespace TerraFX.Interop
     public partial struct D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS : IEquatable<D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS>
     {
         public static bool operator ==([NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS a, [NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS b)
-        {
-            return a.ClearValue == b.ClearValue;
-        }
+            => a.ClearValue == b.ClearValue;
 
         public static bool operator !=([NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS a, [NativeTypeName("const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &")] in D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS b)
-        {
-            return !(a == b);
-        }
+            => !(a == b);
 
         public override bool Equals(object? obj) => (obj is D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_DEPTH_STENCIL_DESC.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_DEPTH_STENCIL_DESC.Manual.cs
@@ -12,27 +12,35 @@ namespace TerraFX.Interop
         public static bool operator ==([NativeTypeName("const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &")] in D3D12_RENDER_PASS_DEPTH_STENCIL_DESC a, [NativeTypeName("const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &")] in D3D12_RENDER_PASS_DEPTH_STENCIL_DESC b)
         {
             if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr)
+            {
                 return false;
+            }
 
             if (!(a.DepthBeginningAccess == b.DepthBeginningAccess))
+            {
                 return false;
+            }
 
             if (!(a.StencilBeginningAccess == b.StencilBeginningAccess))
+            {
                 return false;
+            }
 
             if (!(a.DepthEndingAccess == b.DepthEndingAccess))
+            {
                 return false;
+            }
 
             if (!(a.StencilEndingAccess == b.StencilEndingAccess))
+            {
                 return false;
+            }
 
             return true;
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &")] in D3D12_RENDER_PASS_DEPTH_STENCIL_DESC a, [NativeTypeName("const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &")] in D3D12_RENDER_PASS_DEPTH_STENCIL_DESC b)
-        {
-            return !(a == b);
-        }
+            => !(a == b);
 
         public override bool Equals(object? obj) => (obj is D3D12_RENDER_PASS_DEPTH_STENCIL_DESC other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_ENDING_ACCESS.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_ENDING_ACCESS.Manual.cs
@@ -13,18 +13,20 @@ namespace TerraFX.Interop
         public static bool operator ==([NativeTypeName("const D3D12_RENDER_PASS_ENDING_ACCESS &")] in D3D12_RENDER_PASS_ENDING_ACCESS a, [NativeTypeName("const D3D12_RENDER_PASS_ENDING_ACCESS &")] in D3D12_RENDER_PASS_ENDING_ACCESS b)
         {
             if (a.Type != b.Type)
+            {
                 return false;
+            }
 
             if (a.Type == D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE && !(a.Anonymous.Resolve == b.Anonymous.Resolve))
+            {
                 return false;
+            }
 
             return true;
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_RENDER_PASS_ENDING_ACCESS &")] in D3D12_RENDER_PASS_ENDING_ACCESS a, [NativeTypeName("const D3D12_RENDER_PASS_ENDING_ACCESS &")] in D3D12_RENDER_PASS_ENDING_ACCESS b)
-        {
-            return !(a == b);
-        }
+            => !(a == b);
 
         public override bool Equals(object? obj) => (obj is D3D12_RENDER_PASS_ENDING_ACCESS other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_RENDER_TARGET_DESC.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RENDER_PASS_RENDER_TARGET_DESC.Manual.cs
@@ -12,21 +12,25 @@ namespace TerraFX.Interop
         public static bool operator ==([NativeTypeName("const D3D12_RENDER_PASS_RENDER_TARGET_DESC &")] in D3D12_RENDER_PASS_RENDER_TARGET_DESC a, [NativeTypeName("const D3D12_RENDER_PASS_RENDER_TARGET_DESC &")] in D3D12_RENDER_PASS_RENDER_TARGET_DESC b)
         {
             if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr)
+            {
                 return false;
+            }
 
             if (!(a.BeginningAccess == b.BeginningAccess))
+            {
                 return false;
+            }
 
             if (!(a.EndingAccess == b.EndingAccess))
+            {
                 return false;
+            }
 
             return true;
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_RENDER_PASS_RENDER_TARGET_DESC &")] in D3D12_RENDER_PASS_RENDER_TARGET_DESC a, [NativeTypeName("const D3D12_RENDER_PASS_RENDER_TARGET_DESC &")] in D3D12_RENDER_PASS_RENDER_TARGET_DESC b)
-        {
-            return !(a == b);
-        }
+            => !(a == b);
 
         public override bool Equals(object? obj) => (obj is D3D12_RENDER_PASS_RENDER_TARGET_DESC other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RESOURCE_DESC.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RESOURCE_DESC.Manual.cs
@@ -54,21 +54,9 @@ namespace TerraFX.Interop
             return new D3D12_RESOURCE_DESC(D3D12_RESOURCE_DIMENSION_TEXTURE3D, alignment, width, height, depth, mipLevels, format, 1, 0, layout, flags);
         }
 
-        public ushort Depth
-        {
-            get
-            {
-                return (Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D ? DepthOrArraySize : (ushort)1);
-            }
-        }
+        public ushort Depth => ((Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) ? DepthOrArraySize : (ushort)(1));
 
-        public ushort ArraySize
-        {
-            get
-            {
-                return (Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? DepthOrArraySize : (ushort)1);
-            }
-        }
+        public ushort ArraySize => ((Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D) ? DepthOrArraySize : (ushort)(1));
 
         public byte GetPlaneCount(ID3D12Device* pDevice)
         {
@@ -87,13 +75,21 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC l, [NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC r)
         {
-            return l.Dimension == r.Dimension && l.Alignment == r.Alignment && l.Width == r.Width && l.Height == r.Height && l.DepthOrArraySize == r.DepthOrArraySize && l.MipLevels == r.MipLevels && l.Format == r.Format && l.SampleDesc.Count == r.SampleDesc.Count && l.SampleDesc.Quality == r.SampleDesc.Quality && l.Layout == r.Layout && l.Flags == r.Flags;
+            return (l.Dimension == r.Dimension)
+                && (l.Alignment == r.Alignment)
+                && (l.Width == r.Width)
+                && (l.Height == r.Height)
+                && (l.DepthOrArraySize == r.DepthOrArraySize)
+                && (l.MipLevels == r.MipLevels)
+                && (l.Format == r.Format)
+                && (l.SampleDesc.Count == r.SampleDesc.Count)
+                && (l.SampleDesc.Quality == r.SampleDesc.Quality)
+                && (l.Layout == r.Layout)
+                && (l.Flags == r.Flags);
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC l, [NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is D3D12_RESOURCE_DESC other) && Equals(other);
 

--- a/sources/Interop/Windows/other/d3dx12/D3D12_ROOT_SIGNATURE_DESC1.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_ROOT_SIGNATURE_DESC1.Manual.cs
@@ -63,9 +63,7 @@ namespace TerraFX.Interop
         }
 
         public static bool operator !=(D3D12_ROOT_SIGNATURE_DESC1 left, D3D12_ROOT_SIGNATURE_DESC1 right)
-        {
-            return !(left == right);
-        }
+            => !(left == right);
 
         public void Init(uint numParameters, [NativeTypeName("const D3D12_ROOT_PARAMETER1 *")] D3D12_ROOT_PARAMETER1* _pParameters, uint numStaticSamplers = 0, [NativeTypeName("const D3D12_STATIC_SAMPLER_DESC *")] D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = null, D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
         {

--- a/sources/Interop/Windows/other/d3dx12/D3D12_RT_FORMAT_ARRAY.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_RT_FORMAT_ARRAY.Manual.cs
@@ -12,7 +12,7 @@ namespace TerraFX.Interop
     {
         public D3D12_RT_FORMAT_ARRAY([NativeTypeName("const DXGI_FORMAT *")] DXGI_FORMAT* pFormats, uint NumFormats)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             NumRenderTargets = NumFormats;
             Buffer.MemoryCopy(Unsafe.AsPointer(ref RTFormats), pFormats, sizeof(_RTFormats_e__FixedBuffer), sizeof(_RTFormats_e__FixedBuffer));

--- a/sources/Interop/Windows/other/d3dx12/D3D12_TEXTURE_COPY_LOCATION.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_TEXTURE_COPY_LOCATION.Manual.cs
@@ -3,6 +3,7 @@
 // Ported from d3dx12.h in DirectX-Graphics-Samples commit a7a87f1853b5540f10920518021d91ae641033fb
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
+using System.Runtime.CompilerServices;
 using static TerraFX.Interop.D3D12_TEXTURE_COPY_TYPE;
 
 namespace TerraFX.Interop
@@ -11,7 +12,7 @@ namespace TerraFX.Interop
     {
         public D3D12_TEXTURE_COPY_LOCATION(ID3D12Resource* pRes)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             pResource = pRes;
             Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
@@ -20,7 +21,7 @@ namespace TerraFX.Interop
 
         public D3D12_TEXTURE_COPY_LOCATION(ID3D12Resource* pRes, [NativeTypeName("D3D12_PLACED_SUBRESOURCE_FOOTPRINT const &")] in D3D12_PLACED_SUBRESOURCE_FOOTPRINT Footprint)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             pResource = pRes;
             Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
@@ -28,7 +29,7 @@ namespace TerraFX.Interop
         }
         public D3D12_TEXTURE_COPY_LOCATION(ID3D12Resource* pRes, uint Sub)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             pResource = pRes;
             Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;

--- a/sources/Interop/Windows/other/d3dx12/D3D12_VERSIONED_ROOT_SIGNATURE_DESC.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_VERSIONED_ROOT_SIGNATURE_DESC.Manual.cs
@@ -16,7 +16,7 @@ namespace TerraFX.Interop
     {
         public D3D12_VERSIONED_ROOT_SIGNATURE_DESC([NativeTypeName("const D3D12_ROOT_SIGNATURE_DESC &")] in D3D12_ROOT_SIGNATURE_DESC o)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             Version = D3D_ROOT_SIGNATURE_VERSION_1_0;
             Anonymous.Desc_1_0 = o;
@@ -24,7 +24,7 @@ namespace TerraFX.Interop
 
         public D3D12_VERSIONED_ROOT_SIGNATURE_DESC([NativeTypeName("const D3D12_ROOT_SIGNATURE_DESC1 &")] in D3D12_ROOT_SIGNATURE_DESC1 o)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
             Version = D3D_ROOT_SIGNATURE_VERSION_1_1;
             Anonymous.Desc_1_1 = o;

--- a/sources/Interop/Windows/other/d3dx12/D3D12_VIEWPORT.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/D3D12_VIEWPORT.Manual.cs
@@ -13,13 +13,16 @@ namespace TerraFX.Interop
     {
         public static bool operator ==([NativeTypeName("const D3D12_VIEWPORT &")] in D3D12_VIEWPORT l, [NativeTypeName("const D3D12_VIEWPORT &")] in D3D12_VIEWPORT r)
         {
-            return l.TopLeftX == r.TopLeftX && l.TopLeftY == r.TopLeftY && l.Width == r.Width && l.Height == r.Height && l.MinDepth == r.MinDepth && l.MaxDepth == r.MaxDepth;
+            return (l.TopLeftX == r.TopLeftX)
+                && (l.TopLeftY == r.TopLeftY)
+                && (l.Width == r.Width)
+                && (l.Height == r.Height)
+                && (l.MinDepth == r.MinDepth)
+                && (l.MaxDepth == r.MaxDepth);
         }
 
         public static bool operator !=([NativeTypeName("const D3D12_VIEWPORT &")] in D3D12_VIEWPORT l, [NativeTypeName("const D3D12_VIEWPORT &")] in D3D12_VIEWPORT r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public D3D12_VIEWPORT(float topLeftX, float topLeftY, float width, float height, float minDepth = D3D12_MIN_DEPTH, float maxDepth = D3D12_MAX_DEPTH)
         {

--- a/sources/Interop/Windows/other/d3dx12/Windows.Manual.cs
+++ b/sources/Interop/Windows/other/d3dx12/Windows.Manual.cs
@@ -84,9 +84,9 @@ namespace TerraFX.Interop
             ID3D12Device* pDevice = null;
             var iid = IID_ID3D12Device;
 
-            pDestinationResource->GetDevice(&iid, (void**)&pDevice);
+            _ = pDestinationResource->GetDevice(&iid, (void**)&pDevice);
             pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, 0, null, null, null, &RequiredSize);
-            pDevice->Release();
+            _ = pDevice->Release();
 
             return RequiredSize;
         }
@@ -102,7 +102,7 @@ namespace TerraFX.Interop
             }
 
             byte* pData;
-            int hr = pIntermediate->Map(0, null, (void**)&pData);
+            HRESULT hr = pIntermediate->Map(0, null, (void**)&pData);
 
             if (FAILED(hr))
             {
@@ -112,7 +112,9 @@ namespace TerraFX.Interop
             for (var i = 0u; i < NumSubresources; ++i)
             {
                 if (pRowSizesInBytes[i] > unchecked((nuint)(-1)))
+                {
                     return 0;
+                }
 
                 D3D12_MEMCPY_DEST DestData = new D3D12_MEMCPY_DEST
                 {
@@ -167,12 +169,12 @@ namespace TerraFX.Interop
             ID3D12Device* pDevice = null;
             var iid = IID_ID3D12Device;
 
-            pDestinationResource->GetDevice(&iid, (void**)&pDevice);
+            _ = pDestinationResource->GetDevice(&iid, (void**)&pDevice);
             pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
-            pDevice->Release();
+            _ = pDevice->Release();
 
             ulong Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pSrcData);
-            HeapFree(GetProcessHeap(), 0, pMem);
+            _ = HeapFree(GetProcessHeap(), 0, pMem);
             return Result;
         }
 
@@ -202,12 +204,12 @@ namespace TerraFX.Interop
             ID3D12Device* pDevice = null;
             var iid = IID_ID3D12Device;
 
-            pDestinationResource->GetDevice(&iid, (void**)&pDevice);
+            _ = pDestinationResource->GetDevice(&iid, (void**)&pDevice);
             pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
-            pDevice->Release();
+            _ = pDevice->Release();
 
             ulong Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pResourceData, pSrcData);
-            HeapFree(GetProcessHeap(), 0, pMem);
+            _ = HeapFree(GetProcessHeap(), 0, pMem);
             return Result;
         }
 
@@ -223,9 +225,9 @@ namespace TerraFX.Interop
             ID3D12Device* pDevice = null;
             var iid = IID_ID3D12Device;
 
-            pDestinationResource->GetDevice(&iid, (void**)&pDevice);
+            _ = pDestinationResource->GetDevice(&iid, (void**)&pDevice);
             pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, Layouts, NumRows, RowSizesInBytes, &RequiredSize);
-            pDevice->Release();
+            _ = pDevice->Release();
 
             return UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, Layouts, NumRows, RowSizesInBytes, pSrcData);
         }
@@ -242,9 +244,9 @@ namespace TerraFX.Interop
             ID3D12Device* pDevice = null;
             var iid = IID_ID3D12Device;
 
-            pDestinationResource->GetDevice(&iid, (void**)&pDevice);
+            _ = pDestinationResource->GetDevice(&iid, (void**)&pDevice);
             pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, Layouts, NumRows, RowSizesInBytes, &RequiredSize);
-            pDevice->Release();
+            _ = pDevice->Release();
 
             return UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, Layouts, NumRows, RowSizesInBytes, pResourceData, pSrcData);
         }
@@ -272,7 +274,7 @@ namespace TerraFX.Interop
 
                         case D3D_ROOT_SIGNATURE_VERSION_1_1:
                         {
-                            int hr = S_OK;
+                            HRESULT hr = S_OK;
                             ref readonly D3D12_ROOT_SIGNATURE_DESC1 desc_1_1 = ref pRootSignatureDesc->Anonymous.Desc_1_1;
 
                             nuint ParametersSize = (uint)sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters;
@@ -356,11 +358,11 @@ namespace TerraFX.Interop
                                 {
                                     if (desc_1_1.pParameters[n].ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
                                     {
-                                        HeapFree(GetProcessHeap(), 0, (void*)pParameters_1_0[n].Anonymous.DescriptorTable.pDescriptorRanges);
+                                        _ = HeapFree(GetProcessHeap(), 0, (void*)pParameters_1_0[n].Anonymous.DescriptorTable.pDescriptorRanges);
                                     }
                                 }
 
-                                HeapFree(GetProcessHeap(), 0, pParameters);
+                                _ = HeapFree(GetProcessHeap(), 0, pParameters);
                             }
 
                             return hr;

--- a/sources/Interop/Windows/other/dia2/Windows.Manual.cs
+++ b/sources/Interop/Windows/other/dia2/Windows.Manual.cs
@@ -8,7 +8,7 @@ namespace TerraFX.Interop
     public static partial class Windows
     {
         // __MIDL___MIDL_itf_dia2_0000_0000_0001 
-        public const int E_PDB_OK = unchecked((int)(((uint)1 << 31) | ((uint)0x6d << 16) | 1));
+        public const int E_PDB_OK = unchecked((int)((1u << 31) | (0x6Du << 16) | 1));
         public const int E_PDB_USAGE = E_PDB_OK + 1;
         public const int E_PDB_OUT_OF_MEMORY = E_PDB_USAGE + 1;
         public const int E_PDB_FILE_SYSTEM = E_PDB_OUT_OF_MEMORY + 1;
@@ -37,7 +37,7 @@ namespace TerraFX.Interop
         public const int E_PDB_MAX = E_PDB_OBJECT_DISPOSED + 1;
 
         // __MIDL___MIDL_itf_dia2_0000_0033_0001
-        public const int E_DIA_INPROLOG = unchecked((int)(((uint)1 << 31) | ((uint)0x6d << 16) | 100));
+        public const int E_DIA_INPROLOG = unchecked((int)((1u << 31) | (0x6Du << 16) | 100));
         public const int E_DIA_SYNTAX = E_DIA_INPROLOG + 1;
         public const int E_DIA_FRAME_ACCESS = E_DIA_SYNTAX + 1;
         public const int E_DIA_VALUE = E_DIA_FRAME_ACCESS + 1;

--- a/sources/Interop/Windows/other/helper-types/HBITMAP.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HBITMAP.Manual.cs
@@ -6,13 +6,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HBITMAP : IEquatable<HBITMAP>
     {
-        public HBITMAP(HGDIOBJ value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HBITMAP(HGDIOBJ value) => new HBITMAP(value.Value);
 
-        public static explicit operator HBITMAP(HGDIOBJ value) => new HBITMAP(value);
-
-        public static implicit operator HGDIOBJ(HBITMAP value) => (HGDIOBJ)(value.Value);
+        public static implicit operator HGDIOBJ(HBITMAP value) => new HGDIOBJ(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HBRUSH.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HBRUSH.Manual.cs
@@ -6,13 +6,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HBRUSH : IEquatable<HBRUSH>
     {
-        public HBRUSH(HGDIOBJ value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HBRUSH(HGDIOBJ value) => new HBRUSH(value.Value);
 
-        public static explicit operator HBRUSH(HGDIOBJ value) => new HBRUSH(value);
-
-        public static implicit operator HGDIOBJ(HBRUSH value) => (HGDIOBJ)(value.Value);
+        public static implicit operator HGDIOBJ(HBRUSH value) => new HGDIOBJ(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HCURSOR.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HCURSOR.Manual.cs
@@ -4,13 +4,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HCURSOR
     {
-        public HCURSOR(HICON value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HCURSOR(HICON value) => new HCURSOR(value.Value);
 
-        public static explicit operator HCURSOR(HICON value) => new HCURSOR(value);
-
-        public static implicit operator HICON(HCURSOR value) => (HICON)(value.Value);
+        public static implicit operator HICON(HCURSOR value) => new HICON(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HFONT.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HFONT.Manual.cs
@@ -6,13 +6,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HFONT : IEquatable<HFONT>
     {
-        public HFONT(HGDIOBJ value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HFONT(HGDIOBJ value) => new HFONT(value.Value);
 
-        public static explicit operator HFONT(HGDIOBJ value) => new HFONT(value);
-
-        public static implicit operator HGDIOBJ(HFONT value) => (HGDIOBJ)(value.Value);
+        public static implicit operator HGDIOBJ(HFONT value) => new HGDIOBJ(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HMODULE.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HMODULE.Manual.cs
@@ -4,13 +4,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HMODULE
     {
-        public HMODULE(HINSTANCE value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HMODULE(HINSTANCE value) => new HMODULE(value.Value);
 
-        public static explicit operator HMODULE(HINSTANCE value) => new HMODULE(value);
-
-        public static implicit operator HINSTANCE(HMODULE value) => (HINSTANCE)(value.Value);
+        public static implicit operator HINSTANCE(HMODULE value) => new HINSTANCE(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HPALETTE.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HPALETTE.Manual.cs
@@ -6,13 +6,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HPALETTE : IEquatable<HPALETTE>
     {
-        public HPALETTE(HGDIOBJ value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HPALETTE(HGDIOBJ value) => new HPALETTE(value.Value);
 
-        public static explicit operator HPALETTE(HGDIOBJ value) => new HPALETTE(value);
-
-        public static implicit operator HGDIOBJ(HPALETTE value) => (HGDIOBJ)(value.Value);
+        public static implicit operator HGDIOBJ(HPALETTE value) => new HGDIOBJ(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HPEN.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HPEN.Manual.cs
@@ -6,13 +6,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HPEN : IEquatable<HPEN>
     {
-        public HPEN(HGDIOBJ value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HPEN(HGDIOBJ value) => new HPEN(value.Value);
 
-        public static explicit operator HPEN(HGDIOBJ value) => new HPEN(value);
-
-        public static implicit operator HGDIOBJ(HPEN value) => (HGDIOBJ)(value.Value);
+        public static implicit operator HGDIOBJ(HPEN value) => new HGDIOBJ(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/HRGN.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/HRGN.Manual.cs
@@ -6,13 +6,8 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct HRGN : IEquatable<HRGN>
     {
-        public HRGN(HGDIOBJ value)
-        {
-            Value = value.Value;
-        }
+        public static explicit operator HRGN(HGDIOBJ value) => new HRGN(value.Value);
 
-        public static explicit operator HRGN(HGDIOBJ value) => new HRGN(value);
-
-        public static implicit operator HGDIOBJ(HRGN value) => (HGDIOBJ)(value.Value);
+        public static implicit operator HGDIOBJ(HRGN value) => new HGDIOBJ(value.Value);
     }
 }

--- a/sources/Interop/Windows/other/helper-types/LPARAM.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/LPARAM.Manual.cs
@@ -7,5 +7,81 @@ namespace TerraFX.Interop
         public static explicit operator LPARAM(void* value) => new LPARAM((nint)(value));
 
         public static implicit operator void*(LPARAM value) => (void*)(value.Value);
+
+        public static explicit operator LPARAM(BOOL value) => new LPARAM(value.Value);
+
+        public static explicit operator BOOL(LPARAM value) => new BOOL((int)(value.Value));
+
+        public static explicit operator LPARAM(HANDLE value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HANDLE(LPARAM value) => new HANDLE((void*)(value.Value));
+
+        public static explicit operator LPARAM(HBRUSH value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HBRUSH(LPARAM value) => new HBRUSH((void*)(value.Value));
+
+        public static explicit operator LPARAM(HCURSOR value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HCURSOR(LPARAM value) => new HCURSOR((void*)(value.Value));
+
+        public static explicit operator LPARAM(HDC value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HDC(LPARAM value) => new HDC((void*)(value.Value));
+
+        public static explicit operator LPARAM(HDROP value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HDROP(LPARAM value) => new HDROP((void*)(value.Value));
+
+        public static explicit operator LPARAM(HFONT value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HFONT(LPARAM value) => new HFONT((void*)(value.Value));
+
+        public static explicit operator LPARAM(HGDIOBJ value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HGDIOBJ(LPARAM value) => new HGDIOBJ((void*)(value.Value));
+
+        public static explicit operator LPARAM(HGLOBAL value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HGLOBAL(LPARAM value) => new HGLOBAL((void*)(value.Value));
+
+        public static explicit operator LPARAM(HICON value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HICON(LPARAM value) => new HICON((void*)(value.Value));
+
+        public static explicit operator LPARAM(HINSTANCE value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HINSTANCE(LPARAM value) => new HINSTANCE((void*)(value.Value));
+
+        public static explicit operator LPARAM(HLOCAL value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HLOCAL(LPARAM value) => new HLOCAL((void*)(value.Value));
+
+        public static explicit operator LPARAM(HMENU value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HMENU(LPARAM value) => new HMENU((void*)(value.Value));
+
+        public static explicit operator LPARAM(HMODULE value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HMODULE(LPARAM value) => new HMODULE((void*)(value.Value));
+
+        public static explicit operator LPARAM(HPALETTE value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HPALETTE(LPARAM value) => new HPALETTE((void*)(value.Value));
+
+        public static explicit operator LPARAM(HPEN value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HPEN(LPARAM value) => new HPEN((void*)(value.Value));
+
+        public static explicit operator LPARAM(HRGN value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HRGN(LPARAM value) => new HRGN((void*)(value.Value));
+
+        public static explicit operator LPARAM(HWND value) => new LPARAM((nint)(value.Value));
+
+        public static explicit operator HWND(LPARAM value) => new HWND((void*)(value.Value));
+
+        public static explicit operator LPARAM(LRESULT value) => new LPARAM(value.Value);
+
+        public static explicit operator LPARAM(WPARAM value) => new LPARAM((nint)(value.Value));
     }
 }

--- a/sources/Interop/Windows/other/helper-types/LRESULT.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/LRESULT.Manual.cs
@@ -1,0 +1,87 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace TerraFX.Interop
+{
+    public unsafe partial struct LRESULT
+    {
+        public static explicit operator LRESULT(void* value) => new LRESULT((nint)(value));
+
+        public static implicit operator void*(LRESULT value) => (void*)(value.Value);
+
+        public static explicit operator LRESULT(BOOL value) => new LRESULT(value.Value);
+
+        public static explicit operator BOOL(LRESULT value) => new BOOL((int)(value.Value));
+
+        public static explicit operator LRESULT(HANDLE value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HANDLE(LRESULT value) => new HANDLE((void*)(value.Value));
+
+        public static explicit operator LRESULT(HBRUSH value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HBRUSH(LRESULT value) => new HBRUSH((void*)(value.Value));
+
+        public static explicit operator LRESULT(HCURSOR value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HCURSOR(LRESULT value) => new HCURSOR((void*)(value.Value));
+
+        public static explicit operator LRESULT(HDC value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HDC(LRESULT value) => new HDC((void*)(value.Value));
+
+        public static explicit operator LRESULT(HDROP value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HDROP(LRESULT value) => new HDROP((void*)(value.Value));
+
+        public static explicit operator LRESULT(HFONT value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HFONT(LRESULT value) => new HFONT((void*)(value.Value));
+
+        public static explicit operator LRESULT(HGDIOBJ value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HGDIOBJ(LRESULT value) => new HGDIOBJ((void*)(value.Value));
+
+        public static explicit operator LRESULT(HGLOBAL value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HGLOBAL(LRESULT value) => new HGLOBAL((void*)(value.Value));
+
+        public static explicit operator LRESULT(HICON value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HICON(LRESULT value) => new HICON((void*)(value.Value));
+
+        public static explicit operator LRESULT(HINSTANCE value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HINSTANCE(LRESULT value) => new HINSTANCE((void*)(value.Value));
+
+        public static explicit operator LRESULT(HLOCAL value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HLOCAL(LRESULT value) => new HLOCAL((void*)(value.Value));
+
+        public static explicit operator LRESULT(HMENU value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HMENU(LRESULT value) => new HMENU((void*)(value.Value));
+
+        public static explicit operator LRESULT(HMODULE value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HMODULE(LRESULT value) => new HMODULE((void*)(value.Value));
+
+        public static explicit operator LRESULT(HPALETTE value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HPALETTE(LRESULT value) => new HPALETTE((void*)(value.Value));
+
+        public static explicit operator LRESULT(HPEN value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HPEN(LRESULT value) => new HPEN((void*)(value.Value));
+
+        public static explicit operator LRESULT(HRGN value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HRGN(LRESULT value) => new HRGN((void*)(value.Value));
+
+        public static explicit operator LRESULT(HWND value) => new LRESULT((nint)(value.Value));
+
+        public static explicit operator HWND(LRESULT value) => new HWND((void*)(value.Value));
+
+        public static explicit operator LRESULT(LPARAM value) => new LRESULT(value.Value);
+
+        public static explicit operator LRESULT(WPARAM value) => new LRESULT((nint)(value.Value));
+    }
+}

--- a/sources/Interop/Windows/other/helper-types/WPARAM.Manual.cs
+++ b/sources/Interop/Windows/other/helper-types/WPARAM.Manual.cs
@@ -7,5 +7,81 @@ namespace TerraFX.Interop
         public static explicit operator WPARAM(void* value) => new WPARAM((nuint)(value));
 
         public static implicit operator void*(WPARAM value) => (void*)(value.Value);
+
+        public static explicit operator WPARAM(BOOL value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator BOOL(WPARAM value) => new BOOL((int)(value.Value));
+
+        public static explicit operator WPARAM(HANDLE value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HANDLE(WPARAM value) => new HANDLE((void*)(value.Value));
+
+        public static explicit operator WPARAM(HBRUSH value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HBRUSH(WPARAM value) => new HBRUSH((void*)(value.Value));
+
+        public static explicit operator WPARAM(HCURSOR value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HCURSOR(WPARAM value) => new HCURSOR((void*)(value.Value));
+
+        public static explicit operator WPARAM(HDC value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HDC(WPARAM value) => new HDC((void*)(value.Value));
+
+        public static explicit operator WPARAM(HDROP value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HDROP(WPARAM value) => new HDROP((void*)(value.Value));
+
+        public static explicit operator WPARAM(HFONT value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HFONT(WPARAM value) => new HFONT((void*)(value.Value));
+
+        public static explicit operator WPARAM(HGDIOBJ value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HGDIOBJ(WPARAM value) => new HGDIOBJ((void*)(value.Value));
+
+        public static explicit operator WPARAM(HGLOBAL value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HGLOBAL(WPARAM value) => new HGLOBAL((void*)(value.Value));
+
+        public static explicit operator WPARAM(HICON value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HICON(WPARAM value) => new HICON((void*)(value.Value));
+
+        public static explicit operator WPARAM(HINSTANCE value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HINSTANCE(WPARAM value) => new HINSTANCE((void*)(value.Value));
+
+        public static explicit operator WPARAM(HLOCAL value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HLOCAL(WPARAM value) => new HLOCAL((void*)(value.Value));
+
+        public static explicit operator WPARAM(HMENU value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HMENU(WPARAM value) => new HMENU((void*)(value.Value));
+
+        public static explicit operator WPARAM(HMODULE value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HMODULE(WPARAM value) => new HMODULE((void*)(value.Value));
+
+        public static explicit operator WPARAM(HPALETTE value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HPALETTE(WPARAM value) => new HPALETTE((void*)(value.Value));
+
+        public static explicit operator WPARAM(HPEN value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HPEN(WPARAM value) => new HPEN((void*)(value.Value));
+
+        public static explicit operator WPARAM(HRGN value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HRGN(WPARAM value) => new HRGN((void*)(value.Value));
+
+        public static explicit operator WPARAM(HWND value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator HWND(WPARAM value) => new HWND((void*)(value.Value));
+
+        public static explicit operator WPARAM(LPARAM value) => new WPARAM((nuint)(value.Value));
+
+        public static explicit operator WPARAM(LRESULT value) => new WPARAM((nuint)(value.Value));
     }
 }

--- a/sources/Interop/Windows/shared/dxgi/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/dxgi/Windows.Manual.cs
@@ -7,24 +7,24 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        public static int D3D_SET_OBJECT_NAME_N_A(IDXGIObject* pObject, uint Chars, sbyte* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_N_A(IDXGIObject* pObject, uint Chars, sbyte* pName)
         {
             var guid = WKPDID_D3DDebugObjectName;
             return pObject->SetPrivateData(&guid, Chars, pName);
         }
 
-        public static int D3D_SET_OBJECT_NAME_A(IDXGIObject* pObject, sbyte* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_A(IDXGIObject* pObject, sbyte* pName)
         {
             return D3D_SET_OBJECT_NAME_N_A(pObject, (uint)lstrlenA(pName), pName);
         }
 
-        public static int D3D_SET_OBJECT_NAME_N_W(IDXGIObject* pObject, uint Chars, ushort* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_N_W(IDXGIObject* pObject, uint Chars, ushort* pName)
         {
             var guid = WKPDID_D3DDebugObjectNameW;
             return pObject->SetPrivateData(&guid, Chars * 2, pName);
         }
 
-        public static int D3D_SET_OBJECT_NAME_W(IDXGIObject* pObject, ushort* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_W(IDXGIObject* pObject, ushort* pName)
         {
             return D3D_SET_OBJECT_NAME_N_W(pObject, (uint)lstrlenW(pName), pName);
         }

--- a/sources/Interop/Windows/shared/dxgitype/DXGI_RGBA.Manual.cs
+++ b/sources/Interop/Windows/shared/dxgitype/DXGI_RGBA.Manual.cs
@@ -9,9 +9,9 @@ namespace TerraFX.Interop
     {
         public DXGI_RGBA([NativeTypeName("UINT32")] uint rgb, float a = 1.0f)
         {
-            this.r = (float)((rgb & sc_redMask) >> (int)sc_redShift) / 255.0f;
-            this.g = (float)((rgb & sc_greenMask) >> (int)sc_greenShift) / 255.0f;
-            this.b = (float)((rgb & sc_blueMask) >> (int)sc_blueShift) / 255.0f;
+            r = (float)((rgb & sc_redMask) >> (int)sc_redShift) / 255.0f;
+            g = (float)((rgb & sc_greenMask) >> (int)sc_greenShift) / 255.0f;
+            b = (float)((rgb & sc_blueMask) >> (int)sc_blueShift) / 255.0f;
             this.a = a;
         }
 

--- a/sources/Interop/Windows/shared/dxgitype/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/dxgitype/Windows.Manual.cs
@@ -7,8 +7,8 @@ namespace TerraFX.Interop
 {
     public static partial class Windows
     {
-        public static int MAKE_DXGI_HRESULT(int code) => MAKE_HRESULT(1, _FACDXGI, code);
+        public static HRESULT MAKE_DXGI_HRESULT(int code) => MAKE_HRESULT(1, _FACDXGI, code);
 
-        public static int MAKE_DXGI_STATUS(int code) => MAKE_HRESULT(0, _FACDXGI, code);
+        public static HRESULT MAKE_DXGI_STATUS(int code) => MAKE_HRESULT(0, _FACDXGI, code);
     }
 }

--- a/sources/Interop/Windows/shared/minwindef/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/Windows.Manual.cs
@@ -13,11 +13,13 @@ namespace TerraFX.Interop
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("WORD")]
-        public static ushort MAKEWORD([NativeTypeName("DWORD_PTR")] nuint a, [NativeTypeName("DWORD_PTR")] nuint b) => ((ushort)(((byte)(((nuint)(a)) & 0xff)) | ((ushort)((byte)(((nuint)(b)) & 0xff))) << 8));
+        public static ushort MAKEWORD([NativeTypeName("DWORD_PTR")] nuint a, [NativeTypeName("DWORD_PTR")] nuint b)
+            => ((ushort)(((byte)(((nuint)(a)) & 0xff)) | ((ushort)((byte)(((nuint)(b)) & 0xff))) << 8));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("LONG")]
-        public static int MAKELONG([NativeTypeName("DWORD_PTR")] nuint a, [NativeTypeName("DWORD_PTR")] nuint b) => ((int)(((ushort)(((nuint)(a)) & 0xffff)) | ((uint)((ushort)(((nuint)(b)) & 0xffff))) << 16));
+        public static int MAKELONG([NativeTypeName("DWORD_PTR")] nuint a, [NativeTypeName("DWORD_PTR")] nuint b)
+            => ((int)(((ushort)(((nuint)(a)) & 0xffff)) | ((uint)((ushort)(((nuint)(b)) & 0xffff))) << 16));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("WORD")]

--- a/sources/Interop/Windows/shared/minwindef/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/minwindef/Windows.Manual.cs
@@ -14,37 +14,43 @@ namespace TerraFX.Interop
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("WORD")]
         public static ushort MAKEWORD([NativeTypeName("DWORD_PTR")] nuint a, [NativeTypeName("DWORD_PTR")] nuint b)
-            => ((ushort)(((byte)(((nuint)(a)) & 0xff)) | ((ushort)((byte)(((nuint)(b)) & 0xff))) << 8));
+            => unchecked((ushort)(((byte)(((nuint)(a)) & 0xff)) | ((ushort)((byte)(((nuint)(b)) & 0xff))) << 8));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort MAKEWORD(nint a, nint b) => unchecked(MAKEWORD((nuint)(a), (nuint)(b)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("LONG")]
         public static int MAKELONG([NativeTypeName("DWORD_PTR")] nuint a, [NativeTypeName("DWORD_PTR")] nuint b)
-            => ((int)(((ushort)(((nuint)(a)) & 0xffff)) | ((uint)((ushort)(((nuint)(b)) & 0xffff))) << 16));
+            => unchecked((int)(((ushort)(((nuint)(a)) & 0xffff)) | ((uint)((ushort)(((nuint)(b)) & 0xffff))) << 16));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int MAKELONG(nint a, nint b) => unchecked(MAKEWORD((nuint)(a), (nuint)(b)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("WORD")]
-        public static ushort LOWORD([NativeTypeName("DWORD_PTR")] nuint l) => ((ushort)(((nuint)(l)) & 0xffff));
+        public static ushort LOWORD([NativeTypeName("DWORD_PTR")] nuint l) => unchecked((ushort)(((nuint)(l)) & 0xffff));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort LOWORD(nint l) => LOWORD((nuint)(l));
+        public static ushort LOWORD(nint l) => unchecked(LOWORD((nuint)(l)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NativeTypeName("WORD")]
         public static ushort HIWORD([NativeTypeName("DWORD_PTR")] nuint l) => ((ushort)((((nuint)(l)) >> 16) & 0xffff));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort HIWORD(nint l) => HIWORD((nuint)(l));
+        public static ushort HIWORD(nint l) => unchecked(HIWORD((nuint)(l)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte LOBYTE([NativeTypeName("DWORD_PTR")] nuint w) => ((byte)(((nuint)(w)) & 0xff));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte LOBYTE(nint w) => LOBYTE((nuint)(w));
+        public static byte LOBYTE(nint w) => unchecked(LOBYTE((nuint)(w)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte HIBYTE([NativeTypeName("DWORD_PTR")] nuint w) => ((byte)((((nuint)(w)) >> 8) & 0xff));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte HIBYTE(nint w) => HIBYTE((nuint)(w));
+        public static byte HIBYTE(nint w) => unchecked(HIBYTE((nuint)(w)));
     }
 }

--- a/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/uuids/Windows.Manual.cs
@@ -76,10 +76,8 @@ namespace TerraFX.Interop
             /// <returns>A pointer to memory holding the <see cref="Guid"/> value for the current type.</returns>
             private static Guid* CreateRIID()
             {
-                Guid* p = (Guid*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(T), sizeof(Guid));
-
+                var p = (Guid*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(T), sizeof(Guid));
                 *p = typeof(T).GUID;
-
                 return p;
             }
         }

--- a/sources/Interop/Windows/shared/windef/POINT.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/POINT.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const POINT &")] in POINT l, [NativeTypeName("const POINT &")] in POINT r)
         {
-            return l.x == r.x && l.y == r.y;
+            return (l.x == r.x)
+                && (l.y == r.y);
         }
 
         public static bool operator !=([NativeTypeName("const POINT &")] in POINT l, [NativeTypeName("const POINT &")] in POINT r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is POINT other) && Equals(other);
 

--- a/sources/Interop/Windows/shared/windef/RECT.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/RECT.Manual.cs
@@ -19,13 +19,14 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const RECT &")] in RECT l, [NativeTypeName("const RECT &")] in RECT r)
         {
-            return l.left == r.left && l.top == r.top && l.right == r.right && l.bottom == r.bottom;
+            return (l.left == r.left)
+                && (l.top == r.top)
+                && (l.right == r.right)
+                && (l.bottom == r.bottom);
         }
 
         public static bool operator !=([NativeTypeName("const RECT &")] in RECT l, [NativeTypeName("const RECT &")] in RECT r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is RECT other) && Equals(other);
 

--- a/sources/Interop/Windows/shared/windef/SIZE.Manual.cs
+++ b/sources/Interop/Windows/shared/windef/SIZE.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const SIZE &")] in SIZE l, [NativeTypeName("const SIZE &")] in SIZE r)
         {
-            return l.cx == r.cx && l.cy == r.cy;
+            return (l.cx == r.cx)
+                && (l.cy == r.cy);
         }
 
         public static bool operator !=([NativeTypeName("const SIZE &")] in SIZE l, [NativeTypeName("const SIZE &")] in SIZE r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is SIZE other) && Equals(other);
 

--- a/sources/Interop/Windows/shared/windowsx/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/windowsx/Windows.Manual.cs
@@ -374,7 +374,7 @@ namespace TerraFX.Interop
             => fn((hwnd), WM_SETTEXT, 0u, (LPARAM)(ushort*)(lpszText));
 
         /* INT Cls_OnGetText(HWND hwnd, int cchTextMax, LPTSTR lpszText) */
-        public static LRESULT HANDLE_WM_GETTEXT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int,ushort*, int> fn)
+        public static LRESULT HANDLE_WM_GETTEXT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, ushort*, int> fn)
             => (LRESULT)(uint)(int)fn((hwnd), (int)(wParam), (ushort*)(lParam));
 
         public static int FORWARD_WM_GETTEXT(HWND hwnd, int cchTextMax, ushort* lpszText, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
@@ -466,7 +466,7 @@ namespace TerraFX.Interop
             => (LRESULT)(uint)(BOOL)fn((hwnd), (HDC)(wParam));
 
         public static BOOL FORWARD_WM_ERASEBKGND(HWND hwnd, HDC hdc, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
-            => (BOOL)(uint)fn((hwnd), WM_ERASEBKGND, (WPARAM)(HDC) (hdc), 0);
+            => (BOOL)(uint)fn((hwnd), WM_ERASEBKGND, (WPARAM)(HDC)(hdc), 0);
 
         /* BOOL Cls_OnIconEraseBkgnd(HWND hwnd, HDC hdc) */
         public static LRESULT HANDLE_WM_ICONERASEBKGND(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, BOOL> fn)
@@ -641,7 +641,7 @@ namespace TerraFX.Interop
         }
 
         public static void FORWARD_WM_SYSDEADCHAR(HWND hwnd, ushort ch, int cRepeat, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
-            => fn((hwnd), WM_SYSDEADCHAR, (WPARAM)(ushort )(ch), MAKELPARAM((cRepeat), 0));
+            => fn((hwnd), WM_SYSDEADCHAR, (WPARAM)(ushort)(ch), MAKELPARAM((cRepeat), 0));
 
         /* void Cls_OnMouseMove(HWND hwnd, int x, int y, UINT keyFlags) */
         public static LRESULT HANDLE_WM_MOUSEMOVE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
@@ -1182,7 +1182,7 @@ namespace TerraFX.Interop
             => (HWND)(nuint)fn((hwnd), WM_MDIGETACTIVE, 0u, 0);
 
         /* HMENU Cls_MDISetMenu(HWND hwnd, BOOL fRefresh, HMENU hmenuFrame, HMENU hmenuWindow) */
-        public static LRESULT HANDLE_WM_MDISETMENU(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND,BOOL, HMENU, HMENU, HMENU> fn)
+        public static LRESULT HANDLE_WM_MDISETMENU(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, HMENU, HMENU, HMENU> fn)
             => (LRESULT)(nuint)fn((hwnd), (BOOL)(wParam), (HMENU)(wParam), (HMENU)(lParam));
 
         public static HMENU FORWARD_WM_MDISETMENU(HWND hwnd, BOOL fRefresh, HMENU hmenuFrame, HMENU hmenuWindow, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
@@ -1307,7 +1307,7 @@ namespace TerraFX.Interop
         }
 
         public static void FORWARD_WM_DRAWITEM(HWND hwnd, DRAWITEMSTRUCT* lpDrawItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
-            => fn((hwnd), WM_DRAWITEM, (WPARAM)(((DRAWITEMSTRUCT*)lpDrawItem)->CtlID), (LPARAM) (DRAWITEMSTRUCT*)(lpDrawItem));
+            => fn((hwnd), WM_DRAWITEM, (WPARAM)(((DRAWITEMSTRUCT*)lpDrawItem)->CtlID), (LPARAM)(DRAWITEMSTRUCT*)(lpDrawItem));
 
         /* void Cls_OnMeasureItem(HWND hwnd, MEASUREITEMSTRUCT * lpMeasureItem) */
         public static LRESULT HANDLE_WM_MEASUREITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, MEASUREITEMSTRUCT*, void> fn)
@@ -1327,14 +1327,14 @@ namespace TerraFX.Interop
         }
 
         public static void FORWARD_WM_DELETEITEM(HWND hwnd, DELETEITEMSTRUCT* lpDeleteItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
-            => fn((hwnd), WM_DELETEITEM, (WPARAM)(((DELETEITEMSTRUCT*)(lpDeleteItem))->CtlID), (LPARAM) (DELETEITEMSTRUCT*)(lpDeleteItem));
+            => fn((hwnd), WM_DELETEITEM, (WPARAM)(((DELETEITEMSTRUCT*)(lpDeleteItem))->CtlID), (LPARAM)(DELETEITEMSTRUCT*)(lpDeleteItem));
 
         /* int Cls_OnCompareItem(HWND hwnd, const COMPAREITEMSTRUCT * lpCompareItem) */
         public static LRESULT HANDLE_WM_COMPAREITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, COMPAREITEMSTRUCT*, int> fn)
             => (LRESULT)(uint)(int)fn((hwnd), (COMPAREITEMSTRUCT*)(lParam));
 
         public static int FORWARD_WM_COMPAREITEM(HWND hwnd, COMPAREITEMSTRUCT* lpCompareItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
-            => (int)(uint)fn((hwnd), WM_COMPAREITEM, (WPARAM)(((COMPAREITEMSTRUCT*)(lpCompareItem))->CtlID), (LPARAM) (COMPAREITEMSTRUCT*)(lpCompareItem));
+            => (int)(uint)fn((hwnd), WM_COMPAREITEM, (WPARAM)(((COMPAREITEMSTRUCT*)(lpCompareItem))->CtlID), (LPARAM)(COMPAREITEMSTRUCT*)(lpCompareItem));
 
         /* int Cls_OnVkeyToItem(HWND hwnd, UINT vk, HWND hwndListbox, int iCaret) */
         public static LRESULT HANDLE_WM_VKEYTOITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HWND, int, int> fn)

--- a/sources/Interop/Windows/shared/windowsx/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/windowsx/Windows.Manual.cs
@@ -1,0 +1,1804 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from shared/windowsx.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop
+{
+    public static unsafe partial class Windows
+    {
+        /****** KERNEL Macro APIs ****************************************************/
+
+        public static HMODULE GetInstanceModule(HINSTANCE hInstance) => (HMODULE)(hInstance);
+
+        public static HGLOBAL GlobalPtrHandle(void* lp) => ((HGLOBAL)GlobalHandle(lp));
+
+        public static BOOL GlobalLockPtr(void* lp) => (BOOL)(nuint)GlobalLock(GlobalPtrHandle(lp));
+
+        public static BOOL GlobalUnlockPtr(void* lp) => GlobalUnlock(GlobalPtrHandle(lp));
+
+        public static void* GlobalAllocPtr(uint flags, nuint cb) => (GlobalLock(GlobalAlloc((flags), (cb))));
+
+        public static BOOL GlobalReAllocPtr(void* lp, nuint cbNew, uint flags)
+        {
+            _ = GlobalUnlockPtr(lp);
+            return (BOOL)(nuint)GlobalLock(GlobalReAlloc(GlobalPtrHandle(lp), (cbNew), (flags)));
+        }
+
+        public static BOOL GlobalFreePtr(void* lp)
+        {
+            _ = GlobalUnlockPtr(lp);
+            return (BOOL)(nuint)GlobalFree(GlobalPtrHandle(lp));
+        }
+
+        /****** GDI Macro APIs *******************************************************/
+
+        public static BOOL DeletePen(HPEN hpen) => DeleteObject((HGDIOBJ)(HPEN)(hpen));
+
+        public static HPEN SelectPen(HDC hdc, HPEN hpen) => ((HPEN)SelectObject((hdc), (HGDIOBJ)(HPEN)(hpen)));
+
+        public static HPEN GetStockPen(int i) => ((HPEN)GetStockObject(i));
+
+        public static BOOL DeleteBrush(HBRUSH hbr) => DeleteObject((HGDIOBJ)(HBRUSH)(hbr));
+
+        public static HBRUSH SelectBrush(HDC hdc, HBRUSH hbr) => ((HBRUSH)SelectObject((hdc), (HGDIOBJ)(HBRUSH)(hbr)));
+
+        public static HBRUSH GetStockBrush(int i) => ((HBRUSH)GetStockObject(i));
+
+        public static BOOL DeleteRgn(HRGN hrgn) => DeleteObject((HGDIOBJ)(HRGN)(hrgn));
+
+        public static int CopyRgn(HRGN hrgnDst, HRGN hrgnSrc) => CombineRgn(hrgnDst, hrgnSrc, HRGN.NULL, RGN_COPY);
+
+        public static int IntersectRgn(HRGN hrgnResult, HRGN hrgnA, HRGN hrgnB) => CombineRgn(hrgnResult, hrgnA, hrgnB, RGN_AND);
+
+        public static int SubtractRgn(HRGN hrgnResult, HRGN hrgnA, HRGN hrgnB) => CombineRgn(hrgnResult, hrgnA, hrgnB, RGN_DIFF);
+
+        public static int UnionRgn(HRGN hrgnResult, HRGN hrgnA, HRGN hrgnB) => CombineRgn(hrgnResult, hrgnA, hrgnB, RGN_OR);
+
+        public static int XorRgn(HRGN hrgnResult, HRGN hrgnA, HRGN hrgnB) => CombineRgn(hrgnResult, hrgnA, hrgnB, RGN_XOR);
+
+        public static BOOL DeletePalette(HPALETTE hpal) => DeleteObject((HGDIOBJ)(HPALETTE)(hpal));
+
+        public static BOOL DeleteFont(HFONT hfont) => DeleteObject((HGDIOBJ)(HFONT)(hfont));
+
+        public static HFONT SelectFont(HDC hdc, HFONT hfont) => ((HFONT)SelectObject((hdc), (HGDIOBJ)(HFONT)(hfont)));
+
+        public static HFONT GetStockFont(int i) => ((HFONT)GetStockObject(i));
+
+        public static BOOL DeleteBitmap(HBITMAP hbm) => DeleteObject((HGDIOBJ)(HBITMAP)(hbm));
+
+        public static HBITMAP SelectBitmap(HDC hdc, HBITMAP hbm) => ((HBITMAP)SelectObject((hdc), (HGDIOBJ)(HBITMAP)(hbm)));
+
+        public static BOOL InsetRect(RECT* lprc, int dx, int dy) => InflateRect((lprc), -(dx), -(dy));
+
+        /****** USER Macro APIs ******************************************************/
+
+        public static HMODULE GetWindowInstance(HWND hwnd) => ((HMODULE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE));
+
+        public static uint GetWindowStyle(HWND hwnd) => ((uint)GetWindowLong(hwnd, GWL_STYLE));
+
+        public static uint GetWindowExStyle(HWND hwnd) => ((uint)GetWindowLong(hwnd, GWL_EXSTYLE));
+
+        public static HWND GetWindowOwner(HWND hwnd) => GetWindow(hwnd, GW_OWNER);
+
+        public static HWND GetFirstChild(HWND hwnd) => GetTopWindow(hwnd);
+
+        public static HWND GetFirstSibling(HWND hwnd) => GetWindow(hwnd, GW_HWNDFIRST);
+
+        public static HWND GetLastSibling(HWND hwnd) => GetWindow(hwnd, GW_HWNDLAST);
+
+        public static HWND GetNextSibling(HWND hwnd) => GetWindow(hwnd, GW_HWNDNEXT);
+
+        public static HWND GetPrevSibling(HWND hwnd) => GetWindow(hwnd, GW_HWNDPREV);
+
+        public static int GetWindowID(HWND hwnd) => GetDlgCtrlID(hwnd);
+
+        public static LRESULT SetWindowRedraw(HWND hwnd, BOOL fRedraw) => SNDMSG(hwnd, WM_SETREDRAW, (WPARAM)(BOOL)(fRedraw), 0);
+
+        public static delegate* unmanaged<HWND, uint, WPARAM, LPARAM, LRESULT> SubclassWindow(HWND hwnd, delegate* unmanaged<HWND, uint, WPARAM, LPARAM, LRESULT> lpfn) => ((delegate* unmanaged<HWND, uint, WPARAM, LPARAM, LRESULT>)SetWindowLongPtr((hwnd), GWLP_WNDPROC, (LPARAM)(delegate* unmanaged<HWND, uint, WPARAM, LPARAM, LRESULT>)(lpfn)));
+
+        public static BOOL IsMinimized(HWND hwnd) => IsIconic(hwnd);
+
+        public static BOOL IsMaximized(HWND hwnd) => IsZoomed(hwnd);
+
+        public static BOOL IsRestored(HWND hwnd) => ((GetWindowStyle(hwnd) & (WS_MINIMIZE | WS_MAXIMIZE)) == 0);
+
+        public static void SetWindowFont(HWND hwnd, HFONT hfont, BOOL fRedraw) => FORWARD_WM_SETFONT((hwnd), (hfont), (fRedraw), SNDMSG);
+
+        public static HFONT GetWindowFont(HWND hwnd) => FORWARD_WM_GETFONT((hwnd), SNDMSG);
+
+        public static int MapWindowRect(HWND hwndFrom, HWND hwndTo, POINT* lprc) => MapWindowPoints((hwndFrom), (hwndTo), (POINT*)(lprc), 2);
+
+        public static BOOL IsLButtonDown() => (GetKeyState(VK_LBUTTON) < 0);
+
+        public static BOOL IsRButtonDown() => (GetKeyState(VK_RBUTTON) < 0);
+
+        public static BOOL IsMButtonDown() => (GetKeyState(VK_MBUTTON) < 0);
+
+        public static nint SubclassDialog(HWND hwndDlg, delegate* unmanaged<HWND, uint, WPARAM, LPARAM, nint> lpfn) => (SetWindowLongPtr(hwndDlg, (int)(DWLP_DLGPROC), (LPARAM)(lpfn)));
+
+        public static BOOL SetDlgMsgResult(HWND hwnd, uint msg, BOOL result)
+        {
+            if ((msg) == WM_CTLCOLORMSGBOX ||
+                (msg) == WM_CTLCOLOREDIT ||
+                (msg) == WM_CTLCOLORLISTBOX ||
+                (msg) == WM_CTLCOLORBTN ||
+                (msg) == WM_CTLCOLORDLG ||
+                (msg) == WM_CTLCOLORSCROLLBAR ||
+                (msg) == WM_CTLCOLORSTATIC ||
+                (msg) == WM_COMPAREITEM ||
+                (msg) == WM_VKEYTOITEM ||
+                (msg) == WM_CHARTOITEM ||
+                (msg) == WM_QUERYDRAGICON ||
+                (msg) == WM_INITDIALOG)
+            {
+                return (BOOL)(result);
+            }
+            else
+            {
+                _ = SetWindowLongPtr((hwnd), DWLP_MSGRESULT, (LPARAM)(LRESULT)(result));
+                return TRUE;
+            }
+        }
+
+        public static LRESULT DefDlgProcEx(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam, BOOL* pfRecursion)
+        {
+            *(pfRecursion) = TRUE;
+            return DefDlgProc(hwnd, msg, wParam, lParam);
+        }
+
+        public static BOOL CheckDefDlgRecursion(BOOL* pfRecursion)
+        {
+            if (*(pfRecursion))
+            {
+                *(pfRecursion) = FALSE;
+                return FALSE;
+            }
+            return TRUE;
+        }
+
+        /****** Message crackers ****************************************************/
+
+        /* void Cls_OnCompacting(HWND hwnd, UINT compactRatio) */
+        public static LRESULT HANDLE_WM_COMPACTING(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_COMPACTING(HWND hwnd, uint compactRatio, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_COMPACTING, (WPARAM)(uint)(compactRatio), 0);
+
+        /* void Cls_OnWinIniChange(HWND hwnd, LPCTSTR lpszSectionName) */
+        public static LRESULT HANDLE_WM_WININICHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort*, void> fn)
+        {
+            fn((hwnd), (ushort*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_WININICHANGE(HWND hwnd, ushort* lpszSectionName, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_WININICHANGE, 0u, (LPARAM)(ushort*)(lpszSectionName));
+
+        /* void Cls_OnSysColorChange(HWND hwnd) */
+        public static LRESULT HANDLE_WM_SYSCOLORCHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_SYSCOLORCHANGE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SYSCOLORCHANGE, 0u, 0);
+
+        /* BOOL Cls_OnQueryNewPalette(HWND hwnd) */
+        public static LRESULT HANDLE_WM_QUERYNEWPALETTE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL> fn)
+            => MAKELRESULT((ushort)(BOOL)fn(hwnd), 0);
+
+        public static BOOL FORWARD_WM_QUERYNEWPALETTE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_QUERYNEWPALETTE, 0u, 0);
+
+        /* void Cls_OnPaletteIsChanging(HWND hwnd, HWND hwndPaletteChange) */
+        public static LRESULT HANDLE_WM_PALETTEISCHANGING(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_PALETTEISCHANGING(HWND hwnd, HWND hwndPaletteChange, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_PALETTEISCHANGING, (WPARAM)(HWND)(hwndPaletteChange), 0);
+
+        /* void Cls_OnPaletteChanged(HWND hwnd, HWND hwndPaletteChange) */
+        public static LRESULT HANDLE_WM_PALETTECHANGED(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_PALETTECHANGED(HWND hwnd, HWND hwndPaletteChange, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_PALETTECHANGED, (WPARAM)(HWND)(hwndPaletteChange), 0);
+
+        /* void Cls_OnFontChange(HWND hwnd) */
+        public static LRESULT HANDLE_WM_FONTCHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_FONTCHANGE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_FONTCHANGE, 0u, 0);
+
+        /* void Cls_OnSpoolerStatus(HWND hwnd, UINT status, int cJobInQueue) */
+        public static LRESULT HANDLE_WM_SPOOLERSTATUS(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, int, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), (int)(short)LOWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SPOOLERSTATUS(HWND hwnd, uint status, ushort cJobInQueue, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SPOOLERSTATUS, (WPARAM)(status), MAKELPARAM((cJobInQueue), 0));
+
+        /* void Cls_OnDevModeChange(HWND hwnd, LPCTSTR lpszDeviceName) */
+        public static LRESULT HANDLE_WM_DEVMODECHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort*, void> fn)
+        {
+            fn((hwnd), (ushort*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_DEVMODECHANGE(HWND hwnd, ushort* lpszDeviceName, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DEVMODECHANGE, 0u, (LPARAM)(ushort*)(lpszDeviceName));
+
+        /* void Cls_OnTimeChange(HWND hwnd) */
+        public static LRESULT HANDLE_WM_TIMECHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_TIMECHANGE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_TIMECHANGE, 0u, 0);
+
+        /* void Cls_OnPower(HWND hwnd, int code) */
+        public static LRESULT HANDLE_WM_POWER(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, void> fn)
+        {
+            fn((hwnd), (int)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_POWER(HWND hwnd, int code, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_POWER, (WPARAM)(int)(code), 0);
+
+        /* BOOL Cls_OnQueryEndSession(HWND hwnd) */
+        public static LRESULT HANDLE_WM_QUERYENDSESSION(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL> fn)
+            => MAKELRESULT((ushort)(BOOL)fn(hwnd), 0);
+
+        public static BOOL FORWARD_WM_QUERYENDSESSION(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_QUERYENDSESSION, 0u, 0);
+
+        /* void Cls_OnEndSession(HWND hwnd, BOOL fEnding) */
+        public static LRESULT HANDLE_WM_ENDSESSION(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, void> fn)
+        {
+            fn((hwnd), (BOOL)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_ENDSESSION(HWND hwnd, BOOL fEnding, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_ENDSESSION, (WPARAM)(BOOL)(fEnding), 0);
+
+        /* void Cls_OnQuit(HWND hwnd, int exitCode) */
+        public static LRESULT HANDLE_WM_QUIT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, void> fn)
+        {
+            fn((hwnd), (int)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_QUIT(HWND hwnd, int exitCode, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_QUIT, (WPARAM)(exitCode), 0);
+
+        /* This message is in Windows 3.1 only */
+        /* void Cls_OnSystemError(HWND hwnd, int errCode) */
+        public static LRESULT HANDLE_WM_SYSTEMERROR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, void> fn) => 0;
+
+        public static void FORWARD_WM_SYSTEMERROR(HWND hwnd, int errCode, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn) { }
+
+        /* BOOL Cls_OnCreate(HWND hwnd, LPCREATESTRUCT lpCreateStruct) */
+        public static LRESULT HANDLE_WM_CREATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, CREATESTRUCTW*, BOOL> fn)
+            => fn((hwnd), (CREATESTRUCTW*)(lParam)) ? 0 : (LRESULT)(-1);
+
+        public static BOOL FORWARD_WM_CREATE(HWND hwnd, CREATESTRUCTW* lpCreateStruct, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_CREATE, 0u, (LPARAM)(CREATESTRUCTW*)(lpCreateStruct));
+
+        /* BOOL Cls_OnNCCreate(HWND hwnd, LPCREATESTRUCT lpCreateStruct) */
+        public static LRESULT HANDLE_WM_NCCREATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, CREATESTRUCTW*, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (CREATESTRUCTW*)(lParam));
+
+        public static BOOL FORWARD_WM_NCCREATE(HWND hwnd, CREATESTRUCTW* lpCreateStruct, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_NCCREATE, 0u, (LPARAM)(CREATESTRUCTW*)(lpCreateStruct));
+
+        /* void Cls_OnDestroy(HWND hwnd) */
+        public static LRESULT HANDLE_WM_DESTROY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_DESTROY(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DESTROY, 0u, 0);
+
+        /* void Cls_OnNCDestroy(HWND hwnd) */
+        public static LRESULT HANDLE_WM_NCDESTROY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCDESTROY(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_NCDESTROY, 0u, 0);
+
+        /* void Cls_OnShowWindow(HWND hwnd, BOOL fShow, UINT status) */
+        public static LRESULT HANDLE_WM_SHOWWINDOW(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, uint, void> fn)
+        {
+            fn((hwnd), (BOOL)(wParam), (uint)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SHOWWINDOW(HWND hwnd, BOOL fShow, uint status, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SHOWWINDOW, (WPARAM)(BOOL)(fShow), (LPARAM)(uint)(status));
+
+        /* void Cls_OnSetRedraw(HWND hwnd, BOOL fRedraw) */
+        public static LRESULT HANDLE_WM_SETREDRAW(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, void> fn)
+        {
+            fn((hwnd), (BOOL)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SETREDRAW(HWND hwnd, BOOL fRedraw, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SETREDRAW, (WPARAM)(BOOL)(fRedraw), 0);
+
+        /* void Cls_OnEnable(HWND hwnd, BOOL fEnable) */
+        public static LRESULT HANDLE_WM_ENABLE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, void> fn)
+        {
+            fn((hwnd), (BOOL)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_ENABLE(HWND hwnd, BOOL fEnable, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_ENABLE, (WPARAM)(BOOL)(fEnable), 0);
+
+        /* void Cls_OnSetText(HWND hwnd, LPCTSTR lpszText) */
+        public static LRESULT HANDLE_WM_SETTEXT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort*, void> fn)
+        {
+            fn((hwnd), (ushort*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SETTEXT(HWND hwnd, ushort* lpszText, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SETTEXT, 0u, (LPARAM)(ushort*)(lpszText));
+
+        /* INT Cls_OnGetText(HWND hwnd, int cchTextMax, LPTSTR lpszText) */
+        public static LRESULT HANDLE_WM_GETTEXT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int,ushort*, int> fn)
+            => (LRESULT)(uint)(int)fn((hwnd), (int)(wParam), (ushort*)(lParam));
+
+        public static int FORWARD_WM_GETTEXT(HWND hwnd, int cchTextMax, ushort* lpszText, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (int)(uint)fn((hwnd), WM_GETTEXT, (WPARAM)(int)(cchTextMax), (LPARAM)(ushort*)(lpszText));
+
+        /* INT Cls_OnGetTextLength(HWND hwnd) */
+        public static LRESULT HANDLE_WM_GETTEXTLENGTH(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int> fn)
+            => (LRESULT)(uint)(int)fn(hwnd);
+
+        public static int FORWARD_WM_GETTEXTLENGTH(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (int)(uint)fn((hwnd), WM_GETTEXTLENGTH, 0u, 0);
+
+        /* BOOL Cls_OnWindowPosChanging(HWND hwnd, LPWINDOWPOS lpwpos) */
+        public static LRESULT HANDLE_WM_WINDOWPOSCHANGING(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, WINDOWPOS*, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (WINDOWPOS*)(lParam));
+
+        public static BOOL FORWARD_WM_WINDOWPOSCHANGING(HWND hwnd, WINDOWPOS* lpwpos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_WINDOWPOSCHANGING, 0u, (LPARAM)(WINDOWPOS*)(lpwpos));
+
+        /* void Cls_OnWindowPosChanged(HWND hwnd, const LPWINDOWPOS lpwpos) */
+        public static LRESULT HANDLE_WM_WINDOWPOSCHANGED(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, WINDOWPOS*, void> fn)
+        {
+            fn((hwnd), (WINDOWPOS*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_WINDOWPOSCHANGED(HWND hwnd, WINDOWPOS* lpwpos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_WINDOWPOSCHANGED, 0u, (LPARAM)(WINDOWPOS*)(lpwpos));
+
+        /* void Cls_OnMove(HWND hwnd, int x, int y) */
+        public static LRESULT HANDLE_WM_MOVE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MOVE(HWND hwnd, int x, int y, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MOVE, 0u, MAKELPARAM((x), (y)));
+
+        /* void Cls_OnSize(HWND hwnd, UINT state, int cx, int cy) */
+        public static LRESULT HANDLE_WM_SIZE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, int, int, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SIZE(HWND hwnd, uint state, int cx, int cy, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SIZE, (WPARAM)(uint)(state), MAKELPARAM((cx), (cy)));
+
+        /* void Cls_OnClose(HWND hwnd) */
+        public static LRESULT HANDLE_WM_CLOSE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_CLOSE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CLOSE, 0u, 0);
+
+        /* BOOL Cls_OnQueryOpen(HWND hwnd) */
+        public static LRESULT HANDLE_WM_QUERYOPEN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL> fn)
+            => MAKELRESULT((BOOL)fn(hwnd), 0);
+
+        public static BOOL FORWARD_WM_QUERYOPEN(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_QUERYOPEN, 0u, 0);
+
+        /* void Cls_OnGetMinMaxInfo(HWND hwnd, LPMINMAXINFO lpMinMaxInfo) */
+        public static LRESULT HANDLE_WM_GETMINMAXINFO(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, MINMAXINFO*, void> fn)
+        {
+            fn((hwnd), (MINMAXINFO*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_GETMINMAXINFO(HWND hwnd, MINMAXINFO* lpMinMaxInfo, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_GETMINMAXINFO, 0u, (LPARAM)(MINMAXINFO*)(lpMinMaxInfo));
+
+        /* void Cls_OnPaint(HWND hwnd) */
+        public static LRESULT HANDLE_WM_PAINT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_PAINT(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_PAINT, 0u, 0);
+
+        /* BOOL Cls_OnEraseBkgnd(HWND hwnd, HDC hdc) */
+        public static LRESULT HANDLE_WM_ERASEBKGND(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (HDC)(wParam));
+
+        public static BOOL FORWARD_WM_ERASEBKGND(HWND hwnd, HDC hdc, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_ERASEBKGND, (WPARAM)(HDC) (hdc), 0);
+
+        /* BOOL Cls_OnIconEraseBkgnd(HWND hwnd, HDC hdc) */
+        public static LRESULT HANDLE_WM_ICONERASEBKGND(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (HDC)(wParam));
+
+        public static BOOL FORWARD_WM_ICONERASEBKGND(HWND hwnd, HDC hdc, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_ICONERASEBKGND, (WPARAM)(HDC)(hdc), 0);
+
+        /* void Cls_OnNCPaint(HWND hwnd, HRGN hrgn) */
+        public static LRESULT HANDLE_WM_NCPAINT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HRGN, void> fn)
+        {
+            fn((hwnd), (HRGN)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCPAINT(HWND hwnd, HRGN hrgn, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_NCPAINT, (WPARAM)(HRGN)(hrgn), 0);
+
+        /* UINT Cls_OnNCCalcSize(HWND hwnd, BOOL fCalcValidRects, NCCALCSIZE_PARAMS * lpcsp) */
+        public static LRESULT HANDLE_WM_NCCALCSIZE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, NCCALCSIZE_PARAMS*, uint> fn)
+            => (LRESULT)(uint)(uint)fn((hwnd), (BOOL)(wParam), (NCCALCSIZE_PARAMS*)(lParam));
+
+        public static uint FORWARD_WM_NCCALCSIZE(HWND hwnd, BOOL fCalcValidRects, NCCALCSIZE_PARAMS* lpcsp, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (uint)(uint)fn((hwnd), WM_NCCALCSIZE, (WPARAM)(fCalcValidRects), (LPARAM)(NCCALCSIZE_PARAMS*)(lpcsp));
+
+        /* UINT Cls_OnNCHitTest(HWND hwnd, int x, int y) */
+        public static LRESULT HANDLE_WM_NCHITTEST(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint> fn)
+            => (LRESULT)(uint)(uint)fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam));
+
+        public static uint FORWARD_WM_NCHITTEST(HWND hwnd, int x, int y, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (uint)(uint)fn((hwnd), WM_NCHITTEST, 0u, MAKELPARAM((x), (y)));
+
+        /* HICON Cls_OnQueryDragIcon(HWND hwnd) */
+        public static LRESULT HANDLE_WM_QUERYDRAGICON(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HICON> fn)
+            => (LRESULT)(uint)(uint)fn(hwnd);
+
+        public static HICON FORWARD_WM_QUERYDRAGICON(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HICON)(uint)(uint)fn((hwnd), WM_QUERYDRAGICON, 0u, 0);
+
+        /* void Cls_OnDropFiles(HWND hwnd, HDROP hdrop) */
+        public static LRESULT HANDLE_WM_DROPFILES(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDROP, void> fn)
+        {
+            fn((hwnd), (HDROP)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_DROPFILES(HWND hwnd, HDROP hdrop, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DROPFILES, (WPARAM)(HDROP)(hdrop), 0);
+
+        /* void Cls_OnActivate(HWND hwnd, UINT state, HWND hwndActDeact, BOOL fMinimized) */
+        public static LRESULT HANDLE_WM_ACTIVATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HWND, BOOL, void> fn)
+        {
+            fn((hwnd), (uint)LOWORD(wParam), (HWND)(lParam), (BOOL)HIWORD(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_ACTIVATE(HWND hwnd, uint state, HWND hwndActDeact, BOOL fMinimized, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_ACTIVATE, MAKEWPARAM((state), (nuint)(fMinimized)), (LPARAM)(HWND)(hwndActDeact));
+
+        /* void Cls_OnActivateApp(HWND hwnd, BOOL fActivate, DWORD dwThreadId) */
+        public static LRESULT HANDLE_WM_ACTIVATEAPP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, uint, void> fn)
+        {
+            fn((hwnd), (BOOL)(wParam), (uint)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_ACTIVATEAPP(HWND hwnd, BOOL fActivate, uint dwThreadId, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_ACTIVATEAPP, (WPARAM)(BOOL)(fActivate), (LPARAM)(dwThreadId));
+
+        /* BOOL Cls_OnNCActivate(HWND hwnd, BOOL fActive, HWND hwndActDeact, BOOL fMinimized) */
+        public static LRESULT HANDLE_WM_NCACTIVATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, HWND, BOOL, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (BOOL)(wParam), HWND.NULL, 0);
+
+        public static BOOL FORWARD_WM_NCACTIVATE(HWND hwnd, BOOL fActive, HWND hwndActDeact, BOOL fMinimized, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_NCACTIVATE, (WPARAM)(BOOL)(fActive), 0);
+
+        /* void Cls_OnSetFocus(HWND hwnd, HWND hwndOldFocus) */
+        public static LRESULT HANDLE_WM_SETFOCUS(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SETFOCUS(HWND hwnd, HWND hwndOldFocus, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SETFOCUS, (WPARAM)(HWND)(hwndOldFocus), 0);
+
+        /* void Cls_OnKillFocus(HWND hwnd, HWND hwndNewFocus) */
+        public static LRESULT HANDLE_WM_KILLFOCUS(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_KILLFOCUS(HWND hwnd, HWND hwndNewFocus, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_KILLFOCUS, (WPARAM)(HWND)(hwndNewFocus), 0);
+
+        /* void Cls_OnKey(HWND hwnd, UINT vk, BOOL fDown, int cRepeat, UINT flags) */
+        public static LRESULT HANDLE_WM_KEYDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, BOOL, int, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), TRUE, (int)(short)LOWORD(lParam), (uint)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_KEYDOWN(HWND hwnd, uint vk, int cRepeat, uint flags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_KEYDOWN, (WPARAM)(uint)(vk), MAKELPARAM((nuint)(cRepeat), (flags)));
+
+        /* void Cls_OnKey(HWND hwnd, UINT vk, BOOL fDown, int cRepeat, UINT flags) */
+        public static LRESULT HANDLE_WM_KEYUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, BOOL, int, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), FALSE, (int)(short)LOWORD(lParam), (uint)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_KEYUP(HWND hwnd, uint vk, int cRepeat, uint flags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_KEYUP, (WPARAM)(uint)(vk), MAKELPARAM((nuint)(cRepeat), (flags)));
+
+        /* void Cls_OnChar(HWND hwnd, TCHAR ch, int cRepeat) */
+        public static LRESULT HANDLE_WM_CHAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort, int, void> fn)
+        {
+            fn((hwnd), (ushort)(wParam), (int)(short)LOWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_CHAR(HWND hwnd, ushort ch, int cRepeat, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CHAR, (WPARAM)(ushort)(ch), MAKELPARAM((cRepeat), 0));
+
+        /* void Cls_OnDeadChar(HWND hwnd, TCHAR ch, int cRepeat) */
+        public static LRESULT HANDLE_WM_DEADCHAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort, int, void> fn)
+        {
+            fn((hwnd), (ushort)(wParam), (int)(short)LOWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_DEADCHAR(HWND hwnd, ushort ch, int cRepeat, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DEADCHAR, (WPARAM)(ushort)(ch), MAKELPARAM((cRepeat), 0));
+
+        /* void Cls_OnSysKey(HWND hwnd, UINT vk, BOOL fDown, int cRepeat, UINT flags) */
+        public static LRESULT HANDLE_WM_SYSKEYDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, BOOL, int, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), TRUE, (int)(short)LOWORD(lParam), (uint)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SYSKEYDOWN(HWND hwnd, uint vk, int cRepeat, uint flags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SYSKEYDOWN, (WPARAM)(uint)(vk), MAKELPARAM((nuint)(cRepeat), (flags)));
+
+        /* void Cls_OnSysKey(HWND hwnd, UINT vk, BOOL fDown, int cRepeat, UINT flags) */
+        public static LRESULT HANDLE_WM_SYSKEYUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, BOOL, int, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), FALSE, (int)(short)LOWORD(lParam), (uint)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SYSKEYUP(HWND hwnd, uint vk, int cRepeat, uint flags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SYSKEYUP, (WPARAM)(uint)(vk), MAKELPARAM((nuint)(cRepeat), (flags)));
+
+        /* void Cls_OnSysChar(HWND hwnd, TCHAR ch, int cRepeat) */
+        public static LRESULT HANDLE_WM_SYSCHAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort, int, void> fn)
+        {
+            fn((hwnd), (ushort)(wParam), (int)(short)LOWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SYSCHAR(HWND hwnd, ushort ch, int cRepeat, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SYSCHAR, (WPARAM)(ushort)(ch), MAKELPARAM((cRepeat), 0));
+
+        /* void Cls_OnSysDeadChar(HWND hwnd, TCHAR ch, int cRepeat) */
+        public static LRESULT HANDLE_WM_SYSDEADCHAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, ushort, int, void> fn)
+        {
+            fn((hwnd), (ushort)(wParam), (int)(short)LOWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SYSDEADCHAR(HWND hwnd, ushort ch, int cRepeat, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SYSDEADCHAR, (WPARAM)(ushort )(ch), MAKELPARAM((cRepeat), 0));
+
+        /* void Cls_OnMouseMove(HWND hwnd, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_MOUSEMOVE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MOUSEMOVE(HWND hwnd, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MOUSEMOVE, (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_LBUTTONDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), FALSE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_LBUTTONDOWN(HWND hwnd, BOOL fDoubleClick, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), (uint)((fDoubleClick) ? WM_LBUTTONDBLCLK : WM_LBUTTONDOWN), (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_LBUTTONDBLCLK(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), TRUE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        /* void Cls_OnLButtonUp(HWND hwnd, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_LBUTTONUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_LBUTTONUP(HWND hwnd, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_LBUTTONUP, (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnRButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_RBUTTONDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), FALSE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_RBUTTONDOWN(HWND hwnd, BOOL fDoubleClick, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), (uint)((fDoubleClick) ? WM_RBUTTONDBLCLK : WM_RBUTTONDOWN), (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnRButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_RBUTTONDBLCLK(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), TRUE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        /* void Cls_OnRButtonUp(HWND hwnd, int x, int y, UINT flags) */
+        public static LRESULT HANDLE_WM_RBUTTONUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_RBUTTONUP(HWND hwnd, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_RBUTTONUP, (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnMButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_MBUTTONDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), FALSE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MBUTTONDOWN(HWND hwnd, BOOL fDoubleClick, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), (uint)((fDoubleClick) ? WM_MBUTTONDBLCLK : WM_MBUTTONDOWN), (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnMButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags) */
+        public static LRESULT HANDLE_WM_MBUTTONDBLCLK(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), TRUE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        /* void Cls_OnMButtonUp(HWND hwnd, int x, int y, UINT flags) */
+        public static LRESULT HANDLE_WM_MBUTTONUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MBUTTONUP(HWND hwnd, int x, int y, uint keyFlags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MBUTTONUP, (WPARAM)(uint)(keyFlags), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnMouseWheel(HWND hwnd, int xPos, int yPos, int zDelta, UINT fwKeys) */
+        public static LRESULT HANDLE_WM_MOUSEWHEEL(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (int)(short)HIWORD(wParam), (uint)(short)LOWORD(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MOUSEWHEEL(HWND hwnd, int xPos, int yPos, int zDelta, uint fwKeys, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MOUSEWHEEL, MAKEWPARAM((fwKeys), (nuint)(zDelta)), MAKELPARAM((xPos), (yPos)));
+
+        /* void Cls_OnNCMouseMove(HWND hwnd, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCMOUSEMOVE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCMOUSEMOVE(HWND hwnd, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_NCMOUSEMOVE, (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnNCLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCLBUTTONDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), FALSE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCLBUTTONDOWN(HWND hwnd, BOOL fDoubleClick, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), (uint)((fDoubleClick) ? WM_NCLBUTTONDBLCLK : WM_NCLBUTTONDOWN), (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnNCLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCLBUTTONDBLCLK(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), TRUE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        /* void Cls_OnNCLButtonUp(HWND hwnd, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCLBUTTONUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCLBUTTONUP(HWND hwnd, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_NCLBUTTONUP, (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnNCRButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCRBUTTONDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), FALSE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCRBUTTONDOWN(HWND hwnd, BOOL fDoubleClick, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), (uint)((fDoubleClick) ? WM_NCRBUTTONDBLCLK : WM_NCRBUTTONDOWN), (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnNCRButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCRBUTTONDBLCLK(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), TRUE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        /* void Cls_OnNCRButtonUp(HWND hwnd, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCRBUTTONUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCRBUTTONUP(HWND hwnd, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_NCRBUTTONUP, (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnNCMButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCMBUTTONDOWN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), FALSE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCMBUTTONDOWN(HWND hwnd, BOOL fDoubleClick, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), (uint)((fDoubleClick) ? WM_NCMBUTTONDBLCLK : WM_NCMBUTTONDOWN), (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* void Cls_OnNCMButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCMBUTTONDBLCLK(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, int, int, uint, void> fn)
+        {
+            fn((hwnd), TRUE, (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        /* void Cls_OnNCMButtonUp(HWND hwnd, int x, int y, UINT codeHitTest) */
+        public static LRESULT HANDLE_WM_NCMBUTTONUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_NCMBUTTONUP(HWND hwnd, int x, int y, uint codeHitTest, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_NCMBUTTONUP, (WPARAM)(uint)(codeHitTest), MAKELPARAM((x), (y)));
+
+        /* int Cls_OnMouseActivate(HWND hwnd, HWND hwndTopLevel, UINT codeHitTest, UINT msg) */
+        public static LRESULT HANDLE_WM_MOUSEACTIVATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, uint, int> fn)
+            => (LRESULT)(uint)(int)fn((hwnd), (HWND)(wParam), (uint)LOWORD(lParam), (uint)HIWORD(lParam));
+
+        public static int FORWARD_WM_MOUSEACTIVATE(HWND hwnd, HWND hwndTopLevel, uint codeHitTest, uint msg, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (int)(uint)fn((hwnd), WM_MOUSEACTIVATE, (WPARAM)(HWND)(hwndTopLevel), MAKELPARAM((codeHitTest), (msg)));
+
+        /* void Cls_OnCancelMode(HWND hwnd) */
+        public static LRESULT HANDLE_WM_CANCELMODE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_CANCELMODE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CANCELMODE, 0u, 0);
+
+        /* void Cls_OnTimer(HWND hwnd, UINT id) */
+        public static LRESULT HANDLE_WM_TIMER(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_TIMER(HWND hwnd, uint id, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_TIMER, (WPARAM)(uint)(id), 0);
+
+        /* void Cls_OnInitMenu(HWND hwnd, HMENU hMenu) */
+        public static LRESULT HANDLE_WM_INITMENU(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HMENU, void> fn)
+        {
+            fn((hwnd), (HMENU)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_INITMENU(HWND hwnd, HMENU hMenu, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_INITMENU, (WPARAM)(HMENU)(hMenu), 0);
+
+        /* void Cls_OnInitMenuPopup(HWND hwnd, HMENU hMenu, UINT item, BOOL fSystemMenu) */
+        public static LRESULT HANDLE_WM_INITMENUPOPUP(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HMENU, uint, BOOL, void> fn)
+        {
+            fn((hwnd), (HMENU)(wParam), (uint)LOWORD(lParam), (BOOL)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_INITMENUPOPUP(HWND hwnd, HMENU hMenu, uint item, BOOL fSystemMenu, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_INITMENUPOPUP, (WPARAM)(HMENU)(hMenu), MAKELPARAM((item), (nuint)(fSystemMenu)));
+
+        /* void Cls_OnMenuSelect(HWND hwnd, HMENU hmenu, int item, HMENU hmenuPopup, UINT flags) */
+        public static LRESULT HANDLE_WM_MENUSELECT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HMENU, int, HMENU, uint, void> fn)
+        {
+            fn((hwnd), (HMENU)(lParam), ((HIWORD(wParam) & MF_POPUP) != 0) ? 0 : (int)(LOWORD(wParam)), ((HIWORD(wParam) & MF_POPUP) != 0) ? GetSubMenu((HMENU)lParam, LOWORD(wParam)) : HMENU.NULL, (uint)(((short)HIWORD(wParam) == -1) ? 0xFFFFFFFF : HIWORD(wParam)));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MENUSELECT(HWND hwnd, HMENU hmenu, int item, HMENU hmenuPopup, uint flags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MENUSELECT, MAKEWPARAM((nuint)(item), (flags)), (LPARAM)(HMENU)((hmenu != HMENU.NULL) ? (hmenu) : (hmenuPopup)));
+
+        /* DWORD Cls_OnMenuChar(HWND hwnd, UINT ch, UINT flags, HMENU hmenu) */
+        public static LRESULT HANDLE_WM_MENUCHAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, uint, HMENU, uint> fn)
+            => (LRESULT)(uint)fn((hwnd), (uint)(LOWORD(wParam)), (uint)HIWORD(wParam), (HMENU)(lParam));
+
+        public static uint FORWARD_WM_MENUCHAR(HWND hwnd, uint ch, uint flags, HMENU hmenu, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (uint)fn((hwnd), WM_MENUCHAR, MAKEWPARAM(flags, (ushort)(ch)), (LPARAM)(HMENU)(hmenu));
+
+        /* void Cls_OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify) */
+        public static LRESULT HANDLE_WM_COMMAND(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, HWND, uint, void> fn)
+        {
+            fn((hwnd), (int)(LOWORD(wParam)), (HWND)(lParam), (uint)HIWORD(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_COMMAND(HWND hwnd, int id, HWND hwndCtl, uint codeNotify, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_COMMAND, MAKEWPARAM((uint)(id), (uint)(codeNotify)), (LPARAM)(HWND)(hwndCtl));
+
+        /* void Cls_OnHScroll(HWND hwnd, HWND hwndCtl, UINT code, int pos) */
+        public static LRESULT HANDLE_WM_HSCROLL(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, int, void> fn)
+        {
+            fn((hwnd), (HWND)(lParam), (uint)(LOWORD(wParam)), (int)(short)HIWORD(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_HSCROLL(HWND hwnd, HWND hwndCtl, uint code, int pos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_HSCROLL, MAKEWPARAM((uint)(int)(code), (uint)(int)(pos)), (LPARAM)(HWND)(hwndCtl));
+
+        /* void Cls_OnVScroll(HWND hwnd, HWND hwndCtl, UINT code, int pos) */
+        public static LRESULT HANDLE_WM_VSCROLL(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, int, void> fn)
+        {
+            fn((hwnd), (HWND)(lParam), (uint)(LOWORD(wParam)), (int)(short)HIWORD(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_VSCROLL(HWND hwnd, HWND hwndCtl, uint code, int pos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_VSCROLL, MAKEWPARAM((uint)(int)(code), (uint)(int)(pos)), (LPARAM)(HWND)(hwndCtl));
+
+        /* void Cls_OnCut(HWND hwnd) */
+        public static LRESULT HANDLE_WM_CUT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_CUT(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CUT, 0u, 0);
+
+        /* void Cls_OnCopy(HWND hwnd) */
+        public static LRESULT HANDLE_WM_COPY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_COPY(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_COPY, 0u, 0);
+
+        /* void Cls_OnPaste(HWND hwnd) */
+        public static LRESULT HANDLE_WM_PASTE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_PASTE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_PASTE, 0u, 0);
+
+        /* void Cls_OnClear(HWND hwnd) */
+        public static LRESULT HANDLE_WM_CLEAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_CLEAR(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CLEAR, 0u, 0);
+
+        /* void Cls_OnUndo(HWND hwnd) */
+        public static LRESULT HANDLE_WM_UNDO(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_UNDO(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_UNDO, 0u, 0);
+
+        /* HANDLE Cls_OnRenderFormat(HWND hwnd, UINT fmt) */
+        public static LRESULT HANDLE_WM_RENDERFORMAT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HANDLE> fn)
+            => (LRESULT)(nuint)(HANDLE)fn((hwnd), (uint)(wParam));
+
+        public static HANDLE FORWARD_WM_RENDERFORMAT(HWND hwnd, uint fmt, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HANDLE)(nuint)fn((hwnd), WM_RENDERFORMAT, (WPARAM)(uint)(fmt), 0);
+
+        /* void Cls_OnRenderAllFormats(HWND hwnd) */
+        public static LRESULT HANDLE_WM_RENDERALLFORMATS(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_RENDERALLFORMATS(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_RENDERALLFORMATS, 0u, 0);
+
+        /* void Cls_OnDestroyClipboard(HWND hwnd) */
+        public static LRESULT HANDLE_WM_DESTROYCLIPBOARD(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_DESTROYCLIPBOARD(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DESTROYCLIPBOARD, 0u, 0);
+
+        /* void Cls_OnDrawClipboard(HWND hwnd) */
+        public static LRESULT HANDLE_WM_DRAWCLIPBOARD(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_DRAWCLIPBOARD(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DRAWCLIPBOARD, 0u, 0);
+
+        /* void Cls_OnPaintClipboard(HWND hwnd, HWND hwndCBViewer, const LPPAINTSTRUCT lpPaintStruct) */
+        public static LRESULT HANDLE_WM_PAINTCLIPBOARD(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, PAINTSTRUCT*, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam), (PAINTSTRUCT*)GlobalLock((HGLOBAL)(lParam)));
+            _ = GlobalUnlock((HGLOBAL)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_PAINTCLIPBOARD(HWND hwnd, HWND hwndCBViewer, PAINTSTRUCT* lpPaintStruct, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_PAINTCLIPBOARD, (WPARAM)(HWND)(hwndCBViewer), (LPARAM)(PAINTSTRUCT*)(lpPaintStruct));
+
+        /* void Cls_OnSizeClipboard(HWND hwnd, HWND hwndCBViewer, const LPRECT lprc) */
+        public static LRESULT HANDLE_WM_SIZECLIPBOARD(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, RECT*, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam), (RECT*)GlobalLock((HGLOBAL)(lParam)));
+            _ = GlobalUnlock((HGLOBAL)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SIZECLIPBOARD(HWND hwnd, HWND hwndCBViewer, RECT* lprc, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SIZECLIPBOARD, (WPARAM)(HWND)(hwndCBViewer), (LPARAM)(RECT*)(lprc));
+
+        /* void Cls_OnVScrollClipboard(HWND hwnd, HWND hwndCBViewer, UINT code, int pos) */
+        public static LRESULT HANDLE_WM_VSCROLLCLIPBOARD(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, int, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam), (uint)LOWORD(lParam), (int)(short)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_VSCROLLCLIPBOARD(HWND hwnd, HWND hwndCBViewer, uint code, int pos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_VSCROLLCLIPBOARD, (WPARAM)(HWND)(hwndCBViewer), MAKELPARAM((code), (nuint)(pos)));
+
+        /* void Cls_OnHScrollClipboard(HWND hwnd, HWND hwndCBViewer, UINT code, int pos) */
+        public static LRESULT HANDLE_WM_HSCROLLCLIPBOARD(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, int, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam), (uint)LOWORD(lParam), (int)(short)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_HSCROLLCLIPBOARD(HWND hwnd, HWND hwndCBViewer, uint code, int pos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_HSCROLLCLIPBOARD, (WPARAM)(HWND)(hwndCBViewer), MAKELPARAM((code), (nuint)(pos)));
+
+        /* void Cls_OnAskCBFormatName(HWND hwnd, int cchMax, LPTSTR rgchName) */
+        public static LRESULT HANDLE_WM_ASKCBFORMATNAME(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, ushort*, void> fn)
+        {
+            fn((hwnd), (int)(wParam), (ushort*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_ASKCBFORMATNAME(HWND hwnd, int cchMax, ushort* rgchName, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_ASKCBFORMATNAME, (WPARAM)(int)(cchMax), (LPARAM)(rgchName));
+
+        /* void Cls_OnChangeCBChain(HWND hwnd, HWND hwndRemove, HWND hwndNext) */
+        public static LRESULT HANDLE_WM_CHANGECBCHAIN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam), (HWND)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_CHANGECBCHAIN(HWND hwnd, HWND hwndRemove, HWND hwndNext, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CHANGECBCHAIN, (WPARAM)(HWND)(hwndRemove), (LPARAM)(HWND)(hwndNext));
+
+        /* BOOL Cls_OnSetCursor(HWND hwnd, HWND hwndCursor, UINT codeHitTest, UINT msg) */
+        public static LRESULT HANDLE_WM_SETCURSOR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, uint, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (HWND)(wParam), (uint)LOWORD(lParam), (uint)HIWORD(lParam));
+
+        public static BOOL FORWARD_WM_SETCURSOR(HWND hwnd, HWND hwndCursor, uint codeHitTest, uint msg, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_SETCURSOR, (WPARAM)(HWND)(hwndCursor), MAKELPARAM((codeHitTest), (msg)));
+
+        /* void Cls_OnSysCommand(HWND hwnd, UINT cmd, int x, int y) */
+        public static LRESULT HANDLE_WM_SYSCOMMAND(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, int, int, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SYSCOMMAND(HWND hwnd, uint cmd, int x, int y, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SYSCOMMAND, (WPARAM)(uint)(cmd), MAKELPARAM((x), (y)));
+
+        /* HWND Cls_MDICreate(HWND hwnd, const LPMDICREATESTRUCT lpmcs) */
+        public static LRESULT HANDLE_WM_MDICREATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, MDICREATESTRUCTW*, HWND> fn)
+            => (LRESULT)(uint)(uint)fn((hwnd), (MDICREATESTRUCTW*)(lParam));
+
+        public static HWND FORWARD_WM_MDICREATE(HWND hwnd, MDICREATESTRUCTW* lpmcs, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HWND)(uint)(uint)fn((hwnd), WM_MDICREATE, 0u, (LPARAM)(MDICREATESTRUCTW*)(lpmcs));
+
+        /* void Cls_MDIDestroy(HWND hwnd, HWND hwndDestroy) */
+        public static LRESULT HANDLE_WM_MDIDESTROY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MDIDESTROY(HWND hwnd, HWND hwndDestroy, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MDIDESTROY, (WPARAM)(hwndDestroy), 0);
+
+        /* NOTE: Usable only by MDI client windows */
+        /* void Cls_MDIActivate(HWND hwnd, BOOL fActive, HWND hwndActivate, HWND hwndDeactivate) */
+        public static LRESULT HANDLE_WM_MDIACTIVATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, BOOL, HWND, HWND, void> fn)
+        {
+            fn((hwnd), (BOOL)(lParam == (LPARAM)hwnd), (HWND)(lParam), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MDIACTIVATE(HWND hwnd, BOOL fActive, HWND hwndActivate, HWND hwndDeactivate, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn(hwnd, WM_MDIACTIVATE, (WPARAM)(hwndDeactivate), (LPARAM)(hwndActivate));
+
+        /* void Cls_MDIRestore(HWND hwnd, HWND hwndRestore) */
+        public static LRESULT HANDLE_WM_MDIRESTORE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MDIRESTORE(HWND hwnd, HWND hwndRestore, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MDIRESTORE, (WPARAM)(hwndRestore), 0);
+
+        /* HWND Cls_MDINext(HWND hwnd, HWND hwndCur, BOOL fPrev) */
+        public static LRESULT HANDLE_WM_MDINEXT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, BOOL, HWND> fn)
+            => (LRESULT)(HWND)fn((hwnd), (HWND)(wParam), (BOOL)lParam);
+
+        public static HWND FORWARD_WM_MDINEXT(HWND hwnd, HWND hwndCur, BOOL fPrev, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HWND)(nuint)fn((hwnd), WM_MDINEXT, (WPARAM)(hwndCur), (LPARAM)(fPrev));
+
+        /* void Cls_MDIMaximize(HWND hwnd, HWND hwndMaximize) */
+        public static LRESULT HANDLE_WM_MDIMAXIMIZE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MDIMAXIMIZE(HWND hwnd, HWND hwndMaximize, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MDIMAXIMIZE, (WPARAM)(hwndMaximize), 0);
+
+        /* BOOL Cls_MDITile(HWND hwnd, UINT cmd) */
+        public static LRESULT HANDLE_WM_MDITILE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, BOOL> fn)
+            => (LRESULT)(uint)fn((hwnd), (uint)(wParam));
+
+        public static BOOL FORWARD_WM_MDITILE(HWND hwnd, uint cmd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_MDITILE, (WPARAM)(cmd), 0);
+
+        /* BOOL Cls_MDICascade(HWND hwnd, UINT cmd) */
+        public static LRESULT HANDLE_WM_MDICASCADE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, BOOL> fn)
+            => (LRESULT)(uint)fn((hwnd), (uint)(wParam));
+
+        public static BOOL FORWARD_WM_MDICASCADE(HWND hwnd, uint cmd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_MDICASCADE, (WPARAM)(cmd), 0);
+
+        /* void Cls_MDIIconArrange(HWND hwnd) */
+        public static LRESULT HANDLE_WM_MDIICONARRANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_MDIICONARRANGE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MDIICONARRANGE, 0u, 0);
+
+        /* HWND Cls_MDIGetActive(HWND hwnd) */
+        public static LRESULT HANDLE_WM_MDIGETACTIVE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND> fn)
+            => (LRESULT)(nuint)fn(hwnd);
+
+        public static HWND FORWARD_WM_MDIGETACTIVE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HWND)(nuint)fn((hwnd), WM_MDIGETACTIVE, 0u, 0);
+
+        /* HMENU Cls_MDISetMenu(HWND hwnd, BOOL fRefresh, HMENU hmenuFrame, HMENU hmenuWindow) */
+        public static LRESULT HANDLE_WM_MDISETMENU(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND,BOOL, HMENU, HMENU, HMENU> fn)
+            => (LRESULT)(nuint)fn((hwnd), (BOOL)(wParam), (HMENU)(wParam), (HMENU)(lParam));
+
+        public static HMENU FORWARD_WM_MDISETMENU(HWND hwnd, BOOL fRefresh, HMENU hmenuFrame, HMENU hmenuWindow, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HMENU)(nuint)fn((hwnd), WM_MDISETMENU, (WPARAM)((fRefresh) ? (hmenuFrame) : HMENU.NULL), (LPARAM)(hmenuWindow));
+
+        /* void Cls_OnChildActivate(HWND hwnd) */
+        public static LRESULT HANDLE_WM_CHILDACTIVATE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_CHILDACTIVATE(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CHILDACTIVATE, 0u, 0);
+
+        /* BOOL Cls_OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam) */
+        public static LRESULT HANDLE_WM_INITDIALOG(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, LPARAM, BOOL> fn)
+            => (LRESULT)(uint)(uint)(BOOL)fn((hwnd), (HWND)(wParam), lParam);
+
+        public static BOOL FORWARD_WM_INITDIALOG(HWND hwnd, HWND hwndFocus, LPARAM lParam, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_INITDIALOG, (WPARAM)(HWND)(hwndFocus), (lParam));
+
+        /* HWND Cls_OnNextDlgCtl(HWND hwnd, HWND hwndSetFocus, BOOL fNext) */
+        public static LRESULT HANDLE_WM_NEXTDLGCTL(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, BOOL, HWND> fn)
+            => (LRESULT)(nuint)(HWND)fn((hwnd), (HWND)(wParam), (BOOL)(lParam));
+
+        public static HWND FORWARD_WM_NEXTDLGCTL(HWND hwnd, HWND hwndSetFocus, BOOL fNext, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HWND)(nuint)fn((hwnd), WM_NEXTDLGCTL, (WPARAM)(HWND)(hwndSetFocus), (LPARAM)(fNext));
+
+        /* void Cls_OnParentNotify(HWND hwnd, UINT msg, HWND hwndChild, int idChild) */
+        public static LRESULT HANDLE_WM_PARENTNOTIFY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HWND, int, void> fn)
+        {
+            fn((hwnd), (uint)LOWORD(wParam), (HWND)(lParam), (int)(uint)HIWORD(wParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_PARENTNOTIFY(HWND hwnd, uint msg, HWND hwndChild, int idChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_PARENTNOTIFY, MAKEWPARAM(msg, (nuint)(idChild)), (LPARAM)(hwndChild));
+
+        /* void Cls_OnEnterIdle(HWND hwnd, UINT source, HWND hwndSource) */
+        public static LRESULT HANDLE_WM_ENTERIDLE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HWND, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), (HWND)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_ENTERIDLE(HWND hwnd, uint source, HWND hwndSource, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_ENTERIDLE, (WPARAM)(uint)(source), (LPARAM)(HWND)(hwndSource));
+
+        /* UINT Cls_OnGetDlgCode(HWND hwnd, LPMSG lpmsg) */
+        public static LRESULT HANDLE_WM_GETDLGCODE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, MSG*, uint> fn)
+            => (LRESULT)(uint)(uint)fn(hwnd, (MSG*)(lParam));
+
+        public static uint FORWARD_WM_GETDLGCODE(HWND hwnd, MSG* lpmsg, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (uint)(uint)fn((hwnd), WM_GETDLGCODE, ((lpmsg != null) ? lpmsg->wParam : 0u), (LPARAM)(MSG*)(lpmsg));
+
+        /* HBRUSH Cls_OnCtlColor(HWND hwnd, HDC hdc, HWND hwndChild, int type) */
+        public static LRESULT HANDLE_WM_CTLCOLORMSGBOX(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_MSGBOX);
+
+        public static HBRUSH FORWARD_WM_CTLCOLORMSGBOX(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLORMSGBOX, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        public static LRESULT HANDLE_WM_CTLCOLOREDIT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_EDIT);
+
+        public static HBRUSH FORWARD_WM_CTLCOLOREDIT(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLOREDIT, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        public static LRESULT HANDLE_WM_CTLCOLORLISTBOX(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_LISTBOX);
+
+        public static HBRUSH FORWARD_WM_CTLCOLORLISTBOX(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLORLISTBOX, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        public static LRESULT HANDLE_WM_CTLCOLORBTN(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_BTN);
+
+        public static HBRUSH FORWARD_WM_CTLCOLORBTN(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLORBTN, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        public static LRESULT HANDLE_WM_CTLCOLORDLG(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_DLG);
+
+        public static HBRUSH FORWARD_WM_CTLCOLORDLG(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLORDLG, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        public static LRESULT HANDLE_WM_CTLCOLORSCROLLBAR(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_SCROLLBAR);
+
+        public static HBRUSH FORWARD_WM_CTLCOLORSCROLLBAR(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLORSCROLLBAR, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        public static LRESULT HANDLE_WM_CTLCOLORSTATIC(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HDC, HWND, int, HBRUSH> fn)
+            => (LRESULT)(nuint)(HBRUSH)fn((hwnd), (HDC)(wParam), (HWND)(lParam), CTLCOLOR_STATIC);
+
+        public static HBRUSH FORWARD_WM_CTLCOLORSTATIC(HWND hwnd, HDC hdc, HWND hwndChild, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HBRUSH)(nuint)fn((hwnd), WM_CTLCOLORSTATIC, (WPARAM)(HDC)(hdc), (LPARAM)(HWND)(hwndChild));
+
+        /* void Cls_OnSetFont(HWND hwndCtl, HFONT hfont, BOOL fRedraw) */
+        public static LRESULT HANDLE_WM_SETFONT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HFONT, BOOL, void> fn)
+        {
+            fn((hwnd), (HFONT)(wParam), (BOOL)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_SETFONT(HWND hwnd, HFONT hfont, BOOL fRedraw, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_SETFONT, (WPARAM)(HFONT)(hfont), (LPARAM)(BOOL)(fRedraw));
+
+        /* HFONT Cls_OnGetFont(HWND hwnd) */
+        public static LRESULT HANDLE_WM_GETFONT(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HFONT> fn)
+            => (LRESULT)(nuint)(HFONT)fn(hwnd);
+
+        public static HFONT FORWARD_WM_GETFONT(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (HFONT)(nuint)fn((hwnd), WM_GETFONT, 0u, 0);
+
+        /* void Cls_OnDrawItem(HWND hwnd, const DRAWITEMSTRUCT * lpDrawItem) */
+        public static LRESULT HANDLE_WM_DRAWITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, DRAWITEMSTRUCT*, void> fn)
+        {
+            fn((hwnd), (DRAWITEMSTRUCT*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_DRAWITEM(HWND hwnd, DRAWITEMSTRUCT* lpDrawItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DRAWITEM, (WPARAM)(((DRAWITEMSTRUCT*)lpDrawItem)->CtlID), (LPARAM) (DRAWITEMSTRUCT*)(lpDrawItem));
+
+        /* void Cls_OnMeasureItem(HWND hwnd, MEASUREITEMSTRUCT * lpMeasureItem) */
+        public static LRESULT HANDLE_WM_MEASUREITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, MEASUREITEMSTRUCT*, void> fn)
+        {
+            fn((hwnd), (MEASUREITEMSTRUCT*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_MEASUREITEM(HWND hwnd, MEASUREITEMSTRUCT* lpMeasureItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_MEASUREITEM, (WPARAM)(((MEASUREITEMSTRUCT*)lpMeasureItem)->CtlID), (LPARAM)(MEASUREITEMSTRUCT*)(lpMeasureItem));
+
+        /* void Cls_OnDeleteItem(HWND hwnd, const DELETEITEMSTRUCT * lpDeleteItem) */
+        public static LRESULT HANDLE_WM_DELETEITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, DELETEITEMSTRUCT*, void> fn)
+        {
+            fn((hwnd), (DELETEITEMSTRUCT*)(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_DELETEITEM(HWND hwnd, DELETEITEMSTRUCT* lpDeleteItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DELETEITEM, (WPARAM)(((DELETEITEMSTRUCT*)(lpDeleteItem))->CtlID), (LPARAM) (DELETEITEMSTRUCT*)(lpDeleteItem));
+
+        /* int Cls_OnCompareItem(HWND hwnd, const COMPAREITEMSTRUCT * lpCompareItem) */
+        public static LRESULT HANDLE_WM_COMPAREITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, COMPAREITEMSTRUCT*, int> fn)
+            => (LRESULT)(uint)(int)fn((hwnd), (COMPAREITEMSTRUCT*)(lParam));
+
+        public static int FORWARD_WM_COMPAREITEM(HWND hwnd, COMPAREITEMSTRUCT* lpCompareItem, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (int)(uint)fn((hwnd), WM_COMPAREITEM, (WPARAM)(((COMPAREITEMSTRUCT*)(lpCompareItem))->CtlID), (LPARAM) (COMPAREITEMSTRUCT*)(lpCompareItem));
+
+        /* int Cls_OnVkeyToItem(HWND hwnd, UINT vk, HWND hwndListbox, int iCaret) */
+        public static LRESULT HANDLE_WM_VKEYTOITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HWND, int, int> fn)
+            => (LRESULT)(uint)(int)fn((hwnd), (uint)LOWORD(wParam), (HWND)(lParam), (int)(short)HIWORD(wParam));
+
+        public static int FORWARD_WM_VKEYTOITEM(HWND hwnd, uint vk, HWND hwndListBox, int iCaret, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (int)(uint)fn((hwnd), WM_VKEYTOITEM, MAKEWPARAM((vk), (nuint)(iCaret)), (LPARAM)(hwndListBox));
+
+        /* int Cls_OnCharToItem(HWND hwnd, UINT ch, HWND hwndListbox, int iCaret) */
+        public static LRESULT HANDLE_WM_CHARTOITEM(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, HWND, int, int> fn)
+            => (LRESULT)(uint)(int)fn((hwnd), (uint)LOWORD(wParam), (HWND)(lParam), (int)(short)HIWORD(wParam));
+
+        public static int FORWARD_WM_CHARTOITEM(HWND hwnd, uint ch, HWND hwndListBox, int iCaret, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (int)(uint)fn((hwnd), WM_CHARTOITEM, MAKEWPARAM((uint)(ch), (uint)(iCaret)), (LPARAM)(hwndListBox));
+
+        /* void Cls_OnQueueSync(HWND hwnd) */
+        public static LRESULT HANDLE_WM_QUEUESYNC(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, void> fn)
+        {
+            fn(hwnd);
+            return 0;
+        }
+
+        public static void FORWARD_WM_QUEUESYNC(HWND hwnd, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_QUEUESYNC, 0u, 0);
+
+        /* void Cls_OnCommNotify(HWND hwnd, int cid, UINT flags) */
+        public static LRESULT HANDLE_WM_COMMNOTIFY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, uint, void> fn)
+        {
+            fn((hwnd), (int)(wParam), (uint)LOWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_COMMNOTIFY(HWND hwnd, int cid, uint flags, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_COMMNOTIFY, (WPARAM)(cid), MAKELPARAM((flags), 0));
+
+        /* void Cls_OnDisplayChange(HWND hwnd, UINT bitsPerPixel, UINT cxScreen, UINT cyScreen) */
+        public static LRESULT HANDLE_WM_DISPLAYCHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, uint, uint, void> fn)
+        {
+            fn((hwnd), (uint)(wParam), (uint)LOWORD(lParam), (uint)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_DISPLAYCHANGE(HWND hwnd, uint bitsPerPixel, uint cxScreen, uint cyScreen, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_DISPLAYCHANGE, (WPARAM)(uint)(bitsPerPixel), (LPARAM)MAKELPARAM((uint)(cxScreen), (uint)(cyScreen)));
+
+        /* BOOL Cls_OnDeviceChange(HWND hwnd, UINT uEvent, DWORD dwEventData) */
+        public static LRESULT HANDLE_WM_DEVICECHANGE(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, uint, uint, BOOL> fn)
+            => (LRESULT)(uint)(BOOL)fn((hwnd), (uint)(wParam), (uint)(lParam));
+
+        public static BOOL FORWARD_WM_DEVICECHANGE(HWND hwnd, uint uEvent, uint dwEventData, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)fn((hwnd), WM_DEVICECHANGE, (WPARAM)(uint)(uEvent), (LPARAM)(uint)(dwEventData));
+
+        /* void Cls_OnContextMenu(HWND hwnd, HWND hwndContext, UINT xPos, UINT yPos) */
+        public static LRESULT HANDLE_WM_CONTEXTMENU(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, uint, uint, void> fn)
+        {
+            fn((hwnd), (HWND)(wParam), (uint)(int)(short)LOWORD(lParam), (uint)(int)(short)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_CONTEXTMENU(HWND hwnd, HWND hwndContext, uint xPos, uint yPos, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_CONTEXTMENU, (WPARAM)(HWND)(hwndContext), MAKELPARAM((uint)(xPos), (uint)(yPos)));
+
+        public static LRESULT HANDLE_WM_COPYDATA(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, HWND, COPYDATASTRUCT*, BOOL> fn)
+        {
+            _ = fn((hwnd), (HWND)(wParam), (COPYDATASTRUCT*)lParam);
+            return 0;
+        }
+
+        public static BOOL FORWARD_WM_COPYDATA(HWND hwnd, HWND hwndFrom, COPYDATASTRUCT* pcds, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => (BOOL)(uint)(uint)fn((hwnd), WM_COPYDATA, (WPARAM)(hwndFrom), (LPARAM)(pcds));
+
+        /* void Cls_OnHotKey(HWND hwnd, int idHotKey, UINT fuModifiers, UINT vk) */
+        public static LRESULT HANDLE_WM_HOTKEY(HWND hwnd, WPARAM wParam, LPARAM lParam, delegate*<HWND, int, uint, uint, void> fn)
+        {
+            fn((hwnd), (int)(wParam), (uint)LOWORD(lParam), (uint)HIWORD(lParam));
+            return 0;
+        }
+
+        public static void FORWARD_WM_HOTKEY(HWND hwnd, int idHotKey, uint fuModifiers, uint vk, delegate*<HWND, uint, WPARAM, LPARAM, LRESULT> fn)
+            => fn((hwnd), WM_HOTKEY, (WPARAM)(idHotKey), MAKELPARAM((fuModifiers), (vk)));
+
+        /****** Static control message APIs ******************************************/
+
+        public static BOOL Static_Enable(HWND hwndCtl, BOOL fEnable) => EnableWindow((hwndCtl), (fEnable));
+
+        public static int Static_GetText(HWND hwndCtl, ushort* lpch, int cchMax) => GetWindowText((hwndCtl), (lpch), (cchMax));
+
+        public static int Static_GetTextLength(HWND hwndCtl) => GetWindowTextLength(hwndCtl);
+
+        public static BOOL Static_SetText(HWND hwndCtl, ushort* lpsz) => SetWindowText((hwndCtl), (lpsz));
+
+        public static HICON Static_SetIcon(HWND hwndCtl, HICON hIcon) => ((HICON)(nuint)SNDMSG((hwndCtl), STM_SETICON, (WPARAM)(HICON)(hIcon), 0));
+
+        public static HICON Static_GetIcon(HWND hwndCtl, HICON hIcon) => ((HICON)(nuint)SNDMSG((hwndCtl), STM_GETICON, 0u, 0));
+
+        /****** Button control message APIs ******************************************/
+
+        public static BOOL Button_Enable(HWND hwndCtl, BOOL fEnable) => EnableWindow((hwndCtl), (fEnable));
+
+        public static int Button_GetText(HWND hwndCtl, ushort* lpch, int cchMax) => GetWindowText((hwndCtl), (lpch), (cchMax));
+
+        public static int Button_GetTextLength(HWND hwndCtl) => GetWindowTextLength(hwndCtl);
+
+        public static BOOL Button_SetText(HWND hwndCtl, ushort* lpsz) => SetWindowText((hwndCtl), (lpsz));
+
+        public static int Button_GetCheck(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), BM_GETCHECK, 0u, 0));
+
+        public static void Button_SetCheck(HWND hwndCtl, int check) => SNDMSG((hwndCtl), BM_SETCHECK, (WPARAM)(int)(check), 0);
+
+        public static int Button_GetState(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), BM_GETSTATE, 0u, 0));
+
+        public static uint Button_SetState(HWND hwndCtl, int state) => ((uint)(uint)SNDMSG((hwndCtl), BM_SETSTATE, (WPARAM)(int)(state), 0));
+
+        public static void Button_SetStyle(HWND hwndCtl, int style, BOOL fRedraw) => SNDMSG((hwndCtl), BM_SETSTYLE, (WPARAM)LOWORD(style), MAKELPARAM(((ushort)((fRedraw) ? TRUE : FALSE)), 0));
+
+        /****** Edit control message APIs ********************************************/
+
+        public static BOOL Edit_Enable(HWND hwndCtl, BOOL fEnable) => EnableWindow((hwndCtl), (fEnable));
+
+        public static int Edit_GetText(HWND hwndCtl, ushort* lpch, int cchMax) => GetWindowText((hwndCtl), (lpch), (cchMax));
+
+        public static int Edit_GetTextLength(HWND hwndCtl) => GetWindowTextLength(hwndCtl);
+
+        public static BOOL Edit_SetText(HWND hwndCtl, ushort* lpsz) => SetWindowText((hwndCtl), (lpsz));
+
+        public static void Edit_LimitText(HWND hwndCtl, int cchMax) => SNDMSG((hwndCtl), EM_LIMITTEXT, (WPARAM)(cchMax), 0);
+
+        public static int Edit_GetLineCount(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), EM_GETLINECOUNT, 0u, 0));
+
+        public static int Edit_GetLine(HWND hwndCtl, int line, ushort* lpch, int cchMax)
+        {
+            *((int*)(lpch)) = (cchMax);
+            return ((int)(uint)SNDMSG((hwndCtl), EM_GETLINE, (WPARAM)(int)(line), (LPARAM)(ushort*)(lpch)));
+        }
+
+        public static void Edit_GetRect(HWND hwndCtl, RECT* lprc) => SNDMSG((hwndCtl), EM_GETRECT, 0u, (LPARAM)(RECT*)(lprc));
+
+        public static void Edit_SetRect(HWND hwndCtl, RECT* lprc) => SNDMSG((hwndCtl), EM_SETRECT, 0u, (LPARAM)(RECT*)(lprc));
+
+        public static void Edit_SetRectNoPaint(HWND hwndCtl, RECT* lprc) => SNDMSG((hwndCtl), EM_SETRECTNP, 0u, (LPARAM)(RECT*)(lprc));
+
+        public static uint Edit_GetSel(HWND hwndCtl) => ((uint)SNDMSG((hwndCtl), EM_GETSEL, 0u, 0));
+
+        public static void Edit_SetSel(HWND hwndCtl, WPARAM ichStart, LPARAM ichEnd) => SNDMSG((hwndCtl), EM_SETSEL, (ichStart), (ichEnd));
+
+        public static void Edit_ReplaceSel(HWND hwndCtl, ushort* lpszReplace) => SNDMSG((hwndCtl), EM_REPLACESEL, 0u, (LPARAM)(ushort*)(lpszReplace));
+
+        public static BOOL Edit_GetModify(HWND hwndCtl) => ((BOOL)(uint)SNDMSG((hwndCtl), EM_GETMODIFY, 0u, 0));
+
+        public static void Edit_SetModify(HWND hwndCtl, uint fModified) => SNDMSG((hwndCtl), EM_SETMODIFY, (WPARAM)(uint)(fModified), 0);
+
+        public static BOOL Edit_ScrollCaret(HWND hwndCtl) => ((BOOL)(uint)SNDMSG((hwndCtl), EM_SCROLLCARET, 0u, 0));
+
+        public static int Edit_LineFromChar(HWND hwndCtl, int ich) => ((int)(uint)SNDMSG((hwndCtl), EM_LINEFROMCHAR, (WPARAM)(int)(ich), 0));
+
+        public static int Edit_LineIndex(HWND hwndCtl, int line) => ((int)(uint)SNDMSG((hwndCtl), EM_LINEINDEX, (WPARAM)(int)(line), 0));
+
+        public static int Edit_LineLength(HWND hwndCtl, int line) => ((int)(uint)SNDMSG((hwndCtl), EM_LINELENGTH, (WPARAM)(int)(line), 0));
+
+        public static void Edit_Scroll(HWND hwndCtl, WPARAM dv, LPARAM dh) => SNDMSG((hwndCtl), EM_LINESCROLL, (WPARAM)(dh), (LPARAM)(dv));
+
+        public static BOOL Edit_CanUndo(HWND hwndCtl) => ((BOOL)(uint)SNDMSG((hwndCtl), EM_CANUNDO, 0u, 0));
+
+        public static BOOL Edit_Undo(HWND hwndCtl) => ((BOOL)(uint)SNDMSG((hwndCtl), EM_UNDO, 0u, 0));
+
+        public static void Edit_EmptyUndoBuffer(HWND hwndCtl) => SNDMSG((hwndCtl), EM_EMPTYUNDOBUFFER, 0u, 0);
+
+        public static void Edit_SetPasswordChar(HWND hwndCtl, uint ch) => SNDMSG((hwndCtl), EM_SETPASSWORDCHAR, (WPARAM)(uint)(ch), 0);
+
+        public static void Edit_SetTabStops(HWND hwndCtl, int cTabs, int* lpTabs) => SNDMSG((hwndCtl), EM_SETTABSTOPS, (WPARAM)(int)(cTabs), (LPARAM)(int*)(lpTabs));
+
+        public static BOOL Edit_FmtLines(HWND hwndCtl, BOOL fAddEOL) => ((BOOL)(uint)SNDMSG((hwndCtl), EM_FMTLINES, (WPARAM)(BOOL)(fAddEOL), 0));
+
+        public static HLOCAL Edit_GetHandle(HWND hwndCtl) => ((HLOCAL)(nuint)SNDMSG((hwndCtl), EM_GETHANDLE, 0u, 0));
+
+        public static void Edit_SetHandle(HWND hwndCtl, HLOCAL h) => SNDMSG((hwndCtl), EM_SETHANDLE, (WPARAM)(nuint)(HLOCAL)(h), 0);
+
+        public static int Edit_GetFirstVisibleLine(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), EM_GETFIRSTVISIBLELINE, 0u, 0));
+
+        public static BOOL Edit_SetReadOnly(HWND hwndCtl, BOOL fReadOnly) => ((BOOL)(uint)SNDMSG((hwndCtl), EM_SETREADONLY, (WPARAM)(BOOL)(fReadOnly), 0));
+
+        public static ushort Edit_GetPasswordChar(HWND hwndCtl) => ((ushort)(uint)SNDMSG((hwndCtl), EM_GETPASSWORDCHAR, 0u, 0));
+
+        public static void Edit_SetWordBreakProc(HWND hwndCtl, delegate* unmanaged<ushort*, int, int, int, int> lpfnWordBreak) => SNDMSG((hwndCtl), EM_SETWORDBREAKPROC, 0u, (LPARAM)(delegate* unmanaged<ushort*, int, int, int, int>)(lpfnWordBreak));
+
+        public static delegate* unmanaged<ushort*, int, int, int, int> Edit_GetWordBreakProc(HWND hwndCtl) => ((delegate* unmanaged<ushort*, int, int, int, int>)SNDMSG((hwndCtl), EM_GETWORDBREAKPROC, 0u, 0));
+
+        /****** ScrollBar control message APIs ***************************************/
+
+        /* NOTE: flags parameter is a collection of ESB_* values, NOT a boolean! */
+        public static BOOL ScrollBar_Enable(HWND hwndCtl, uint flags) => EnableScrollBar((hwndCtl), SB_CTL, (flags));
+
+        public static BOOL ScrollBar_Show(HWND hwndCtl, BOOL fShow) => ShowWindow((hwndCtl), (fShow) ? SW_SHOWNORMAL : SW_HIDE);
+
+        public static int ScrollBar_SetPos(HWND hwndCtl, int pos, BOOL fRedraw) => SetScrollPos((hwndCtl), SB_CTL, (pos), (fRedraw));
+
+        public static int ScrollBar_GetPos(HWND hwndCtl) => GetScrollPos((hwndCtl), SB_CTL);
+
+        public static BOOL ScrollBar_SetRange(HWND hwndCtl, int posMin, int posMax, BOOL fRedraw) => SetScrollRange((hwndCtl), SB_CTL, (posMin), (posMax), (fRedraw));
+
+        public static BOOL ScrollBar_GetRange(HWND hwndCtl, int* lpposMin, int* lpposMax) => GetScrollRange((hwndCtl), SB_CTL, (lpposMin), (lpposMax));
+
+        /****** ListBox control message APIs *****************************************/
+
+        public static BOOL ListBox_Enable(HWND hwndCtl, BOOL fEnable) => EnableWindow((hwndCtl), (fEnable));
+
+        public static int ListBox_GetCount(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), LB_GETCOUNT, 0u, 0));
+
+        public static BOOL ListBox_ResetContent(HWND hwndCtl) => ((BOOL)(uint)SNDMSG((hwndCtl), LB_RESETCONTENT, 0u, 0));
+
+        public static int ListBox_AddString(HWND hwndCtl, ushort* lpsz) => ((int)(uint)SNDMSG((hwndCtl), LB_ADDSTRING, 0u, (LPARAM)(ushort*)(lpsz)));
+
+        public static int ListBox_InsertString(HWND hwndCtl, int index, ushort* lpsz) => ((int)(uint)SNDMSG((hwndCtl), LB_INSERTSTRING, (WPARAM)(int)(index), (LPARAM)(ushort*)(lpsz)));
+
+        public static int ListBox_AddItemData(HWND hwndCtl, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), LB_ADDSTRING, 0u, (LPARAM)(data)));
+
+        public static int ListBox_InsertItemData(HWND hwndCtl, int index, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), LB_INSERTSTRING, (WPARAM)(int)(index), (LPARAM)(data)));
+
+        public static int ListBox_DeleteString(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), LB_DELETESTRING, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_GetTextLen(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), LB_GETTEXTLEN, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_GetText(HWND hwndCtl, int index, ushort* lpszBuffer) => ((int)(uint)SNDMSG((hwndCtl), LB_GETTEXT, (WPARAM)(int)(index), (LPARAM)(ushort*)(lpszBuffer)));
+
+        public static LRESULT ListBox_GetItemData(HWND hwndCtl, int index) => ((LRESULT)(nuint)SNDMSG((hwndCtl), LB_GETITEMDATA, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_SetItemData(HWND hwndCtl, int index, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), LB_SETITEMDATA, (WPARAM)(int)(index), (LPARAM)(data)));
+
+        public static int ListBox_FindString(HWND hwndCtl, int indexStart, ushort* lpszFind) => ((int)(uint)SNDMSG((hwndCtl), LB_FINDSTRING, (WPARAM)(int)(indexStart), (LPARAM)(ushort*)(lpszFind)));
+
+        public static int ListBox_FindItemData(HWND hwndCtl, int indexStart, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), LB_FINDSTRING, (WPARAM)(int)(indexStart), (LPARAM)(data)));
+
+        public static int ListBox_SetSel(HWND hwndCtl, BOOL fSelect, LPARAM index) => ((int)(uint)SNDMSG((hwndCtl), LB_SETSEL, (WPARAM)(BOOL)(fSelect), (LPARAM)(index)));
+
+        public static int ListBox_SelItemRange(HWND hwndCtl, BOOL fSelect, ushort first, ushort last) => ((int)(uint)SNDMSG((hwndCtl), LB_SELITEMRANGE, (WPARAM)(BOOL)(fSelect), MAKELPARAM((first), (last))));
+
+        public static int ListBox_GetCurSel(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), LB_GETCURSEL, 0u, 0));
+
+        public static int ListBox_SetCurSel(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), LB_SETCURSEL, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_SelectString(HWND hwndCtl, int indexStart, ushort* lpszFind) => ((int)(uint)SNDMSG((hwndCtl), LB_SELECTSTRING, (WPARAM)(int)(indexStart), (LPARAM)(ushort*)(lpszFind)));
+
+        public static int ListBox_SelectItemData(HWND hwndCtl, int indexStart, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), LB_SELECTSTRING, (WPARAM)(int)(indexStart), (LPARAM)(data)));
+
+        public static int ListBox_GetSel(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), LB_GETSEL, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_GetSelCount(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), LB_GETSELCOUNT, 0u, 0));
+
+        public static int ListBox_GetTopIndex(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), LB_GETTOPINDEX, 0u, 0));
+
+        public static int ListBox_GetSelItems(HWND hwndCtl, int cItems, int* lpItems) => ((int)(uint)SNDMSG((hwndCtl), LB_GETSELITEMS, (WPARAM)(int)(cItems), (LPARAM)(int*)(lpItems)));
+
+        public static int ListBox_SetTopIndex(HWND hwndCtl, int indexTop) => ((int)(uint)SNDMSG((hwndCtl), LB_SETTOPINDEX, (WPARAM)(int)(indexTop), 0));
+
+        public static void ListBox_SetColumnWidth(HWND hwndCtl, int cxColumn) => SNDMSG((hwndCtl), LB_SETCOLUMNWIDTH, (WPARAM)(int)(cxColumn), 0);
+
+        public static int ListBox_GetHorizontalExtent(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), LB_GETHORIZONTALEXTENT, 0u, 0));
+
+        public static void ListBox_SetHorizontalExtent(HWND hwndCtl, int cxExtent) => SNDMSG((hwndCtl), LB_SETHORIZONTALEXTENT, (WPARAM)(int)(cxExtent), 0);
+
+        public static BOOL ListBox_SetTabStops(HWND hwndCtl, int cTabs, int* lpTabs) => ((BOOL)(uint)SNDMSG((hwndCtl), LB_SETTABSTOPS, (WPARAM)(int)(cTabs), (LPARAM)(int*)(lpTabs)));
+
+        public static int ListBox_GetItemRect(HWND hwndCtl, int index, RECT* lprc) => ((int)(uint)SNDMSG((hwndCtl), LB_GETITEMRECT, (WPARAM)(int)(index), (LPARAM)(RECT*)(lprc)));
+
+        public static int ListBox_SetCaretIndex(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), LB_SETCARETINDEX, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_GetCaretIndex(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), LB_GETCARETINDEX, 0u, 0));
+
+        public static int ListBox_FindStringExact(HWND hwndCtl, int indexStart, ushort* lpszFind) => ((int)(uint)SNDMSG((hwndCtl), LB_FINDSTRINGEXACT, (WPARAM)(int)(indexStart), (LPARAM)(ushort*)(lpszFind)));
+
+        public static int ListBox_SetItemHeight(HWND hwndCtl, int index, ushort cy) => ((int)(uint)SNDMSG((hwndCtl), LB_SETITEMHEIGHT, (WPARAM)(int)(index), MAKELPARAM((cy), 0)));
+
+        public static int ListBox_GetItemHeight(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), LB_GETITEMHEIGHT, (WPARAM)(int)(index), 0));
+
+        public static int ListBox_Dir(HWND hwndCtl, uint attrs, ushort* lpszFileSpec) => ((int)(uint)SNDMSG((hwndCtl), LB_DIR, (WPARAM)(uint)(attrs), (LPARAM)(ushort*)(lpszFileSpec)));
+
+        /****** ComboBox control message APIs ****************************************/
+
+        public static BOOL ComboBox_Enable(HWND hwndCtl, BOOL fEnable) => EnableWindow((hwndCtl), (fEnable));
+
+        public static int ComboBox_GetText(HWND hwndCtl, ushort* lpch, int cchMax) => GetWindowText((hwndCtl), (lpch), (cchMax));
+
+        public static int ComboBox_GetTextLength(HWND hwndCtl) => GetWindowTextLength(hwndCtl);
+
+        public static BOOL ComboBox_SetText(HWND hwndCtl, ushort* lpsz) => SetWindowText((hwndCtl), (lpsz));
+
+        public static int ComboBox_LimitText(HWND hwndCtl, int cchLimit) => ((int)(uint)SNDMSG((hwndCtl), CB_LIMITTEXT, (WPARAM)(int)(cchLimit), 0));
+
+        public static uint ComboBox_GetEditSel(HWND hwndCtl) => ((uint)SNDMSG((hwndCtl), CB_GETEDITSEL, 0u, 0));
+
+        public static int ComboBox_SetEditSel(HWND hwndCtl, ushort ichStart, ushort ichEnd) => ((int)(uint)SNDMSG((hwndCtl), CB_SETEDITSEL, 0u, MAKELPARAM((ichStart), (ichEnd))));
+
+        public static int ComboBox_GetCount(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), CB_GETCOUNT, 0u, 0));
+
+        public static int ComboBox_ResetContent(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), CB_RESETCONTENT, 0u, 0));
+
+        public static int ComboBox_AddString(HWND hwndCtl, ushort* lpsz) => ((int)(uint)SNDMSG((hwndCtl), CB_ADDSTRING, 0u, (LPARAM)(ushort*)(lpsz)));
+
+        public static int ComboBox_InsertString(HWND hwndCtl, int index, ushort* lpsz) => ((int)(uint)SNDMSG((hwndCtl), CB_INSERTSTRING, (WPARAM)(int)(index), (LPARAM)(ushort*)(lpsz)));
+
+        public static int ComboBox_AddItemData(HWND hwndCtl, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), CB_ADDSTRING, 0u, (LPARAM)(data)));
+
+        public static int ComboBox_InsertItemData(HWND hwndCtl, int index, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), CB_INSERTSTRING, (WPARAM)(int)(index), (LPARAM)(data)));
+
+        public static int ComboBox_DeleteString(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), CB_DELETESTRING, (WPARAM)(int)(index), 0));
+
+        public static int ComboBox_GetLBTextLen(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), CB_GETLBTEXTLEN, (WPARAM)(int)(index), 0));
+
+        public static int ComboBox_GetLBText(HWND hwndCtl, int index, ushort* lpszBuffer) => ((int)(uint)SNDMSG((hwndCtl), CB_GETLBTEXT, (WPARAM)(int)(index), (LPARAM)(ushort*)(lpszBuffer)));
+
+        public static LRESULT ComboBox_GetItemData(HWND hwndCtl, int index) => ((LRESULT)(nuint)SNDMSG((hwndCtl), CB_GETITEMDATA, (WPARAM)(int)(index), 0));
+
+        public static int ComboBox_SetItemData(HWND hwndCtl, int index, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), CB_SETITEMDATA, (WPARAM)(int)(index), (LPARAM)(data)));
+
+        public static int ComboBox_FindString(HWND hwndCtl, int indexStart, ushort* lpszFind) => ((int)(uint)SNDMSG((hwndCtl), CB_FINDSTRING, (WPARAM)(int)(indexStart), (LPARAM)(ushort*)(lpszFind)));
+
+        public static int ComboBox_FindItemData(HWND hwndCtl, int indexStart, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), CB_FINDSTRING, (WPARAM)(int)(indexStart), (LPARAM)(data)));
+
+        public static int ComboBox_GetCurSel(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), CB_GETCURSEL, 0u, 0));
+
+        public static int ComboBox_SetCurSel(HWND hwndCtl, int index) => ((int)(uint)SNDMSG((hwndCtl), CB_SETCURSEL, (WPARAM)(int)(index), 0));
+
+        public static int ComboBox_SelectString(HWND hwndCtl, int indexStart, ushort* lpszSelect) => ((int)(uint)SNDMSG((hwndCtl), CB_SELECTSTRING, (WPARAM)(int)(indexStart), (LPARAM)(ushort*)(lpszSelect)));
+
+        public static int ComboBox_SelectItemData(HWND hwndCtl, int indexStart, LPARAM data) => ((int)(uint)SNDMSG((hwndCtl), CB_SELECTSTRING, (WPARAM)(int)(indexStart), (LPARAM)(data)));
+
+        public static int ComboBox_Dir(HWND hwndCtl, uint attrs, ushort* lpszFileSpec) => ((int)(uint)SNDMSG((hwndCtl), CB_DIR, (WPARAM)(uint)(attrs), (LPARAM)(ushort*)(lpszFileSpec)));
+
+        public static BOOL ComboBox_ShowDropdown(HWND hwndCtl, BOOL fShow) => ((BOOL)(uint)SNDMSG((hwndCtl), CB_SHOWDROPDOWN, (WPARAM)(BOOL)(fShow), 0));
+
+        public static int ComboBox_FindStringExact(HWND hwndCtl, int indexStart, ushort* lpszFind) => ((int)(uint)SNDMSG((hwndCtl), CB_FINDSTRINGEXACT, (WPARAM)(int)(indexStart), (LPARAM)(ushort*)(lpszFind)));
+
+        public static BOOL ComboBox_GetDroppedState(HWND hwndCtl) => ((BOOL)(uint)SNDMSG((hwndCtl), CB_GETDROPPEDSTATE, 0u, 0));
+
+        public static void ComboBox_GetDroppedControlRect(HWND hwndCtl, RECT* lprc) => SNDMSG((hwndCtl), CB_GETDROPPEDCONTROLRECT, 0u, (LPARAM)(RECT*)(lprc));
+
+        public static int ComboBox_GetItemHeight(HWND hwndCtl) => ((int)(uint)SNDMSG((hwndCtl), CB_GETITEMHEIGHT, 0u, 0));
+
+        public static int ComboBox_SetItemHeight(HWND hwndCtl, int index, int cyItem) => ((int)(uint)SNDMSG((hwndCtl), CB_SETITEMHEIGHT, (WPARAM)(int)(index), (LPARAM)(int)cyItem));
+
+        public static uint ComboBox_GetExtendedUI(HWND hwndCtl) => ((uint)(uint)SNDMSG((hwndCtl), CB_GETEXTENDEDUI, 0u, 0));
+
+        public static int ComboBox_SetExtendedUI(HWND hwndCtl, uint flags) => ((int)(uint)SNDMSG((hwndCtl), CB_SETEXTENDEDUI, (WPARAM)(uint)(flags), 0));
+
+        /****** Alternate porting layer macros ****************************************/
+
+        /* USER MESSAGES: */
+
+        public static WPARAM GET_WPARAM(WPARAM wp, LPARAM lp) => (wp);
+
+        public static LPARAM GET_LPARAM(WPARAM wp, LPARAM lp) => (lp);
+
+        public static int GET_X_LPARAM(LPARAM lp) => ((int)(short)LOWORD(lp));
+
+        public static int GET_Y_LPARAM(LPARAM lp) => ((int)(short)HIWORD(lp));
+
+        public static ushort GET_WM_ACTIVATE_STATE(WPARAM wp, LPARAM lp) => LOWORD(wp);
+
+        public static BOOL GET_WM_ACTIVATE_FMINIMIZED(WPARAM wp, LPARAM lp) => (BOOL)HIWORD(wp);
+
+        public static HWND GET_WM_ACTIVATE_HWND(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_ACTIVATE_MPS(ushort s, BOOL fmin, HWND hwnd) => ((WPARAM)MAKELONG((s), (fmin)), (LPARAM)(hwnd));
+
+        public static ushort GET_WM_CHARTOITEM_CHAR(WPARAM wp, LPARAM lp) => (ushort)LOWORD(wp);
+
+        public static ushort GET_WM_CHARTOITEM_POS(WPARAM wp, LPARAM lp) => HIWORD(wp);
+
+        public static HWND GET_WM_CHARTOITEM_HWND(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_CHARTOITEM_MPS(ushort ch, ushort pos, HWND hwnd) => ((WPARAM)MAKELONG((pos), (ch)), (LPARAM)(hwnd));
+
+        public static ushort GET_WM_COMMAND_ID(WPARAM wp, LPARAM lp) => LOWORD(wp);
+
+        public static HWND GET_WM_COMMAND_HWND(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static ushort GET_WM_COMMAND_CMD(WPARAM wp, LPARAM lp) => HIWORD(wp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_COMMAND_MPS(ushort id, HWND hwnd, ushort cmd) => ((WPARAM)MAKELONG(id, cmd), (LPARAM)(hwnd));
+
+        public static HDC GET_WM_CTLCOLOR_HDC(WPARAM wp, LPARAM lp, uint msg) => (HDC)(wp);
+
+        public static HWND GET_WM_CTLCOLOR_HWND(WPARAM wp, LPARAM lp, uint msg) => (HWND)(lp);
+
+        public static ushort GET_WM_CTLCOLOR_TYPE(WPARAM wp, LPARAM lp, uint msg) => (ushort)(msg - WM_CTLCOLORMSGBOX);
+
+        public static ushort GET_WM_CTLCOLOR_MSG(ushort type) => (ushort)(WM_CTLCOLORMSGBOX + (type));
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_CTLCOLOR_MPS(HDC hdc, HWND hwnd, ushort type) => ((WPARAM)(hdc), (LPARAM)(hwnd));
+
+        public static ushort GET_WM_MENUSELECT_CMD(WPARAM wp, LPARAM lp) => LOWORD(wp);
+
+        public static uint GET_WM_MENUSELECT_FLAGS(WPARAM wp, LPARAM lp) => (uint)(int)(short)HIWORD(wp);
+
+        public static HMENU GET_WM_MENUSELECT_HMENU(WPARAM wp, LPARAM lp) => (HMENU)(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_MENUSELECT_MPS(ushort cmd, uint f, HMENU hmenu) => ((WPARAM)MAKELONG(cmd, f), (LPARAM)(hmenu));
+
+        /* Note: the following are for interpreting MDIclient to MDI child messages. */
+        public static BOOL GET_WM_MDIACTIVATE_FACTIVATE(HWND hwnd, WPARAM wp, LPARAM lp) => (lp == (LPARAM)hwnd);
+
+        public static HWND GET_WM_MDIACTIVATE_HWNDDEACT(WPARAM wp, LPARAM lp) => (HWND)(wp);
+
+        public static HWND GET_WM_MDIACTIVATE_HWNDACTIVATE(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        /* Note: the following is for sending to the MDI client window. */
+        public static (WPARAM wp, LPARAM lp) GET_WM_MDIACTIVATE_MPS(BOOL f, HWND hwndD, HWND hwndA) => ((WPARAM)(hwndA), 0);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_MDISETMENU_MPS(HMENU hmenuF, HMENU hmenuW) => ((WPARAM)hmenuF, (LPARAM)hmenuW);
+
+        public static ushort GET_WM_MENUCHAR_CHAR(WPARAM wp, LPARAM lp) => (ushort)LOWORD(wp);
+
+        public static HMENU GET_WM_MENUCHAR_HMENU(WPARAM wp, LPARAM lp) => (HMENU)(lp);
+
+        public static BOOL GET_WM_MENUCHAR_FMENU(WPARAM wp, LPARAM lp) => (BOOL)HIWORD(wp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_MENUCHAR_MPS(ushort ch, HMENU hmenu, BOOL f) => ((WPARAM)MAKELONG(ch, f), (LPARAM)(hmenu));
+
+        public static ushort GET_WM_PARENTNOTIFY_MSG(WPARAM wp, LPARAM lp) => LOWORD(wp);
+
+        public static ushort GET_WM_PARENTNOTIFY_ID(WPARAM wp, LPARAM lp) => HIWORD(wp);
+
+        public static HWND GET_WM_PARENTNOTIFY_HWNDCHILD(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static int GET_WM_PARENTNOTIFY_X(WPARAM wp, LPARAM lp) => (int)(short)LOWORD(lp);
+
+        public static int GET_WM_PARENTNOTIFY_Y(WPARAM wp, LPARAM lp) => (int)(short)HIWORD(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_PARENTNOTIFY_MPS(ushort msg, ushort id, HWND hwnd) => ((WPARAM)MAKELONG(id, msg), (LPARAM)(hwnd));
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_PARENTNOTIFY2_MPS(ushort msg, int x, int y) => ((WPARAM)MAKELONG(0, msg), MAKELONG(x, y));
+
+        public static int GET_WM_VKEYTOITEM_CODE(WPARAM wp, LPARAM lp) => (int)(short)LOWORD(wp);
+
+        public static ushort GET_WM_VKEYTOITEM_ITEM(WPARAM wp, LPARAM lp) => HIWORD(wp);
+
+        public static HWND GET_WM_VKEYTOITEM_HWND(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_VKEYTOITEM_MPS(int code, ushort item, HWND hwnd) => ((WPARAM)MAKELONG(item, code), (LPARAM)(hwnd));
+
+        public static int GET_EM_SETSEL_START(WPARAM wp, LPARAM lp) => (int)(wp);
+
+        public static LPARAM GET_EM_SETSEL_END(WPARAM wp, LPARAM lp) => (lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_EM_SETSEL_MPS(int iStart, LPARAM iEnd) => ((WPARAM)(iStart), (LPARAM)(iEnd));
+
+        public static (WPARAM wp, LPARAM lp) GET_EM_LINESCROLL_MPS(WPARAM vert, LPARAM horz) => ((WPARAM)horz, (LPARAM)vert);
+
+        public static HWND GET_WM_CHANGECBCHAIN_HWNDNEXT(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static ushort GET_WM_HSCROLL_CODE(WPARAM wp, LPARAM lp) => LOWORD(wp);
+
+        public static ushort GET_WM_HSCROLL_POS(WPARAM wp, LPARAM lp) => HIWORD(wp);
+
+        public static HWND GET_WM_HSCROLL_HWND(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_HSCROLL_MPS(ushort code, ushort pos, HWND hwnd) => ((WPARAM)MAKELONG(code, pos), (LPARAM)(hwnd));
+
+        public static ushort GET_WM_VSCROLL_CODE(WPARAM wp, LPARAM lp) => LOWORD(wp);
+
+        public static ushort GET_WM_VSCROLL_POS(WPARAM wp, LPARAM lp) => HIWORD(wp);
+
+        public static HWND GET_WM_VSCROLL_HWND(WPARAM wp, LPARAM lp) => (HWND)(lp);
+
+        public static (WPARAM wp, LPARAM lp) GET_WM_VSCROLL_MPS(ushort code, ushort pos, HWND hwnd) => ((WPARAM)MAKELONG(code, pos), (LPARAM)(hwnd));
+    }
+}

--- a/sources/Interop/Windows/shared/winerror/Windows.Manual.cs
+++ b/sources/Interop/Windows/shared/winerror/Windows.Manual.cs
@@ -7,79 +7,69 @@ namespace TerraFX.Interop
 {
     public static partial class Windows
     {
-        public static bool SUCCEEDED(int hr)
+        public static bool SUCCEEDED(HRESULT hr)
         {
             return hr >= 0;
         }
 
-        public static bool FAILED(int hr)
+        public static bool FAILED(HRESULT hr)
         {
             return hr < 0;
         }
 
-        public static bool IS_ERROR(int Status)
+        public static bool IS_ERROR(HRESULT Status)
         {
             return ((uint)Status >> 31) == SEVERITY_ERROR;
         }
 
-        public static int HRESULT_CODE(int hr)
+        public static int HRESULT_CODE(HRESULT hr)
         {
             return hr & 0xFFFF;
         }
 
-        public static int SCODE_CODE(int sc)
+        public static int SCODE_CODE(HRESULT sc)
         {
             return sc & 0xFFFF;
         }
 
-        public static int HRESULT_FACILITY(int hr)
+        public static int HRESULT_FACILITY(HRESULT hr)
         {
             return (hr >> 16) & 0x1FFF;
         }
 
-        public static int SCODE_FACILITY(int sc)
+        public static int SCODE_FACILITY(HRESULT sc)
         {
             return (sc >> 16) & 0x1FFF;
         }
 
-        public static int HRESULT_SEVERITY(int hr)
+        public static int HRESULT_SEVERITY(HRESULT hr)
         {
             return (hr >> 31) & 0x1;
         }
 
-        public static int SCODE_SEVERITY(int sc)
+        public static int SCODE_SEVERITY(HRESULT sc)
         {
             return (sc >> 31) & 0x1;
         }
 
-        public static int MAKE_HRESULT(int sev, int fac, int code)
+        public static HRESULT MAKE_HRESULT(int sev, int fac, int code)
         {
             return (int)(((uint)sev << 31) | ((uint)fac << 16) | (uint)code);
         }
 
-        public static int MAKE_SCODE(int sev, int fac, int code)
+        public static HRESULT MAKE_SCODE(int sev, int fac, int code)
         {
             return (int)(((uint)sev << 31) | ((uint)fac << 16) | (uint)code);
         }
 
-        public static int __HRESULT_FROM_WIN32(int x)
+        public static HRESULT HRESULT_FROM_WIN32(int x)
         {
             return (x <= 0) ? x : ((x & 0x0000FFFF) | (FACILITY_WIN32 << 16) | unchecked((int)0x80000000));
         }
 
-        public static int HRESULT_FROM_WIN32(int x)
-        {
-            return __HRESULT_FROM_WIN32(x);
-        }
-
-        public static int __HRESULT_FROM_NT(int x)
+        public static HRESULT HRESULT_FROM_NT(int x)
         {
             return ((HRESULT)((x) | FACILITY_NT_BIT));
-        }
-
-        public static int HRESULT_FROM_NT(int x)
-        {
-            return __HRESULT_FROM_NT(x);
         }
     }
 }

--- a/sources/Interop/Windows/um/Audioclient/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/Audioclient/Windows.Manual.cs
@@ -7,8 +7,8 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        public static int AUDCLNT_ERR(int n) => MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, n);
+        public static HRESULT AUDCLNT_ERR(int n) => MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, n);
 
-        public static int AUDCLNT_SUCCESS(int n) => MAKE_SCODE(SEVERITY_SUCCESS, FACILITY_AUDCLNT, n);        
+        public static HRESULT AUDCLNT_SUCCESS(int n) => MAKE_SCODE(SEVERITY_SUCCESS, FACILITY_AUDCLNT, n);        
     }
 }

--- a/sources/Interop/Windows/um/CommCtrl/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/CommCtrl/Windows.Manual.cs
@@ -16,17 +16,16 @@ namespace TerraFX.Interop
         [DllImport("comctl32", EntryPoint = "CreateToolbarEx", ExactSpelling = true, SetLastError = true)]
         public static extern HWND CreateToolbarEx64(HWND hwnd, [NativeTypeName("DWORD")] uint ws, uint wID, int nBitmaps, HINSTANCE hBMInst, [NativeTypeName("UINT_PTR")] nuint wBMID, [NativeTypeName("LPCTBBUTTON")] TBBUTTON64* lpButtons, int iNumButtons, int dxButton, int dyButton, int dxBitmap, int dyBitmap, uint uStructSize);
 
-        public static int FlatSB_GetScrollPropPtr(HWND param0, int propIndex, int* param2)
+        public static BOOL FlatSB_GetScrollPropPtr(HWND param0, int propIndex, nint* param2)
         {
             if (sizeof(nint) == 4)
             {
-                return FlatSB_GetScrollProp(param0, propIndex, param2);
+                return FlatSB_GetScrollProp(param0, propIndex, (int*)param2);
             }
             else
             {
                 [DllImport("comctl32", EntryPoint = "FlatSB_GetScrollPropPtr", ExactSpelling = true)]
-                [return: NativeTypeName("LONG_PTR")]
-                static extern int _FlatSB_GetScrollPropPtr(HWND param0, int propIndex, int* param2);
+                static extern BOOL _FlatSB_GetScrollPropPtr(HWND param0, int propIndex, nint* param2);
 
                 return _FlatSB_GetScrollPropPtr(param0, propIndex, param2);
             }

--- a/sources/Interop/Windows/um/D2DErr/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/D2DErr/Windows.Manual.cs
@@ -7,8 +7,8 @@ namespace TerraFX.Interop
 {
     public static partial class Windows
     {
-        public static int MAKE_D2DHR(int sev, int code) => MAKE_HRESULT(sev, FACILITY_D2D, code);
+        public static HRESULT MAKE_D2DHR(int sev, int code) => MAKE_HRESULT(sev, FACILITY_D2D, code);
 
-        public static int MAKE_D2DHR_ERR(int code) => MAKE_D2DHR(1, code);
+        public static HRESULT MAKE_D2DHR_ERR(int code) => MAKE_D2DHR(1, code);
     }
 }

--- a/sources/Interop/Windows/um/SetupAPI/SP_INSTALLWIZARD_DATA.Manual.cs
+++ b/sources/Interop/Windows/um/SetupAPI/SP_INSTALLWIZARD_DATA.Manual.cs
@@ -128,8 +128,7 @@ namespace TerraFX.Interop
             }
         }
 
-        [NativeTypeName("LPARAM")]
-        public ref nint PrivateData
+        public ref LPARAM PrivateData
         {
             get
             {

--- a/sources/Interop/Windows/um/SetupAPI/SP_INSTALLWIZARD_DATA32.Manual.cs
+++ b/sources/Interop/Windows/um/SetupAPI/SP_INSTALLWIZARD_DATA32.Manual.cs
@@ -29,8 +29,7 @@ namespace TerraFX.Interop
         [NativeTypeName("DWORD")]
         public uint PrivateFlags;
 
-        [NativeTypeName("LPARAM")]
-        public nint PrivateData;
+        public LPARAM PrivateData;
 
         public HWND hwndWizardDlg;
 

--- a/sources/Interop/Windows/um/SetupAPI/SP_INSTALLWIZARD_DATA64.Manual.cs
+++ b/sources/Interop/Windows/um/SetupAPI/SP_INSTALLWIZARD_DATA64.Manual.cs
@@ -28,8 +28,7 @@ namespace TerraFX.Interop
         [NativeTypeName("DWORD")]
         public uint PrivateFlags;
 
-        [NativeTypeName("LPARAM")]
-        public nint PrivateData;
+        public LPARAM PrivateData;
 
         public HWND hwndWizardDlg;
 

--- a/sources/Interop/Windows/um/ShObjIdl/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/ShObjIdl/Windows.Manual.cs
@@ -16,7 +16,7 @@ namespace TerraFX.Interop
         {
             *ppszResolvedPath = null;
             ITEMIDLIST* pidlFolder = SHSimpleIDListFromPath(pszFolderPath);
-            int hr = unchecked((pidlFolder) != null ? ((int)(0)) : ((int)(0x80070057)));
+            HRESULT hr = unchecked((pidlFolder) != null ? ((int)(0)) : ((int)(0x80070057)));
 
             if (((unchecked((int)(hr))) >= 0))
             {
@@ -31,10 +31,10 @@ namespace TerraFX.Interop
                     if (((unchecked((int)(hr))) >= 0))
                     {
                         unchecked(hr) = psiResolved->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, ppszResolvedPath);
-                        psiResolved->Release();
+                        _ = psiResolved->Release();
                     }
 
-                    psiFolder->Release();
+                    _ = psiFolder->Release();
                 }
 
                 CoTaskMemFree(pidlFolder);

--- a/sources/Interop/Windows/um/ShObjIdl_core/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/ShObjIdl_core/Windows.Manual.cs
@@ -25,7 +25,7 @@ namespace TerraFX.Interop
         {
             *ppv = null;
             IShellLibrary* plib;
-            int hr;
+            HRESULT hr;
 
             fixed (Guid* rclsid = &CLSID_ShellLibrary)
             {
@@ -40,7 +40,7 @@ namespace TerraFX.Interop
                     hr = plib->QueryInterface(riid, ppv);
                 }
 
-                plib->Release();
+                _ = plib->Release();
             }
 
             return hr;
@@ -50,7 +50,7 @@ namespace TerraFX.Interop
         {
             *ppv = null;
             IShellLibrary* plib;
-            int hr;
+            HRESULT hr;
 
             fixed (Guid* rclsid = &CLSID_ShellLibrary)
             {
@@ -65,7 +65,7 @@ namespace TerraFX.Interop
                     hr = plib->QueryInterface(riid, ppv);
                 }
 
-                plib->Release();
+                _ = plib->Release();
             }
 
             return hr;
@@ -75,12 +75,12 @@ namespace TerraFX.Interop
         {
             *ppv = null;
             IShellItem* psiLibrary;
-            int hr = SHCreateItemFromParsingName(pszParsingName, null, __uuidof<IShellItem>(), (void**)(&psiLibrary));
+            HRESULT hr = SHCreateItemFromParsingName(pszParsingName, null, __uuidof<IShellItem>(), (void**)(&psiLibrary));
 
             if ((((int)(hr)) >= 0))
             {
                 hr = SHLoadLibraryFromItem(psiLibrary, grfMode, riid, ppv);
-                psiLibrary->Release();
+                _ = psiLibrary->Release();
             }
 
             return hr;
@@ -89,12 +89,12 @@ namespace TerraFX.Interop
         public static HRESULT SHAddFolderPathToLibrary(IShellLibrary* plib, [NativeTypeName("PCWSTR")] ushort* pszFolderPath)
         {
             IShellItem* psiFolder;
-            int hr = SHCreateItemFromParsingName(pszFolderPath, null, __uuidof<IShellItem>(), (void**)(&psiFolder));
+            HRESULT hr = SHCreateItemFromParsingName(pszFolderPath, null, __uuidof<IShellItem>(), (void**)(&psiFolder));
 
             if ((((int)(hr)) >= 0))
             {
                 hr = plib->AddFolder(psiFolder);
-                psiFolder->Release();
+                _ = psiFolder->Release();
             }
 
             return hr;
@@ -103,7 +103,7 @@ namespace TerraFX.Interop
         public static HRESULT SHRemoveFolderPathFromLibrary(IShellLibrary* plib, [NativeTypeName("PCWSTR")] ushort* pszFolderPath)
         {
             ITEMIDLIST* pidlFolder = SHSimpleIDListFromPath(pszFolderPath);
-            int hr = unchecked((pidlFolder) != null ? ((int)(0)) : ((int)(0x80070057)));
+            HRESULT hr = unchecked((pidlFolder) != null ? ((int)(0)) : ((int)(0x80070057)));
 
             if (((unchecked((int)(hr))) >= 0))
             {
@@ -113,7 +113,7 @@ namespace TerraFX.Interop
                 if (((unchecked((int)(hr))) >= 0))
                 {
                     unchecked(hr) = plib->RemoveFolder(psiFolder);
-                    psiFolder->Release();
+                    _ = psiFolder->Release();
                 }
 
                 CoTaskMemFree(pidlFolder);
@@ -130,7 +130,7 @@ namespace TerraFX.Interop
             }
 
             IShellItem* psiFolder;
-            int hr = SHCreateItemFromParsingName(pszFolderPath, null, __uuidof<IShellItem>(), (void**)(&psiFolder));
+            HRESULT hr = SHCreateItemFromParsingName(pszFolderPath, null, __uuidof<IShellItem>(), (void**)(&psiFolder));
 
             if ((((int)(hr)) >= 0))
             {
@@ -144,10 +144,10 @@ namespace TerraFX.Interop
                         hr = psiSavedTo->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, ppszSavedToPath);
                     }
 
-                    psiSavedTo->Release();
+                    _ = psiSavedTo->Release();
                 }
 
-                psiFolder->Release();
+                _ = psiFolder->Release();
             }
 
             return hr;
@@ -159,11 +159,11 @@ namespace TerraFX.Interop
             {
                 if (hwndDelegate != (nint)(0))
                 {
-                    SetPropW(hwndSource, (ushort*)(lpString), (HANDLE)(hwndDelegate));
+                    _ = SetPropW(hwndSource, (ushort*)(lpString), (HANDLE)(hwndDelegate));
                 }
                 else
                 {
-                    RemovePropW(hwndSource, (ushort*)(lpString));
+                    _ = RemovePropW(hwndSource, (ushort*)(lpString));
                 }
             }
         }

--- a/sources/Interop/Windows/um/SpatialAudioHrtf/SpatialAudioHrtfActivationParams.Manual.cs
+++ b/sources/Interop/Windows/um/SpatialAudioHrtf/SpatialAudioHrtfActivationParams.Manual.cs
@@ -25,16 +25,12 @@ namespace TerraFX.Interop
 
         public HANDLE EventHandle;
 
-        [NativeTypeName("ISpatialAudioObjectRenderStreamNotify *")]
         public ISpatialAudioObjectRenderStreamNotify* NotifyObject;
 
-        [NativeTypeName("SpatialAudioHrtfDistanceDecay *")]
         public SpatialAudioHrtfDistanceDecay* DistanceDecay;
 
-        [NativeTypeName("SpatialAudioHrtfDirectivityUnion *")]
         public SpatialAudioHrtfDirectivityUnion* Directivity;
 
-        [NativeTypeName("SpatialAudioHrtfEnvironmentType *")]
         public SpatialAudioHrtfEnvironmentType* Environment;
 
         [NativeTypeName("SpatialAudioHrtfOrientation *")]

--- a/sources/Interop/Windows/um/Uxtheme/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/Uxtheme/Windows.Manual.cs
@@ -9,11 +9,11 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        public static int BufferedPaintMakeOpaque(HPAINTBUFFER hBufferedPaint, RECT* prc) => BufferedPaintSetAlpha(hBufferedPaint, prc, 255);
+        public static HRESULT BufferedPaintMakeOpaque(HPAINTBUFFER hBufferedPaint, RECT* prc) => BufferedPaintSetAlpha(hBufferedPaint, prc, 255);
 
-        public static int SetWindowThemeNonClientAttributes(HWND hwnd, uint dwMask, uint dwAttributes)
+        public static HRESULT SetWindowThemeNonClientAttributes(HWND hwnd, uint dwMask, uint dwAttributes)
         {
-            WTA_OPTIONS wta = new WTA_OPTIONS();
+            var wta = new WTA_OPTIONS();
             wta.dwFlags = dwAttributes;
             wta.dwMask = dwMask;
             return SetWindowThemeAttribute(hwnd, WTA_NONCLIENT, (void*)&(wta), (uint) sizeof(WTA_OPTIONS));

--- a/sources/Interop/Windows/um/WinUser/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/WinUser/Windows.Manual.cs
@@ -195,52 +195,49 @@ namespace TerraFX.Interop
         public static int POINTTOPOINTS(POINTS pt) => MAKELONG((ushort)pt.x, (ushort)pt.y);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("WPARAM")]
-        public static nuint MAKEWPARAM(ushort l, ushort h) => (nuint)MAKELONG(l, h);
+        public static WPARAM MAKEWPARAM(ushort l, ushort h) => (nuint)MAKELONG(l, h);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("LPARAM")]
-        public static nint MAKELPARAM(ushort l, ushort h) => MAKELONG(l, h);
+        public static LPARAM MAKELPARAM(ushort l, ushort h) => MAKELONG(l, h);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("LRESULT")]
-        public static nint MAKELRESULT(ushort l, ushort h) => MAKELONG(l, h);
+        public static LRESULT MAKELRESULT(ushort l, ushort h) => MAKELONG(l, h);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short GET_APPCOMMAND_LPARAM([NativeTypeName("LPARAM")] nint lParam) => unchecked((short)(HIWORD((uint)lParam) & ~FAPPCOMMAND_MASK));
+        public static short GET_APPCOMMAND_LPARAM(LPARAM lParam) => unchecked((short)(HIWORD((uint)lParam) & ~FAPPCOMMAND_MASK));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_DEVICE_LPARAM([NativeTypeName("LPARAM")] nint lParam) => unchecked((ushort)(HIWORD((uint)lParam) & FAPPCOMMAND_MASK));
+        public static ushort GET_DEVICE_LPARAM(LPARAM lParam) => unchecked((ushort)(HIWORD((uint)lParam) & FAPPCOMMAND_MASK));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_MOUSEORKEY_LPARAM([NativeTypeName("LPARAM")] nint lParam) => GET_DEVICE_LPARAM(lParam);
+        public static ushort GET_MOUSEORKEY_LPARAM(LPARAM lParam) => GET_DEVICE_LPARAM(lParam);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_FLAGS_LPARAM([NativeTypeName("LPARAM")] nint lParam) => LOWORD(unchecked((uint)lParam));
+        public static ushort GET_FLAGS_LPARAM(LPARAM lParam) => LOWORD(unchecked((uint)lParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_KEYSTATE_LPARAM([NativeTypeName("LPARAM")] nint lParam) => GET_FLAGS_LPARAM(lParam);
+        public static ushort GET_KEYSTATE_LPARAM(LPARAM lParam) => GET_FLAGS_LPARAM(lParam);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short GET_WHEEL_DELTA_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => unchecked((short)HIWORD((uint)wParam));
+        public static short GET_WHEEL_DELTA_WPARAM(WPARAM wParam) => unchecked((short)HIWORD((uint)wParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_KEYSTATE_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => LOWORD(unchecked((uint)wParam));
+        public static ushort GET_KEYSTATE_WPARAM(WPARAM wParam) => LOWORD(unchecked((uint)wParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short GET_NCHITTEST_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => unchecked((short)LOWORD((uint)wParam));
+        public static short GET_NCHITTEST_WPARAM(WPARAM wParam) => unchecked((short)LOWORD((uint)wParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_XBUTTON_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => HIWORD(unchecked((uint)wParam));
+        public static ushort GET_XBUTTON_WPARAM(WPARAM wParam) => HIWORD(unchecked((uint)wParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BOOL ExitWindows(uint dwReserved, int Code) => ExitWindowsEx(EWX_LOGOFF, 0xFFFFFFFF);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BOOL PostAppMessageA([NativeTypeName("DWORD")] uint idThread, uint wMsg, [NativeTypeName("WPARAM")] nuint wParam, [NativeTypeName("LPARAM")] nint lParam) => PostThreadMessageA(idThread, wMsg, wParam, lParam);
+        public static BOOL PostAppMessageA([NativeTypeName("DWORD")] uint idThread, uint wMsg, WPARAM wParam, LPARAM lParam) => PostThreadMessageA(idThread, wMsg, wParam, lParam);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BOOL PostAppMessageW([NativeTypeName("DWORD")] uint idThread, uint wMsg, [NativeTypeName("WPARAM")] nuint wParam, [NativeTypeName("LPARAM")] nint lParam) => PostThreadMessageW(idThread, wMsg, wParam, lParam);
+        public static BOOL PostAppMessageW([NativeTypeName("DWORD")] uint idThread, uint wMsg, WPARAM wParam, LPARAM lParam) => PostThreadMessageW(idThread, wMsg, wParam, lParam);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static HWND CreateWindowA([NativeTypeName("LPCSTR")] sbyte* lpClassName, [NativeTypeName("LPCSTR")] sbyte* lpWindowName, [NativeTypeName("DWORD")] uint dwStyle, int x, int y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, [NativeTypeName("LPVOID")] void* lpParam) => CreateWindowExA(0, lpClassName, lpWindowName, dwStyle, x, y,nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
@@ -280,43 +277,43 @@ namespace TerraFX.Interop
         public static int TOUCH_COORD_TO_PIXEL(int l) => l / 100;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_POINTERID_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => LOWORD(unchecked((uint)wParam));
+        public static ushort GET_POINTERID_WPARAM(WPARAM wParam) => LOWORD(unchecked((uint)wParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_FLAG_SET_WPARAM([NativeTypeName("WPARAM")] nuint wParam, uint flag) => (HIWORD(unchecked((uint)wParam)) & flag) == flag;
+        public static bool IS_POINTER_FLAG_SET_WPARAM(WPARAM wParam, uint flag) => (HIWORD(unchecked((uint)wParam)) & flag) == flag;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_NEW_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_NEW);
+        public static bool IS_POINTER_NEW_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_NEW);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_INRANGE_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_INRANGE);
+        public static bool IS_POINTER_INRANGE_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_INRANGE);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_INCONTACT_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_INCONTACT);
+        public static bool IS_POINTER_INCONTACT_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_INCONTACT);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_FIRSTBUTTON_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_FIRSTBUTTON);
+        public static bool IS_POINTER_FIRSTBUTTON_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_FIRSTBUTTON);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_SECONDBUTTON_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_SECONDBUTTON);
+        public static bool IS_POINTER_SECONDBUTTON_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_SECONDBUTTON);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_THIRDBUTTON_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_THIRDBUTTON);
+        public static bool IS_POINTER_THIRDBUTTON_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_THIRDBUTTON);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_FOURTHBUTTON_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_FOURTHBUTTON);
+        public static bool IS_POINTER_FOURTHBUTTON_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_FOURTHBUTTON);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_FIFTHBUTTON_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_FIFTHBUTTON);
+        public static bool IS_POINTER_FIFTHBUTTON_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_FIFTHBUTTON);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_PRIMARY_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_PRIMARY);
+        public static bool IS_POINTER_PRIMARY_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_PRIMARY);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool HAS_POINTER_CONFIDENCE_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_CONFIDENCE);
+        public static bool HAS_POINTER_CONFIDENCE_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_CONFIDENCE);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IS_POINTER_CANCELED_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_CANCELED);
+        public static bool IS_POINTER_CANCELED_WPARAM(WPARAM wParam) => IS_POINTER_FLAG_SET_WPARAM(wParam, POINTER_MESSAGE_FLAG_CANCELED);
 
         [NativeTypeName("#define GetWindowLongPtr GetWindowLongPtrW")]
         public static delegate*<HWND, int, nint> GetWindowLongPtr => &GetWindowLongPtrW;
@@ -467,7 +464,7 @@ namespace TerraFX.Interop
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BOOL EnumTaskWindows(IntPtr hTask, [NativeTypeName("WNDENUMPROC")] delegate* unmanaged<HWND, LPARAM, BOOL> lpfn, [NativeTypeName("LPARAM")] nint lParam) => EnumThreadWindows((uint)hTask, lpfn, lParam);
+        public static BOOL EnumTaskWindows(IntPtr hTask, [NativeTypeName("WNDENUMPROC")] delegate* unmanaged<HWND, LPARAM, BOOL> lpfn, LPARAM lParam) => EnumThreadWindows((uint)hTask, lpfn, lParam);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static HWND GetNextWindow(HWND hWnd, ushort wCmd) => GetWindow(hWnd, wCmd);
@@ -482,14 +479,13 @@ namespace TerraFX.Interop
         public static HANDLE GetWindowTask(HWND hWnd) => (HANDLE)GetWindowThreadProcessId(hWnd, null);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("LRESULT")]
-        public static IntPtr DefHookProc(int nCode, [NativeTypeName("WPARAM")] nuint wParam, [NativeTypeName("LPARAM")] nint lParam, HHOOK phhk) => CallNextHookEx(phhk, nCode, wParam, lParam);
+        public static LRESULT DefHookProc(int nCode, WPARAM wParam, LPARAM lParam, HHOOK phhk) => CallNextHookEx(phhk, nCode, wParam, lParam);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GET_SC_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => unchecked((int)(wParam & 0xFFF0));
+        public static int GET_SC_WPARAM(WPARAM wParam) => unchecked((int)(wParam & 0xFFF0));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static nuint GET_RAWINPUT_CODE_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => wParam & 0xFF;
+        public static nuint GET_RAWINPUT_CODE_WPARAM(WPARAM wParam) => wParam & (nuint)(0xFFu);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint RAWINPUT_ALIGN(nint x) => (x + sizeof(nint) - 1) & ~(sizeof(nint) - 1);
@@ -501,10 +497,10 @@ namespace TerraFX.Interop
         public static int RIDEV_EXMODE(int mode) => mode & RIDEV_EXMODEMASK;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_DEVICE_CHANGE_WPARAM([NativeTypeName("WPARAM")] nuint wParam) => LOWORD(unchecked((uint)wParam));
+        public static ushort GET_DEVICE_CHANGE_WPARAM(WPARAM wParam) => LOWORD(unchecked((uint)wParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort GET_DEVICE_CHANGE_LPARAM([NativeTypeName("LPARAM")] nint lParam) => LOWORD(unchecked((uint)lParam));
+        public static ushort GET_DEVICE_CHANGE_LPARAM(LPARAM lParam) => LOWORD(unchecked((uint)lParam));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort GID_ROTATE_ANGLE_TO_ARGUMENT(ushort _arg_) => (ushort)((_arg_ + (2.0 * 3.14159265)) / (4.0 * 3.14159265) * 65535.0);

--- a/sources/Interop/Windows/um/WinUser/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/WinUser/Windows.Manual.cs
@@ -186,22 +186,31 @@ namespace TerraFX.Interop
         public static POINT POINTSTOPOINT(POINTS pts)
         {
             return new POINT {
-                x = (short)LOWORD(*(uint*)&pts),
-                y = (short)HIWORD(*(uint*)&pts),
+                x = unchecked((int)(short)LOWORD(*(int*)&pts)),
+                y = unchecked((int)(short)HIWORD(*(int*)&pts)),
             };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int POINTTOPOINTS(POINTS pt) => MAKELONG((ushort)pt.x, (ushort)pt.y);
+        public static int POINTTOPOINTS(POINTS pt) => unchecked(MAKELONG((nuint)(short)pt.x, (nuint)(short)pt.y));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static WPARAM MAKEWPARAM(ushort l, ushort h) => (nuint)MAKELONG(l, h);
+        public static WPARAM MAKEWPARAM([NativeTypeName("DWORD_PTR")] nuint l, [NativeTypeName("DWORD_PTR")] nuint h) => unchecked((WPARAM)(uint)MAKELONG(l, h));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static LPARAM MAKELPARAM(ushort l, ushort h) => MAKELONG(l, h);
+        public static WPARAM MAKEWPARAM(nint l, nint h) => unchecked(MAKEWPARAM((nuint)(l), (nuint)(h)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static LRESULT MAKELRESULT(ushort l, ushort h) => MAKELONG(l, h);
+        public static LPARAM MAKELPARAM([NativeTypeName("DWORD_PTR")] nuint l, [NativeTypeName("DWORD_PTR")] nuint h) => unchecked((LPARAM)(uint)MAKELONG(l, h));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static LPARAM MAKELPARAM(nint l, nint h) => unchecked(MAKELPARAM((nuint)(l), (nuint)(h)));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static LRESULT MAKELRESULT([NativeTypeName("DWORD_PTR")] nuint l, [NativeTypeName("DWORD_PTR")] nuint h) => unchecked((LRESULT)(uint)MAKELONG(l, h));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static LRESULT MAKELRESULT(nint l, nint h) => unchecked(MAKELRESULT((nuint)(l), (nuint)(h)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short GET_APPCOMMAND_LPARAM(LPARAM lParam) => unchecked((short)(HIWORD((uint)lParam) & ~FAPPCOMMAND_MASK));

--- a/sources/Interop/Windows/um/d2d1/D2D1_LAYER_PARAMETERS.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1/D2D1_LAYER_PARAMETERS.Manual.cs
@@ -68,22 +68,22 @@ namespace TerraFX.Interop
             }
         }
 
-        public D2D1_LAYER_PARAMETERS([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public D2D1_LAYER_PARAMETERS([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
              : this(InfiniteRect, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions)
         {
         }
 
-        public D2D1_LAYER_PARAMETERS([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public D2D1_LAYER_PARAMETERS([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
             : this(contentBounds, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions)
         {
         }
 
-        public D2D1_LAYER_PARAMETERS([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public D2D1_LAYER_PARAMETERS([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
             : this(InfiniteRect, geometricMask, maskAntialiasMode, maskTransform, opacity, opacityBrush, layerOptions)
         {
         }
 
-        public D2D1_LAYER_PARAMETERS([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public D2D1_LAYER_PARAMETERS([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
         {
             this = LayerParameters(contentBounds, geometricMask, maskAntialiasMode, maskTransform, opacity, opacityBrush, layerOptions);
         }

--- a/sources/Interop/Windows/um/d2d1/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1/Windows.Manual.cs
@@ -25,14 +25,14 @@ namespace TerraFX.Interop
 
         public const uint D2D1_INTERPOLATION_MODE_DEFINITION_MIPMAP_LINEAR = 7;
 
-        public static HRESULT D2D1CreateFactory<Factory>(D2D1_FACTORY_TYPE factoryType, [NativeTypeName("void **")] void** factory)
+        public static HRESULT D2D1CreateFactory<Factory>(D2D1_FACTORY_TYPE factoryType, void** factory)
             where Factory : unmanaged
         {
             var iid = typeof(Factory).GUID;
             return D2D1CreateFactory(factoryType, &iid, null, factory);
         }
 
-        public static HRESULT D2D1CreateFactory<Factory>(D2D1_FACTORY_TYPE factoryType, [NativeTypeName("const D2D1_FACTORY_OPTIONS *")] D2D1_FACTORY_OPTIONS* pFactoryOptions, [NativeTypeName("void **")] void** factory)
+        public static HRESULT D2D1CreateFactory<Factory>(D2D1_FACTORY_TYPE factoryType, [NativeTypeName("const D2D1_FACTORY_OPTIONS *")] D2D1_FACTORY_OPTIONS* pFactoryOptions, void** factory)
             where Factory : unmanaged
         {
             var iid = typeof(Factory).GUID;

--- a/sources/Interop/Windows/um/d2d1_1/D2D1_EFFECT_INPUT_DESCRIPTION.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1_1/D2D1_EFFECT_INPUT_DESCRIPTION.Manual.cs
@@ -9,7 +9,7 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct D2D1_EFFECT_INPUT_DESCRIPTION
     {
-        public D2D1_EFFECT_INPUT_DESCRIPTION([NativeTypeName("ID2D1Effect *")] ID2D1Effect* effect, [NativeTypeName("UINT32")] uint inputIndex, [NativeTypeName("D2D1_RECT_F")] D2D_RECT_F inputRectangle)
+        public D2D1_EFFECT_INPUT_DESCRIPTION(ID2D1Effect* effect, [NativeTypeName("UINT32")] uint inputIndex, [NativeTypeName("D2D1_RECT_F")] D2D_RECT_F inputRectangle)
         {
             this = EffectInputDescription(effect, inputIndex, inputRectangle);
         }

--- a/sources/Interop/Windows/um/d2d1_1/D2D1_LAYER_PARAMETERS1.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1_1/D2D1_LAYER_PARAMETERS1.Manual.cs
@@ -68,22 +68,22 @@ namespace TerraFX.Interop
             }
         }
 
-        public D2D1_LAYER_PARAMETERS1([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public D2D1_LAYER_PARAMETERS1([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
              : this(InfiniteRect, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions)
         {
         }
 
-        public D2D1_LAYER_PARAMETERS1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public D2D1_LAYER_PARAMETERS1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
             : this(contentBounds, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions)
         {
         }
 
-        public D2D1_LAYER_PARAMETERS1([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public D2D1_LAYER_PARAMETERS1([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
             : this(InfiniteRect, geometricMask, maskAntialiasMode, maskTransform, opacity, opacityBrush, layerOptions)
         {
         }
 
-        public D2D1_LAYER_PARAMETERS1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public D2D1_LAYER_PARAMETERS1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
         {
             this = LayerParameters1(contentBounds, geometricMask, maskAntialiasMode, maskTransform, opacity, opacityBrush, layerOptions);
         }

--- a/sources/Interop/Windows/um/d2d1_1/ID2D1Effect.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1_1/ID2D1Effect.Manual.cs
@@ -17,7 +17,7 @@ namespace TerraFX.Interop
             where T : unmanaged
         {
             T value;
-            int ignoreHr = GetValueByName(propertyName, (byte*)&value, unchecked((uint)sizeof(T)));
+            _ = GetValueByName(propertyName, (byte*)&value, unchecked((uint)sizeof(T)));
             return value;
         }
 
@@ -45,7 +45,7 @@ namespace TerraFX.Interop
             where U : unmanaged
         {
             T value;
-            int ignoreHr = GetValue((uint)(object)index, (byte*)&value, unchecked((uint)sizeof(T)));
+            _ = GetValue((uint)(object)index, (byte*)&value, unchecked((uint)sizeof(T)));
             return value;
         }
 

--- a/sources/Interop/Windows/um/d2d1_1/ID2D1Properties.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1_1/ID2D1Properties.Manual.cs
@@ -17,7 +17,7 @@ namespace TerraFX.Interop
             where T : unmanaged
         {
             T value;
-            int ignoreHr = GetValueByName(propertyName, (byte*)&value, unchecked((uint)sizeof(T)));
+            _ = GetValueByName(propertyName, (byte*)&value, unchecked((uint)sizeof(T)));
             return value;
         }
 
@@ -45,7 +45,7 @@ namespace TerraFX.Interop
             where U : unmanaged
         {
             T value;
-            int ignoreHr = GetValue((uint)(object)index, (byte*)&value, unchecked((uint)sizeof(T)));
+            _ = GetValue((uint)(object)index, (byte*)&value, unchecked((uint)sizeof(T)));
             return value;
         }
 

--- a/sources/Interop/Windows/um/d2d1_1helper/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1_1helper/Windows.Manual.cs
@@ -80,22 +80,22 @@ namespace TerraFX.Interop
             return bitmapProperties;
         }
 
-        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
         {
             return LayerParameters1(InfiniteRect, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions);
         }
 
-        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
         {
             return LayerParameters1(contentBounds, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions);
         }
 
-        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
         {
             return LayerParameters1(InfiniteRect, geometricMask, maskAntialiasMode, maskTransform, opacity, opacityBrush, layerOptions);
         }
 
-        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
+        public static D2D1_LAYER_PARAMETERS1 LayerParameters1([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS1 layerOptions = D2D1_LAYER_OPTIONS1_NONE)
         {
             D2D1_LAYER_PARAMETERS1 layerParameters = default;
 
@@ -170,7 +170,7 @@ namespace TerraFX.Interop
             return renderingControls;
         }
 
-        public static D2D1_EFFECT_INPUT_DESCRIPTION EffectInputDescription([NativeTypeName("ID2D1Effect *")] ID2D1Effect* effect, [NativeTypeName("UINT32")] uint inputIndex, [NativeTypeName("D2D1_RECT_F")] D2D_RECT_F inputRectangle)
+        public static D2D1_EFFECT_INPUT_DESCRIPTION EffectInputDescription(ID2D1Effect* effect, [NativeTypeName("UINT32")] uint inputIndex, [NativeTypeName("D2D1_RECT_F")] D2D_RECT_F inputRectangle)
         {
             D2D1_EFFECT_INPUT_DESCRIPTION description;
 
@@ -252,9 +252,9 @@ namespace TerraFX.Interop
             return rect;
         }
 
-        public static HRESULT SetDpiCompensatedEffectInput([NativeTypeName("ID2D1DeviceContext *")] ID2D1DeviceContext *deviceContext, [NativeTypeName("ID2D1Effect *")] ID2D1Effect *effect, [NativeTypeName("UINT32")] uint inputIndex, [NativeTypeName("ID2D1Bitmap *")] ID2D1Bitmap* inputBitmap, D2D1_INTERPOLATION_MODE interpolationMode = D2D1_INTERPOLATION_MODE_LINEAR, D2D1_BORDER_MODE borderMode = D2D1_BORDER_MODE_HARD)
+        public static HRESULT SetDpiCompensatedEffectInput(ID2D1DeviceContext *deviceContext, ID2D1Effect *effect, [NativeTypeName("UINT32")] uint inputIndex, ID2D1Bitmap* inputBitmap, D2D1_INTERPOLATION_MODE interpolationMode = D2D1_INTERPOLATION_MODE_LINEAR, D2D1_BORDER_MODE borderMode = D2D1_BORDER_MODE_HARD)
         {
-            int hr = S_OK;
+            HRESULT hr = S_OK;
             ID2D1Effect *dpiCompensationEffect = null;
 
             if (inputBitmap != null)
@@ -295,7 +295,7 @@ namespace TerraFX.Interop
 
                 if (dpiCompensationEffect != null)
                 {
-                    dpiCompensationEffect->Release();
+                    _ = dpiCompensationEffect->Release();
                 }
             }
 

--- a/sources/Interop/Windows/um/d2d1helper/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1helper/Windows.Manual.cs
@@ -273,22 +273,22 @@ namespace TerraFX.Interop
             return hwndRenderTargetProperties;
         }
 
-        public static D2D1_LAYER_PARAMETERS LayerParameters([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public static D2D1_LAYER_PARAMETERS LayerParameters([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
         {
             return LayerParameters(InfiniteRect, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions);
         }
 
-        public static D2D1_LAYER_PARAMETERS LayerParameters([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public static D2D1_LAYER_PARAMETERS LayerParameters([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
         {
             return LayerParameters(contentBounds, geometricMask, maskAntialiasMode, IdentityMatrix, opacity, opacityBrush, layerOptions);
         }
 
-        public static D2D1_LAYER_PARAMETERS LayerParameters([NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public static D2D1_LAYER_PARAMETERS LayerParameters([Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush* opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
         {
             return LayerParameters(InfiniteRect, geometricMask, maskAntialiasMode, maskTransform, opacity, opacityBrush, layerOptions);
         }
 
-        public static D2D1_LAYER_PARAMETERS LayerParameters([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [NativeTypeName("ID2D1Geometry *"), Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, [NativeTypeName("ID2D1Brush *")] ID2D1Brush *opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
+        public static D2D1_LAYER_PARAMETERS LayerParameters([NativeTypeName("const D2D1_RECT_F")] in D2D_RECT_F contentBounds, [Optional] ID2D1Geometry* geometricMask, [Optional] D2D1_ANTIALIAS_MODE maskAntialiasMode, [NativeTypeName("D2D1_MATRIX_3X2_F")] D2D_MATRIX_3X2_F maskTransform, float opacity = 1.0f, ID2D1Brush *opacityBrush = null, D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE)
         {
             D2D1_LAYER_PARAMETERS layerParameters = default;
 

--- a/sources/Interop/Windows/um/d2d1svg/ID2D1SvgElement.Manual.cs
+++ b/sources/Interop/Windows/um/d2d1svg/ID2D1SvgElement.Manual.cs
@@ -9,31 +9,31 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct ID2D1SvgElement
     {
-        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, [NativeTypeName("ID2D1SvgAttribute **")] ID2D1SvgAttribute** value)
+        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, ID2D1SvgAttribute** value)
         {
             var iid = IID_ID2D1SvgAttribute;
             return GetAttributeValue(name, &iid, (void**)value);
         }
 
-        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, [NativeTypeName("ID2D1SvgPaint **")] ID2D1SvgPaint** value)
+        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, ID2D1SvgPaint** value)
         {
             var iid = IID_ID2D1SvgPaint;
             return GetAttributeValue(name, &iid, (void**)value);
         }
 
-        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, [NativeTypeName("ID2D1SvgStrokeDashArray **")] ID2D1SvgStrokeDashArray** value)
+        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, ID2D1SvgStrokeDashArray** value)
         {
             var iid = IID_ID2D1SvgStrokeDashArray;
             return GetAttributeValue(name, &iid, (void**)value);
         }
 
-        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, [NativeTypeName("ID2D1SvgPointCollection **")] ID2D1SvgPointCollection** value)
+        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, ID2D1SvgPointCollection** value)
         {
             var iid = IID_ID2D1SvgPointCollection;
             return GetAttributeValue(name, &iid, (void**)value);
         }
 
-        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, [NativeTypeName("ID2D1SvgPathData **")] ID2D1SvgPathData** value)
+        public HRESULT GetAttributeValue([NativeTypeName("PCWSTR")] ushort* name, ID2D1SvgPathData** value)
         {
             var iid = IID_ID2D1SvgPathData;
             return GetAttributeValue(name, &iid, (void**)value);

--- a/sources/Interop/Windows/um/d3d10/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/d3d10/Windows.Manual.cs
@@ -9,15 +9,9 @@ namespace TerraFX.Interop
 {
     public static partial class Windows
     {
-        public static int MAKE_D3D10_HRESULT(int code)
-        {
-            return MAKE_HRESULT(1, _FACD3D10, code);
-        }
+        public static HRESULT MAKE_D3D10_HRESULT(int code) => MAKE_HRESULT(1, _FACD3D10, code);
         
-        public static int MAKE_D3D10_STATUS(int code)
-        {
-            return MAKE_HRESULT(0, _FACD3D10, code);
-        }
+        public static HRESULT MAKE_D3D10_STATUS(int code) => MAKE_HRESULT(0, _FACD3D10, code);
 
         public static D3D10_FILTER D3D10_ENCODE_BASIC_FILTER(int min, int mag, int mip, bool bComparison)
         {
@@ -44,9 +38,9 @@ namespace TerraFX.Interop
             return ((D3D10_FILTER_TYPE)(((int)(d3d10Filter) >> (0)) & (0x3)));
         }
 
-        public static int D3D10_DECODE_IS_COMPARISON_FILTER(D3D10_FILTER d3d10Filter)
+        public static bool D3D10_DECODE_IS_COMPARISON_FILTER(D3D10_FILTER d3d10Filter)
         {
-            return ((int)(d3d10Filter) & (0x80));
+            return ((int)(d3d10Filter) & (0x80)) != 0;
         }
 
         public static bool D3D10_DECODE_IS_ANISOTROPIC_FILTER(D3D10_FILTER d3d10Filter)

--- a/sources/Interop/Windows/um/d3d11/D3D11_BOX.Manual.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_BOX.Manual.cs
@@ -21,13 +21,16 @@ namespace TerraFX.Interop
 
         public static bool operator ==(D3D11_BOX l, D3D11_BOX r)
         {
-            return l.left == r.left && l.top == r.top && l.front == r.front && l.right == r.right && l.bottom == r.bottom && l.back == r.back;
+            return (l.left == r.left)
+                && (l.top == r.top)
+                && (l.front == r.front)
+                && (l.right == r.right)
+                && (l.bottom == r.bottom)
+                && (l.back == r.back);
         }
 
         public static bool operator !=(D3D11_BOX l, D3D11_BOX r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is D3D11_BOX other) && Equals(other);
 

--- a/sources/Interop/Windows/um/d3d11/D3D11_SHADER_RESOURCE_VIEW_DESC.Manual.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_SHADER_RESOURCE_VIEW_DESC.Manual.cs
@@ -193,7 +193,9 @@ namespace TerraFX.Interop
                 {
                     arraySize = TexDesc.ArraySize - firstArraySlice;
                     if (D3D11_SRV_DIMENSION_TEXTURECUBEARRAY == viewDimension)
+                    {
                         arraySize /= 6;
+                    }
                 }
             }
 

--- a/sources/Interop/Windows/um/d3d11/D3D11_VIEWPORT.Manual.cs
+++ b/sources/Interop/Windows/um/d3d11/D3D11_VIEWPORT.Manual.cs
@@ -174,13 +174,16 @@ namespace TerraFX.Interop
 
         public static bool operator ==(in D3D11_VIEWPORT l, in D3D11_VIEWPORT r)
         {
-            return l.TopLeftX == r.TopLeftX && l.TopLeftY == r.TopLeftY && l.Width == r.Width && l.Height == r.Height && l.MinDepth == r.MinDepth && l.MaxDepth == r.MaxDepth;
+            return (l.TopLeftX == r.TopLeftX)
+                && (l.TopLeftY == r.TopLeftY)
+                && (l.Width == r.Width)
+                && (l.Height == r.Height)
+                && (l.MinDepth == r.MinDepth)
+                && (l.MaxDepth == r.MaxDepth);
         }
 
         public static bool operator !=(in D3D11_VIEWPORT l, in D3D11_VIEWPORT r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public override bool Equals(object? obj) => (obj is D3D11_VIEWPORT other) && Equals(other);
 

--- a/sources/Interop/Windows/um/d3d11/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/d3d11/Windows.Manual.cs
@@ -38,9 +38,9 @@ namespace TerraFX.Interop
             }
         }
 
-        public static int MAKE_D3D11_HRESULT(int code) => MAKE_HRESULT(1, unchecked((int)_FACD3D11), code);
+        public static HRESULT MAKE_D3D11_HRESULT(int code) => MAKE_HRESULT(1, unchecked((int)_FACD3D11), code);
 
-        public static int MAKE_D3D11_STATUS(int code) => MAKE_HRESULT(0, unchecked((int)_FACD3D11), code);
+        public static HRESULT MAKE_D3D11_STATUS(int code) => MAKE_HRESULT(0, unchecked((int)_FACD3D11), code);
 
         public static D3D11_FILTER D3D11_ENCODE_BASIC_FILTER(D3D11_FILTER_TYPE min, D3D11_FILTER_TYPE mag, D3D11_FILTER_TYPE mip, D3D11_FILTER_REDUCTION_TYPE reduction)
         {

--- a/sources/Interop/Windows/um/d3d11_3/D3D11_SHADER_RESOURCE_VIEW_DESC1.Manual.cs
+++ b/sources/Interop/Windows/um/d3d11_3/D3D11_SHADER_RESOURCE_VIEW_DESC1.Manual.cs
@@ -195,7 +195,9 @@ namespace TerraFX.Interop
                 {
                     arraySize = TexDesc.ArraySize - firstArraySlice;
                     if (D3D11_SRV_DIMENSION_TEXTURECUBEARRAY == viewDimension)
+                    {
                         arraySize /= 6;
+                    }
                 }
             }
 

--- a/sources/Interop/Windows/um/d3d12/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/d3d12/Windows.Manual.cs
@@ -81,30 +81,30 @@ namespace TerraFX.Interop
 
         public static uint D3D12_GET_COARSE_SHADING_RATE_Y_AXIS(uint y) => y & D3D12_SHADING_RATE_VALID_MASK;
 
-        public static int D3D12ReflectLibrary(void* pSrcData, nuint SrcDataSize, ID3D12LibraryReflection** ppReflector)
+        public static HRESULT D3D12ReflectLibrary(void* pSrcData, nuint SrcDataSize, ID3D12LibraryReflection** ppReflector)
         {
             var iid = IID_ID3D12LibraryReflection;
             return D3DReflectLibrary(pSrcData, SrcDataSize, &iid, (void**)ppReflector);
         }
 
-        public static int D3D_SET_OBJECT_NAME_N_A(ID3D12Object* pObject, uint Chars, sbyte* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_N_A(ID3D12Object* pObject, uint Chars, sbyte* pName)
         {
             var guid = WKPDID_D3DDebugObjectName;
             return pObject->SetPrivateData(&guid, Chars, pName);
         }
 
-        public static int D3D_SET_OBJECT_NAME_A(ID3D12Object* pObject, sbyte* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_A(ID3D12Object* pObject, sbyte* pName)
         {
             return D3D_SET_OBJECT_NAME_N_A(pObject, (uint)lstrlenA(pName), pName);
         }
 
-        public static int D3D_SET_OBJECT_NAME_N_W(ID3D12Object* pObject, uint Chars, ushort* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_N_W(ID3D12Object* pObject, uint Chars, ushort* pName)
         {
             var guid = WKPDID_D3DDebugObjectNameW;
             return pObject->SetPrivateData(&guid, Chars * 2, pName);
         }
 
-        public static int D3D_SET_OBJECT_NAME_W(ID3D12Object* pObject, ushort* pName)
+        public static HRESULT D3D_SET_OBJECT_NAME_W(ID3D12Object* pObject, ushort* pName)
         {
             return D3D_SET_OBJECT_NAME_N_W(pObject, (uint)lstrlenW(pName), pName);
         }

--- a/sources/Interop/Windows/um/dcommon/D2D1_PIXEL_FORMAT.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D1_PIXEL_FORMAT.Manual.cs
@@ -29,9 +29,9 @@ namespace TerraFX.Interop
             }
         }
 
-        public D2D1_PIXEL_FORMAT(DXGI_FORMAT dxgiFormat = DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE alphaMode = D2D1_ALPHA_MODE_UNKNOWN)
+        public D2D1_PIXEL_FORMAT(DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE alphaMode = D2D1_ALPHA_MODE_UNKNOWN)
         {
-            this.format = dxgiFormat;
+            this.format = format;
             this.alphaMode = alphaMode;
         }
     }

--- a/sources/Interop/Windows/um/dcommon/D2D_MATRIX_3X2_F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_MATRIX_3X2_F.Manual.cs
@@ -13,16 +13,16 @@ namespace TerraFX.Interop
 {
     public unsafe partial struct D2D_MATRIX_3X2_F : IEquatable<D2D_MATRIX_3X2_F>
     {
-        public D2D_MATRIX_3X2_F(float m11, float m12, float m21, float m22, float m31, float m32)
+        public D2D_MATRIX_3X2_F(float m11, float m12, float m21, float m22, float dx, float dy)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
-            Anonymous.Anonymous2._11 = m11;
-            Anonymous.Anonymous2._12 = m12;
-            Anonymous.Anonymous2._21 = m21;
-            Anonymous.Anonymous2._22 = m22;
-            Anonymous.Anonymous2._31 = m31;
-            Anonymous.Anonymous2._32 = m32;
+            this.m11 = m11;
+            this.m12 = m12;
+            this.m21 = m21;
+            this.m22 = m22;
+            this.dx = dx;
+            this.dy = dy;
         }
 
         public static ref readonly D2D_MATRIX_3X2_F Identity
@@ -48,12 +48,12 @@ namespace TerraFX.Interop
         {
             D2D_MATRIX_3X2_F translation = default;
 
-            translation.Anonymous.Anonymous2._11 = 1.0f;
-            translation.Anonymous.Anonymous2._12 = 0.0f;
-            translation.Anonymous.Anonymous2._21 = 0.0f;
-            translation.Anonymous.Anonymous2._22 = 1.0f;
-            translation.Anonymous.Anonymous2._31 = size.width;
-            translation.Anonymous.Anonymous2._32 = size.height;
+            translation.m11 = 1.0f;
+            translation.m12 = 0.0f;
+            translation.m21 = 0.0f;
+            translation.m22 = 1.0f;
+            translation.dx = size.width;
+            translation.dy = size.height;
 
             return translation;
         }
@@ -67,12 +67,12 @@ namespace TerraFX.Interop
         {
             D2D_MATRIX_3X2_F scale = default;
 
-            scale.Anonymous.Anonymous2._11 = size.width;
-            scale.Anonymous.Anonymous2._12 = 0.0f;
-            scale.Anonymous.Anonymous2._21 = 0.0f;
-            scale.Anonymous.Anonymous2._22 = size.height;
-            scale.Anonymous.Anonymous2._31 = center.x - size.width * center.x;
-            scale.Anonymous.Anonymous2._32 = center.y - size.height * center.y;
+            scale.m11 = size.width;
+            scale.m12 = 0.0f;
+            scale.m21 = 0.0f;
+            scale.m22 = size.height;
+            scale.dx = center.x - size.width * center.x;
+            scale.dy = center.y - size.height * center.y;
 
             return scale;
         }
@@ -85,9 +85,7 @@ namespace TerraFX.Interop
         public static D2D_MATRIX_3X2_F Rotation(float angle, D2D_POINT_2F center = default)
         {
             D2D_MATRIX_3X2_F rotation;
-
             D2D1MakeRotateMatrix(angle, center, &rotation);
-
             return rotation;
         }
 
@@ -101,12 +99,7 @@ namespace TerraFX.Interop
         }
 
         public readonly float Determinant
-        {
-            get
-            {
-                return (Anonymous.Anonymous2._11 * Anonymous.Anonymous2._22) - (Anonymous.Anonymous2._12 * Anonymous.Anonymous2._21);
-            }
-        }
+            => (Anonymous.Anonymous1.m11 * Anonymous.Anonymous1.m22) - (Anonymous.Anonymous1.m12 * Anonymous.Anonymous1.m21);
             
         public readonly bool IsInvertible
         {
@@ -131,18 +124,20 @@ namespace TerraFX.Interop
         {
             get
             {
-                return Anonymous.Anonymous2._11 == 1.0f && Anonymous.Anonymous2._12 == 0.0f && Anonymous.Anonymous2._21 == 0.0f && Anonymous.Anonymous2._22 == 1.0f && Anonymous.Anonymous2._31 == 0.0f && Anonymous.Anonymous2._32 == 0.0f;
+                return (Anonymous.Anonymous1.m11 == 1.0f) && (Anonymous.Anonymous1.m12 == 0.0f)
+                    && (Anonymous.Anonymous1.m21 == 0.0f) && (Anonymous.Anonymous1.m22 == 1.0f)
+                    && (Anonymous.Anonymous1.dx == 0.0f) && (Anonymous.Anonymous1.dy == 0.0f);
             }
         }
 
         public void SetProduct([NativeTypeName("const D2D1_MATRIX_3X2 &")] in D2D_MATRIX_3X2_F a, [NativeTypeName("const D2D1_MATRIX_3X2 &")] in D2D_MATRIX_3X2_F b)
         {
-            Anonymous.Anonymous2._11 = (a.Anonymous.Anonymous2._11 * b.Anonymous.Anonymous2._11) + (a.Anonymous.Anonymous2._12 * b.Anonymous.Anonymous2._21);
-            Anonymous.Anonymous2._12 = (a.Anonymous.Anonymous2._11 * b.Anonymous.Anonymous2._12) + (a.Anonymous.Anonymous2._12 * b.Anonymous.Anonymous2._22);
-            Anonymous.Anonymous2._21 = (a.Anonymous.Anonymous2._21 * b.Anonymous.Anonymous2._11) + (a.Anonymous.Anonymous2._22 * b.Anonymous.Anonymous2._21);
-            Anonymous.Anonymous2._22 = (a.Anonymous.Anonymous2._21 * b.Anonymous.Anonymous2._12) + (a.Anonymous.Anonymous2._22 * b.Anonymous.Anonymous2._22);
-            Anonymous.Anonymous2._31 = (a.Anonymous.Anonymous2._31 * b.Anonymous.Anonymous2._11) + (a.Anonymous.Anonymous2._32 * b.Anonymous.Anonymous2._21) + b.Anonymous.Anonymous2._31;
-            Anonymous.Anonymous2._32 = (a.Anonymous.Anonymous2._31 * b.Anonymous.Anonymous2._12) + (a.Anonymous.Anonymous2._32 * b.Anonymous.Anonymous2._22) + b.Anonymous.Anonymous2._32;
+            m11 = (a.m11 * b.m11) + (a.m12 * b.m21);
+            m12 = (a.m11 * b.m12) + (a.m12 * b.m22);
+            m21 = (a.m21 * b.m11) + (a.m22 * b.m21);
+            m22 = (a.m21 * b.m12) + (a.m22 * b.m22);
+            dx = (a.dx * b.m11) + (a.dy * b.m21) + b.dx;
+            dy = (a.dx * b.m12) + (a.dy * b.m22) + b.dy;
         }
 
         public static D2D_MATRIX_3X2_F operator *([NativeTypeName("const D2D1_MATRIX_3X2_F &")] in D2D_MATRIX_3X2_F a, [NativeTypeName("const D2D1_MATRIX_3X2_F &")] in D2D_MATRIX_3X2_F b)
@@ -158,31 +153,29 @@ namespace TerraFX.Interop
         {
             D2D_POINT_2F result = new D2D_POINT_2F
             {
-                x = point.x * Anonymous.Anonymous2._11 + point.y * Anonymous.Anonymous2._21 + Anonymous.Anonymous2._31,
-                y= point.x * Anonymous.Anonymous2._12 + point.y * Anonymous.Anonymous2._22 + Anonymous.Anonymous2._32,
+                x = (point.x * Anonymous.Anonymous1.m11) + (point.y * Anonymous.Anonymous1.m21) + Anonymous.Anonymous1.dx,
+                y = (point.x * Anonymous.Anonymous1.m12) + (point.y * Anonymous.Anonymous1.m22) + Anonymous.Anonymous1.dy,
             };
             return result;
         }
 
         public static D2D_POINT_2F operator *([NativeTypeName("const D2D1_POINT_2F &")] in D2D_POINT_2F point, [NativeTypeName("const D2D1_MATRIX_3X2_F &")] in D2D_MATRIX_3X2_F matrix)
-        {
-            return matrix.TransformPoint(point);
-        }
+            => matrix.TransformPoint(point);
 
         public static bool operator ==(D2D_MATRIX_3X2_F l, D2D_MATRIX_3X2_F r)
         {
-            return l.Anonymous.Anonymous2._11 == r.Anonymous.Anonymous2._11 && l.Anonymous.Anonymous2._12 == r.Anonymous.Anonymous2._12 && l.Anonymous.Anonymous2._21 == r.Anonymous.Anonymous2._21 && l.Anonymous.Anonymous2._22 == r.Anonymous.Anonymous2._22 && l.Anonymous.Anonymous2._31 == r.Anonymous.Anonymous2._31 && l.Anonymous.Anonymous2._32 == r.Anonymous.Anonymous2._32;
+            return (l.m11 == r.m11) && (l.m12 == r.m12)
+                && (l.m21 == r.m21) && (l.m22 == r.m22)
+                && (l.dx == r.dx) && (l.dy == r.dy);
         }
 
         public static bool operator !=(D2D_MATRIX_3X2_F l, D2D_MATRIX_3X2_F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_MATRIX_3X2_F other) => this == other;
 
         public override bool Equals(object? obj) => (obj is D2D_MATRIX_3X2_F other) && this == other;
 
-        public override int GetHashCode() => HashCode.Combine(Anonymous.Anonymous2._11, Anonymous.Anonymous2._12, Anonymous.Anonymous2._21, Anonymous.Anonymous2._22, Anonymous.Anonymous2._31, Anonymous.Anonymous2._32);
+        public override int GetHashCode() => HashCode.Combine(m11, m12, m21, m22, dx, dy);
     }
 }

--- a/sources/Interop/Windows/um/dcommon/D2D_MATRIX_4X3_F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_MATRIX_4X3_F.Manual.cs
@@ -1,4 +1,4 @@
-// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License._d in the repository root for more information.
 
 // Ported from um/d2d1_1helper.h in the Windows SDK for Windows 10.0.20348.0
 // Original source is Copyright © Microsoft. All rights reserved.
@@ -14,20 +14,20 @@ namespace TerraFX.Interop
     {
         public D2D_MATRIX_4X3_F(float m11, float m12, float m13, float m21, float m22, float m23, float m31, float m32, float m33, float m41, float m42, float m43)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
-            Anonymous.Anonymous._11 = m11;
-            Anonymous.Anonymous._12 = m12;
-            Anonymous.Anonymous._13 = m13;
-            Anonymous.Anonymous._21 = m21;
-            Anonymous.Anonymous._22 = m22;
-            Anonymous.Anonymous._23 = m23;
-            Anonymous.Anonymous._31 = m31;
-            Anonymous.Anonymous._32 = m32;
-            Anonymous.Anonymous._33 = m33;
-            Anonymous.Anonymous._41 = m41;
-            Anonymous.Anonymous._42 = m42;
-            Anonymous.Anonymous._43 = m43;
+            _11 = m11;
+            _12 = m12;
+            _13 = m13;
+            _21 = m21;
+            _22 = m22;
+            _23 = m23;
+            _31 = m31;
+            _32 = m32;
+            _33 = m33;
+            _41 = m41;
+            _42 = m42;
+            _43 = m43;
         }
 
         public static ref readonly D2D_MATRIX_4X3_F Identity
@@ -57,13 +57,14 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D_MATRIX_4X3_F &")] in D2D_MATRIX_4X3_F l, [NativeTypeName("const D2D_MATRIX_4X3_F &")] in D2D_MATRIX_4X3_F r)
         {
-            return l.Anonymous.Anonymous._11 == r.Anonymous.Anonymous._11 && l.Anonymous.Anonymous._12 == r.Anonymous.Anonymous._12 && l.Anonymous.Anonymous._13 == r.Anonymous.Anonymous._13 && l.Anonymous.Anonymous._21 == r.Anonymous.Anonymous._21 && l.Anonymous.Anonymous._22 == r.Anonymous.Anonymous._22 && l.Anonymous.Anonymous._23 == r.Anonymous.Anonymous._23 && l.Anonymous.Anonymous._31 == r.Anonymous.Anonymous._31 && l.Anonymous.Anonymous._32 == r.Anonymous.Anonymous._32 && l.Anonymous.Anonymous._33 == r.Anonymous.Anonymous._33 && l.Anonymous.Anonymous._41 == r.Anonymous.Anonymous._41 && l.Anonymous.Anonymous._42 == r.Anonymous.Anonymous._42 && l.Anonymous.Anonymous._43 == r.Anonymous.Anonymous._43;
+            return (l._11 == r._11) && (l._12 == r._12) && (l._13 == r._13)
+                && (l._21 == r._21) && (l._22 == r._22) && (l._23 == r._23)
+                && (l._31 == r._31) && (l._32 == r._32) && (l._33 == r._33)
+                && (l._41 == r._41) && (l._42 == r._42) && (l._43 == r._43);
         }
 
         public static bool operator !=([NativeTypeName("const D2D_MATRIX_4X3_F &")] in D2D_MATRIX_4X3_F l, [NativeTypeName("const D2D_MATRIX_4X3_F &")] in D2D_MATRIX_4X3_F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_MATRIX_4X3_F other) => this == other;
 
@@ -73,18 +74,18 @@ namespace TerraFX.Interop
         {
             var hashCode = new HashCode();
             {
-                hashCode.Add(Anonymous.Anonymous._11);
-                hashCode.Add(Anonymous.Anonymous._12);
-                hashCode.Add(Anonymous.Anonymous._13);
-                hashCode.Add(Anonymous.Anonymous._21);
-                hashCode.Add(Anonymous.Anonymous._22);
-                hashCode.Add(Anonymous.Anonymous._23);
-                hashCode.Add(Anonymous.Anonymous._31);
-                hashCode.Add(Anonymous.Anonymous._32);
-                hashCode.Add(Anonymous.Anonymous._33);
-                hashCode.Add(Anonymous.Anonymous._41);
-                hashCode.Add(Anonymous.Anonymous._42);
-                hashCode.Add(Anonymous.Anonymous._43);
+                hashCode.Add(_11);
+                hashCode.Add(_12);
+                hashCode.Add(_13);
+                hashCode.Add(_21);
+                hashCode.Add(_22);
+                hashCode.Add(_23);
+                hashCode.Add(_31);
+                hashCode.Add(_32);
+                hashCode.Add(_33);
+                hashCode.Add(_41);
+                hashCode.Add(_42);
+                hashCode.Add(_43);
             }
             return hashCode.ToHashCode();
         }

--- a/sources/Interop/Windows/um/dcommon/D2D_MATRIX_4X4_F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_MATRIX_4X4_F.Manual.cs
@@ -1,4 +1,4 @@
-// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License._d in the repository root for more information.
 
 // Ported from um/d2d1_1helper.h in the Windows SDK for Windows 10.0.20348.0
 // Original source is Copyright © Microsoft. All rights reserved.
@@ -15,24 +15,24 @@ namespace TerraFX.Interop
     {
         public D2D_MATRIX_4X4_F(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31, float m32, float m33, float m34, float m41, float m42, float m43, float m44)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
-            Anonymous.Anonymous._11 = m11;
-            Anonymous.Anonymous._12 = m12;
-            Anonymous.Anonymous._13 = m13;
-            Anonymous.Anonymous._14 = m14;
-            Anonymous.Anonymous._21 = m21;
-            Anonymous.Anonymous._22 = m22;
-            Anonymous.Anonymous._23 = m23;
-            Anonymous.Anonymous._24 = m24;
-            Anonymous.Anonymous._31 = m31;
-            Anonymous.Anonymous._32 = m32;
-            Anonymous.Anonymous._33 = m33;
-            Anonymous.Anonymous._34 = m34;
-            Anonymous.Anonymous._41 = m41;
-            Anonymous.Anonymous._42 = m42;
-            Anonymous.Anonymous._43 = m43;
-            Anonymous.Anonymous._44 = m44;
+            _11 = m11;
+            _12 = m12;
+            _13 = m13;
+            _14 = m14;
+            _21 = m21;
+            _22 = m22;
+            _23 = m23;
+            _24 = m24;
+            _31 = m31;
+            _32 = m32;
+            _33 = m33;
+            _34 = m34;
+            _41 = m41;
+            _42 = m42;
+            _43 = m43;
+            _44 = m44;
         }
 
         public static ref readonly D2D_MATRIX_4X4_F Identity
@@ -66,34 +66,35 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_MATRIX_4X4_F &")] in D2D_MATRIX_4X4_F l, [NativeTypeName("const D2D1_MATRIX_4X4_F &")] in D2D_MATRIX_4X4_F r)
         {
-            return l.Anonymous.Anonymous._11 == r.Anonymous.Anonymous._11 && l.Anonymous.Anonymous._12 == r.Anonymous.Anonymous._12 && l.Anonymous.Anonymous._13 == r.Anonymous.Anonymous._13 && l.Anonymous.Anonymous._14 == r.Anonymous.Anonymous._14 && l.Anonymous.Anonymous._21 == r.Anonymous.Anonymous._21 && l.Anonymous.Anonymous._22 == r.Anonymous.Anonymous._22 && l.Anonymous.Anonymous._23 == r.Anonymous.Anonymous._23 && l.Anonymous.Anonymous._24 == r.Anonymous.Anonymous._24 && l.Anonymous.Anonymous._31 == r.Anonymous.Anonymous._31 && l.Anonymous.Anonymous._32 == r.Anonymous.Anonymous._32 && l.Anonymous.Anonymous._33 == r.Anonymous.Anonymous._33 && l.Anonymous.Anonymous._34 == r.Anonymous.Anonymous._34 && l.Anonymous.Anonymous._41 == r.Anonymous.Anonymous._41 && l.Anonymous.Anonymous._42 == r.Anonymous.Anonymous._42 && l.Anonymous.Anonymous._43 == r.Anonymous.Anonymous._43 && l.Anonymous.Anonymous._44 == r.Anonymous.Anonymous._44;
+            return (l._11 == r._11) && (l._12 == r._12) && (l._13 == r._13) && (l._14 == r._14)
+                && (l._21 == r._21) && (l._22 == r._22) && (l._23 == r._23) && (l._24 == r._24)
+                && (l._31 == r._31) && (l._32 == r._32) && (l._33 == r._33) && (l._34 == r._34)
+                && (l._41 == r._41) && (l._42 == r._42) && (l._43 == r._43) && (l._44 == r._44);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_MATRIX_4X4_F &")] in D2D_MATRIX_4X4_F l, [NativeTypeName("const D2D1_MATRIX_4X4_F &")] in D2D_MATRIX_4X4_F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public static D2D_MATRIX_4X4_F Translation(float x, float y, float z)
         {
             D2D_MATRIX_4X4_F translation = default;
 
-            translation.Anonymous.Anonymous._11 = 1.0f;
-            translation.Anonymous.Anonymous._12 = 0.0f;
-            translation.Anonymous.Anonymous._13 = 0.0f;
-            translation.Anonymous.Anonymous._14 = 0.0f;
-            translation.Anonymous.Anonymous._21 = 0.0f;
-            translation.Anonymous.Anonymous._22 = 1.0f;
-            translation.Anonymous.Anonymous._23 = 0.0f;
-            translation.Anonymous.Anonymous._24 = 0.0f;
-            translation.Anonymous.Anonymous._31 = 0.0f;
-            translation.Anonymous.Anonymous._32 = 0.0f;
-            translation.Anonymous.Anonymous._33 = 1.0f;
-            translation.Anonymous.Anonymous._34 = 0.0f;
-            translation.Anonymous.Anonymous._41 = x;
-            translation.Anonymous.Anonymous._42 = y;
-            translation.Anonymous.Anonymous._43 = z;
-            translation.Anonymous.Anonymous._44 = 1.0f;
+            translation._11 = 1.0f;
+            translation._12 = 0.0f;
+            translation._13 = 0.0f;
+            translation._14 = 0.0f;
+            translation._21 = 0.0f;
+            translation._22 = 1.0f;
+            translation._23 = 0.0f;
+            translation._24 = 0.0f;
+            translation._31 = 0.0f;
+            translation._32 = 0.0f;
+            translation._33 = 1.0f;
+            translation._34 = 0.0f;
+            translation._41 = x;
+            translation._42 = y;
+            translation._43 = z;
+            translation._44 = 1.0f;
 
             return translation;
         }
@@ -102,22 +103,22 @@ namespace TerraFX.Interop
         {
             D2D_MATRIX_4X4_F scale = default;
 
-            scale.Anonymous.Anonymous._11 = x;
-            scale.Anonymous.Anonymous._12 = 0.0f;
-            scale.Anonymous.Anonymous._13 = 0.0f;
-            scale.Anonymous.Anonymous._14 = 0.0f;
-            scale.Anonymous.Anonymous._21 = 0.0f;
-            scale.Anonymous.Anonymous._22 = y;
-            scale.Anonymous.Anonymous._23 = 0.0f;
-            scale.Anonymous.Anonymous._24 = 0.0f;
-            scale.Anonymous.Anonymous._31 = 0.0f;
-            scale.Anonymous.Anonymous._32 = 0.0f;
-            scale.Anonymous.Anonymous._33 = z;
-            scale.Anonymous.Anonymous._34 = 0.0f;
-            scale.Anonymous.Anonymous._41 = 0.0f;
-            scale.Anonymous.Anonymous._42 = 0.0f;
-            scale.Anonymous.Anonymous._43 = 0.0f;
-            scale.Anonymous.Anonymous._44 = 1.0f;
+            scale._11 = x;
+            scale._12 = 0.0f;
+            scale._13 = 0.0f;
+            scale._14 = 0.0f;
+            scale._21 = 0.0f;
+            scale._22 = y;
+            scale._23 = 0.0f;
+            scale._24 = 0.0f;
+            scale._31 = 0.0f;
+            scale._32 = 0.0f;
+            scale._33 = z;
+            scale._34 = 0.0f;
+            scale._41 = 0.0f;
+            scale._42 = 0.0f;
+            scale._43 = 0.0f;
+            scale._44 = 1.0f;
 
             return scale;
         }
@@ -219,10 +220,10 @@ namespace TerraFX.Interop
         {
             get
             {
-                float minor1 = Anonymous.Anonymous._41 * (Anonymous.Anonymous._12 * (Anonymous.Anonymous._23 * Anonymous.Anonymous._34 - Anonymous.Anonymous._33 * Anonymous.Anonymous._24) - Anonymous.Anonymous._13 * (Anonymous.Anonymous._22 * Anonymous.Anonymous._34 - Anonymous.Anonymous._24 * Anonymous.Anonymous._32) + Anonymous.Anonymous._14 * (Anonymous.Anonymous._22 * Anonymous.Anonymous._33 - Anonymous.Anonymous._23 * Anonymous.Anonymous._32));
-                float minor2 = Anonymous.Anonymous._42 * (Anonymous.Anonymous._11 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._34 - Anonymous.Anonymous._31 * Anonymous.Anonymous._24) - Anonymous.Anonymous._13 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._34 - Anonymous.Anonymous._24 * Anonymous.Anonymous._31) + Anonymous.Anonymous._14 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._33 - Anonymous.Anonymous._23 * Anonymous.Anonymous._31));
-                float minor3 = Anonymous.Anonymous._43 * (Anonymous.Anonymous._11 * (Anonymous.Anonymous._22 * Anonymous.Anonymous._34 - Anonymous.Anonymous._32 * Anonymous.Anonymous._24) - Anonymous.Anonymous._12 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._34 - Anonymous.Anonymous._24 * Anonymous.Anonymous._31) + Anonymous.Anonymous._14 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._32 - Anonymous.Anonymous._22 * Anonymous.Anonymous._31));
-                float minor4 = Anonymous.Anonymous._44 * (Anonymous.Anonymous._11 * (Anonymous.Anonymous._22 * Anonymous.Anonymous._33 - Anonymous.Anonymous._32 * Anonymous.Anonymous._23) - Anonymous.Anonymous._12 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._33 - Anonymous.Anonymous._23 * Anonymous.Anonymous._31) + Anonymous.Anonymous._13 * (Anonymous.Anonymous._21 * Anonymous.Anonymous._32 - Anonymous.Anonymous._22 * Anonymous.Anonymous._31));
+                float minor1 = _41 * (_12 * (_23 * _34 - _33 * _24) - _13 * (_22 * _34 - _24 * _32) + _14 * (_22 * _33 - _23 * _32));
+                float minor2 = _42 * (_11 * (_21 * _34 - _31 * _24) - _13 * (_21 * _34 - _24 * _31) + _14 * (_21 * _33 - _23 * _31));
+                float minor3 = _43 * (_11 * (_22 * _34 - _32 * _24) - _12 * (_21 * _34 - _24 * _31) + _14 * (_21 * _32 - _22 * _31));
+                float minor4 = _44 * (_11 * (_22 * _33 - _32 * _23) - _12 * (_21 * _33 - _23 * _31) + _13 * (_21 * _32 - _22 * _31));
 
                 return minor1 - minor2 + minor3 - minor4;
             }
@@ -232,28 +233,31 @@ namespace TerraFX.Interop
         {
             get
             {
-                return Anonymous.Anonymous._11 == 1.0f && Anonymous.Anonymous._12 == 0.0f && Anonymous.Anonymous._13 == 0.0f && Anonymous.Anonymous._14 == 0.0f && Anonymous.Anonymous._21 == 0.0f && Anonymous.Anonymous._22 == 1.0f && Anonymous.Anonymous._23 == 0.0f && Anonymous.Anonymous._24 == 0.0f && Anonymous.Anonymous._31 == 0.0f && Anonymous.Anonymous._32 == 0.0f && Anonymous.Anonymous._33 == 1.0f && Anonymous.Anonymous._34 == 0.0f && Anonymous.Anonymous._41 == 0.0f && Anonymous.Anonymous._42 == 0.0f && Anonymous.Anonymous._43 == 0.0f && Anonymous.Anonymous._44 == 1.0f;
+                return (_11 == 1.0f) && (_12 == 0.0f) && (_13 == 0.0f) && (_14 == 0.0f)
+                    && (_21 == 0.0f) && (_22 == 1.0f) && (_23 == 0.0f) && (_24 == 0.0f)
+                    && (_31 == 0.0f) && (_32 == 0.0f) && (_33 == 1.0f) && (_34 == 0.0f)
+                    && (_41 == 0.0f) && (_42 == 0.0f) && (_43 == 0.0f) && (_44 == 1.0f);
             }
         }
 
         public void SetProduct([NativeTypeName("const D2D1_MATRIX_4x4_F &")] in D2D_MATRIX_4X4_F a, [NativeTypeName("const D2D1_MATRIX_4x4_F &")] in D2D_MATRIX_4X4_F b)
         {
-            Anonymous.Anonymous._11 = a.Anonymous.Anonymous._11 * b.Anonymous.Anonymous._11 + a.Anonymous.Anonymous._12 * b.Anonymous.Anonymous._21 + a.Anonymous.Anonymous._13 * b.Anonymous.Anonymous._31 + a.Anonymous.Anonymous._14 * b.Anonymous.Anonymous._41;
-            Anonymous.Anonymous._12 = a.Anonymous.Anonymous._11 * b.Anonymous.Anonymous._12 + a.Anonymous.Anonymous._12 * b.Anonymous.Anonymous._22 + a.Anonymous.Anonymous._13 * b.Anonymous.Anonymous._32 + a.Anonymous.Anonymous._14 * b.Anonymous.Anonymous._42;
-            Anonymous.Anonymous._13 = a.Anonymous.Anonymous._11 * b.Anonymous.Anonymous._13 + a.Anonymous.Anonymous._12 * b.Anonymous.Anonymous._23 + a.Anonymous.Anonymous._13 * b.Anonymous.Anonymous._33 + a.Anonymous.Anonymous._14 * b.Anonymous.Anonymous._43;
-            Anonymous.Anonymous._14 = a.Anonymous.Anonymous._11 * b.Anonymous.Anonymous._14 + a.Anonymous.Anonymous._12 * b.Anonymous.Anonymous._24 + a.Anonymous.Anonymous._13 * b.Anonymous.Anonymous._34 + a.Anonymous.Anonymous._14 * b.Anonymous.Anonymous._44;
-            Anonymous.Anonymous._21 = a.Anonymous.Anonymous._21 * b.Anonymous.Anonymous._11 + a.Anonymous.Anonymous._22 * b.Anonymous.Anonymous._21 + a.Anonymous.Anonymous._23 * b.Anonymous.Anonymous._31 + a.Anonymous.Anonymous._24 * b.Anonymous.Anonymous._41;
-            Anonymous.Anonymous._22 = a.Anonymous.Anonymous._21 * b.Anonymous.Anonymous._12 + a.Anonymous.Anonymous._22 * b.Anonymous.Anonymous._22 + a.Anonymous.Anonymous._23 * b.Anonymous.Anonymous._32 + a.Anonymous.Anonymous._24 * b.Anonymous.Anonymous._42;
-            Anonymous.Anonymous._23 = a.Anonymous.Anonymous._21 * b.Anonymous.Anonymous._13 + a.Anonymous.Anonymous._22 * b.Anonymous.Anonymous._23 + a.Anonymous.Anonymous._23 * b.Anonymous.Anonymous._33 + a.Anonymous.Anonymous._24 * b.Anonymous.Anonymous._43;
-            Anonymous.Anonymous._24 = a.Anonymous.Anonymous._21 * b.Anonymous.Anonymous._14 + a.Anonymous.Anonymous._22 * b.Anonymous.Anonymous._24 + a.Anonymous.Anonymous._23 * b.Anonymous.Anonymous._34 + a.Anonymous.Anonymous._24 * b.Anonymous.Anonymous._44;
-            Anonymous.Anonymous._31 = a.Anonymous.Anonymous._31 * b.Anonymous.Anonymous._11 + a.Anonymous.Anonymous._32 * b.Anonymous.Anonymous._21 + a.Anonymous.Anonymous._33 * b.Anonymous.Anonymous._31 + a.Anonymous.Anonymous._34 * b.Anonymous.Anonymous._41;
-            Anonymous.Anonymous._32 = a.Anonymous.Anonymous._31 * b.Anonymous.Anonymous._12 + a.Anonymous.Anonymous._32 * b.Anonymous.Anonymous._22 + a.Anonymous.Anonymous._33 * b.Anonymous.Anonymous._32 + a.Anonymous.Anonymous._34 * b.Anonymous.Anonymous._42;
-            Anonymous.Anonymous._33 = a.Anonymous.Anonymous._31 * b.Anonymous.Anonymous._13 + a.Anonymous.Anonymous._32 * b.Anonymous.Anonymous._23 + a.Anonymous.Anonymous._33 * b.Anonymous.Anonymous._33 + a.Anonymous.Anonymous._34 * b.Anonymous.Anonymous._43;
-            Anonymous.Anonymous._34 = a.Anonymous.Anonymous._31 * b.Anonymous.Anonymous._14 + a.Anonymous.Anonymous._32 * b.Anonymous.Anonymous._24 + a.Anonymous.Anonymous._33 * b.Anonymous.Anonymous._34 + a.Anonymous.Anonymous._34 * b.Anonymous.Anonymous._44;
-            Anonymous.Anonymous._41 = a.Anonymous.Anonymous._41 * b.Anonymous.Anonymous._11 + a.Anonymous.Anonymous._42 * b.Anonymous.Anonymous._21 + a.Anonymous.Anonymous._43 * b.Anonymous.Anonymous._31 + a.Anonymous.Anonymous._44 * b.Anonymous.Anonymous._41;
-            Anonymous.Anonymous._42 = a.Anonymous.Anonymous._41 * b.Anonymous.Anonymous._12 + a.Anonymous.Anonymous._42 * b.Anonymous.Anonymous._22 + a.Anonymous.Anonymous._43 * b.Anonymous.Anonymous._32 + a.Anonymous.Anonymous._44 * b.Anonymous.Anonymous._42;
-            Anonymous.Anonymous._43 = a.Anonymous.Anonymous._41 * b.Anonymous.Anonymous._13 + a.Anonymous.Anonymous._42 * b.Anonymous.Anonymous._23 + a.Anonymous.Anonymous._43 * b.Anonymous.Anonymous._33 + a.Anonymous.Anonymous._44 * b.Anonymous.Anonymous._43;
-            Anonymous.Anonymous._44 = a.Anonymous.Anonymous._41 * b.Anonymous.Anonymous._14 + a.Anonymous.Anonymous._42 * b.Anonymous.Anonymous._24 + a.Anonymous.Anonymous._43 * b.Anonymous.Anonymous._34 + a.Anonymous.Anonymous._44 * b.Anonymous.Anonymous._44;
+            _11 = a._11 * b._11 + a._12 * b._21 + a._13 * b._31 + a._14 * b._41;
+            _12 = a._11 * b._12 + a._12 * b._22 + a._13 * b._32 + a._14 * b._42;
+            _13 = a._11 * b._13 + a._12 * b._23 + a._13 * b._33 + a._14 * b._43;
+            _14 = a._11 * b._14 + a._12 * b._24 + a._13 * b._34 + a._14 * b._44;
+            _21 = a._21 * b._11 + a._22 * b._21 + a._23 * b._31 + a._24 * b._41;
+            _22 = a._21 * b._12 + a._22 * b._22 + a._23 * b._32 + a._24 * b._42;
+            _23 = a._21 * b._13 + a._22 * b._23 + a._23 * b._33 + a._24 * b._43;
+            _24 = a._21 * b._14 + a._22 * b._24 + a._23 * b._34 + a._24 * b._44;
+            _31 = a._31 * b._11 + a._32 * b._21 + a._33 * b._31 + a._34 * b._41;
+            _32 = a._31 * b._12 + a._32 * b._22 + a._33 * b._32 + a._34 * b._42;
+            _33 = a._31 * b._13 + a._32 * b._23 + a._33 * b._33 + a._34 * b._43;
+            _34 = a._31 * b._14 + a._32 * b._24 + a._33 * b._34 + a._34 * b._44;
+            _41 = a._41 * b._11 + a._42 * b._21 + a._43 * b._31 + a._44 * b._41;
+            _42 = a._41 * b._12 + a._42 * b._22 + a._43 * b._32 + a._44 * b._42;
+            _43 = a._41 * b._13 + a._42 * b._23 + a._43 * b._33 + a._44 * b._43;
+            _44 = a._41 * b._14 + a._42 * b._24 + a._43 * b._34 + a._44 * b._44;
         }
 
         public static D2D_MATRIX_4X4_F operator *([NativeTypeName("const D2D1_MATRIX_4x4_F &")] in D2D_MATRIX_4X4_F a, [NativeTypeName("const D2D1_MATRIX_4x4_F &")] in D2D_MATRIX_4X4_F b)
@@ -273,22 +277,22 @@ namespace TerraFX.Interop
         {
             var hashCode = new HashCode();
             {
-                hashCode.Add(Anonymous.Anonymous._11);
-                hashCode.Add(Anonymous.Anonymous._12);
-                hashCode.Add(Anonymous.Anonymous._13);
-                hashCode.Add(Anonymous.Anonymous._14);
-                hashCode.Add(Anonymous.Anonymous._21);
-                hashCode.Add(Anonymous.Anonymous._22);
-                hashCode.Add(Anonymous.Anonymous._23);
-                hashCode.Add(Anonymous.Anonymous._24);
-                hashCode.Add(Anonymous.Anonymous._31);
-                hashCode.Add(Anonymous.Anonymous._32);
-                hashCode.Add(Anonymous.Anonymous._33);
-                hashCode.Add(Anonymous.Anonymous._34);
-                hashCode.Add(Anonymous.Anonymous._41);
-                hashCode.Add(Anonymous.Anonymous._42);
-                hashCode.Add(Anonymous.Anonymous._43);
-                hashCode.Add(Anonymous.Anonymous._44);
+                hashCode.Add(_11);
+                hashCode.Add(_12);
+                hashCode.Add(_13);
+                hashCode.Add(_14);
+                hashCode.Add(_21);
+                hashCode.Add(_22);
+                hashCode.Add(_23);
+                hashCode.Add(_24);
+                hashCode.Add(_31);
+                hashCode.Add(_32);
+                hashCode.Add(_33);
+                hashCode.Add(_34);
+                hashCode.Add(_41);
+                hashCode.Add(_42);
+                hashCode.Add(_43);
+                hashCode.Add(_44);
             }
             return hashCode.ToHashCode();
         }

--- a/sources/Interop/Windows/um/dcommon/D2D_MATRIX_5X4_F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_MATRIX_5X4_F.Manual.cs
@@ -1,4 +1,4 @@
-// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License._d in the repository root for more information.
 
 // Ported from um/d2d1_1helper.h in the Windows SDK for Windows 10.0.20348.0
 // Original source is Copyright © Microsoft. All rights reserved.
@@ -47,39 +47,41 @@ namespace TerraFX.Interop
 
         public D2D_MATRIX_5X4_F(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31, float m32, float m33, float m34, float m41, float m42, float m43, float m44, float m51, float m52, float m53, float m54)
         {
-            this = default;
+            Unsafe.SkipInit(out this);
 
-            Anonymous.Anonymous._11 = m11;
-            Anonymous.Anonymous._12 = m12;
-            Anonymous.Anonymous._13 = m13;
-            Anonymous.Anonymous._14 = m14;
-            Anonymous.Anonymous._21 = m21;
-            Anonymous.Anonymous._22 = m22;
-            Anonymous.Anonymous._23 = m23;
-            Anonymous.Anonymous._24 = m24;
-            Anonymous.Anonymous._31 = m31;
-            Anonymous.Anonymous._32 = m32;
-            Anonymous.Anonymous._33 = m33;
-            Anonymous.Anonymous._34 = m34;
-            Anonymous.Anonymous._41 = m41;
-            Anonymous.Anonymous._42 = m42;
-            Anonymous.Anonymous._43 = m43;
-            Anonymous.Anonymous._44 = m44;
-            Anonymous.Anonymous._51 = m51;
-            Anonymous.Anonymous._52 = m52;
-            Anonymous.Anonymous._53 = m53;
-            Anonymous.Anonymous._54 = m54;
+            _11 = m11;
+            _12 = m12;
+            _13 = m13;
+            _14 = m14;
+            _21 = m21;
+            _22 = m22;
+            _23 = m23;
+            _24 = m24;
+            _31 = m31;
+            _32 = m32;
+            _33 = m33;
+            _34 = m34;
+            _41 = m41;
+            _42 = m42;
+            _43 = m43;
+            _44 = m44;
+            _51 = m51;
+            _52 = m52;
+            _53 = m53;
+            _54 = m54;
         }
 
         public static bool operator ==([NativeTypeName("const D2D1_MATRIX_5X4_F &")] in D2D_MATRIX_5X4_F l, [NativeTypeName("const D2D1_MATRIX_5X4_F &")] in D2D_MATRIX_5X4_F r)
         {
-            return l.Anonymous.Anonymous._11 == r.Anonymous.Anonymous._11 && l.Anonymous.Anonymous._12 == r.Anonymous.Anonymous._12 && l.Anonymous.Anonymous._13 == r.Anonymous.Anonymous._13 && l.Anonymous.Anonymous._14 == r.Anonymous.Anonymous._14 && l.Anonymous.Anonymous._21 == r.Anonymous.Anonymous._21 && l.Anonymous.Anonymous._22 == r.Anonymous.Anonymous._22 && l.Anonymous.Anonymous._23 == r.Anonymous.Anonymous._23 && l.Anonymous.Anonymous._24 == r.Anonymous.Anonymous._24 && l.Anonymous.Anonymous._31 == r.Anonymous.Anonymous._31 && l.Anonymous.Anonymous._32 == r.Anonymous.Anonymous._32 && l.Anonymous.Anonymous._33 == r.Anonymous.Anonymous._33 && l.Anonymous.Anonymous._34 == r.Anonymous.Anonymous._34 && l.Anonymous.Anonymous._41 == r.Anonymous.Anonymous._41 && l.Anonymous.Anonymous._42 == r.Anonymous.Anonymous._42 && l.Anonymous.Anonymous._43 == r.Anonymous.Anonymous._43 && l.Anonymous.Anonymous._43 == r.Anonymous.Anonymous._44 && l.Anonymous.Anonymous._51 == r.Anonymous.Anonymous._51 && l.Anonymous.Anonymous._52 == r.Anonymous.Anonymous._52 && l.Anonymous.Anonymous._53 == r.Anonymous.Anonymous._53 && l.Anonymous.Anonymous._53 == r.Anonymous.Anonymous._54;
+            return (l._11 == r._11) && (l._12 == r._12) && (l._13 == r._13) && (l._14 == r._14)
+                && (l._21 == r._21) && (l._22 == r._22) && (l._23 == r._23) && (l._24 == r._24)
+                && (l._31 == r._31) && (l._32 == r._32) && (l._33 == r._33) && (l._34 == r._34)
+                && (l._41 == r._41) && (l._42 == r._42) && (l._43 == r._43) && (l._44 == r._44)
+                && (l._51 == r._51) && (l._52 == r._52) && (l._53 == r._53) && (l._54 == r._54);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_MATRIX_5X4_F &")] in D2D_MATRIX_5X4_F l, [NativeTypeName("const D2D1_MATRIX_5X4_F &")] in D2D_MATRIX_5X4_F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_MATRIX_5X4_F other) => this == other;
 
@@ -89,26 +91,26 @@ namespace TerraFX.Interop
         {
             var hashCode = new HashCode();
             {
-                hashCode.Add(Anonymous.Anonymous._11);
-                hashCode.Add(Anonymous.Anonymous._12);
-                hashCode.Add(Anonymous.Anonymous._13);
-                hashCode.Add(Anonymous.Anonymous._14);
-                hashCode.Add(Anonymous.Anonymous._21);
-                hashCode.Add(Anonymous.Anonymous._22);
-                hashCode.Add(Anonymous.Anonymous._23);
-                hashCode.Add(Anonymous.Anonymous._24);
-                hashCode.Add(Anonymous.Anonymous._31);
-                hashCode.Add(Anonymous.Anonymous._32);
-                hashCode.Add(Anonymous.Anonymous._33);
-                hashCode.Add(Anonymous.Anonymous._34);
-                hashCode.Add(Anonymous.Anonymous._41);
-                hashCode.Add(Anonymous.Anonymous._42);
-                hashCode.Add(Anonymous.Anonymous._43);
-                hashCode.Add(Anonymous.Anonymous._44);
-                hashCode.Add(Anonymous.Anonymous._51);
-                hashCode.Add(Anonymous.Anonymous._52);
-                hashCode.Add(Anonymous.Anonymous._53);
-                hashCode.Add(Anonymous.Anonymous._54);
+                hashCode.Add(_11);
+                hashCode.Add(_12);
+                hashCode.Add(_13);
+                hashCode.Add(_14);
+                hashCode.Add(_21);
+                hashCode.Add(_22);
+                hashCode.Add(_23);
+                hashCode.Add(_24);
+                hashCode.Add(_31);
+                hashCode.Add(_32);
+                hashCode.Add(_33);
+                hashCode.Add(_34);
+                hashCode.Add(_41);
+                hashCode.Add(_42);
+                hashCode.Add(_43);
+                hashCode.Add(_44);
+                hashCode.Add(_51);
+                hashCode.Add(_52);
+                hashCode.Add(_53);
+                hashCode.Add(_54);
             }
             return hashCode.ToHashCode();
         }

--- a/sources/Interop/Windows/um/dcommon/D2D_POINT_2F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_POINT_2F.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_POINT_2F &")] in D2D_POINT_2F l, [NativeTypeName("const D2D1_POINT_2F &")] in D2D_POINT_2F r)
         {
-            return l.x == r.x && l.y == r.y;
+            return (l.x == r.x)
+                && (l.y == r.y);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_POINT_2F &")] in D2D_POINT_2F l, [NativeTypeName("const D2D1_POINT_2F &")] in D2D_POINT_2F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_POINT_2F other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_POINT_2U.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_POINT_2U.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_POINT_2U &")] in D2D_POINT_2U l, [NativeTypeName("const D2D1_POINT_2U &")] in D2D_POINT_2U r)
         {
-            return l.x == r.x && l.y == r.y;
+            return (l.x == r.x)
+                && (l.y == r.y);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_POINT_2U &")] in D2D_POINT_2U l, [NativeTypeName("const D2D1_POINT_2U &")] in D2D_POINT_2U r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_POINT_2U other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_RECT_F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_RECT_F.Manual.cs
@@ -37,13 +37,14 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_RECT_F &")] in D2D_RECT_F l, [NativeTypeName("const D2D1_RECT_F &")] in D2D_RECT_F r)
         {
-            return l.left == r.left && l.top == r.top && l.right == r.right && l.bottom == r.bottom;
+            return (l.left == r.left)
+                && (l.top == r.top)
+                && (l.right == r.right)
+                && (l.bottom == r.bottom);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_RECT_F &")] in D2D_RECT_F l, [NativeTypeName("const D2D1_RECT_F &")] in D2D_RECT_F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_RECT_F other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_RECT_U.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_RECT_U.Manual.cs
@@ -19,13 +19,14 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_RECT_U &")] in D2D_RECT_U l, [NativeTypeName("const D2D1_RECT_U &")] in D2D_RECT_U r)
         {
-            return l.left == r.left && l.top == r.top && l.right == r.right && l.bottom == r.bottom;
+            return (l.left == r.left)
+                && (l.top == r.top)
+                && (l.right == r.right)
+                && (l.bottom == r.bottom);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_RECT_U &")] in D2D_RECT_U l, [NativeTypeName("const D2D1_RECT_U &")] in D2D_RECT_U r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public static D2D_RECT_U Infinite
         {

--- a/sources/Interop/Windows/um/dcommon/D2D_SIZE_F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_SIZE_F.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_SIZE_F &")] in D2D_SIZE_F l, [NativeTypeName("const D2D1_SIZE_F &")] in D2D_SIZE_F r)
         {
-            return l.width == r.width && l.height == r.height;
+            return (l.width == r.width)
+                && (l.height == r.height);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_SIZE_F &")] in D2D_SIZE_F l, [NativeTypeName("const D2D1_SIZE_F &")] in D2D_SIZE_F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_SIZE_F other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_SIZE_U.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_SIZE_U.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D1_SIZE_U &")] in D2D_SIZE_U l, [NativeTypeName("const D2D1_SIZE_U &")] in D2D_SIZE_U r)
         {
-            return l.width == r.width && l.height == r.height;
+            return (l.width == r.width)
+                && (l.height == r.height);
         }
 
         public static bool operator !=([NativeTypeName("const D2D1_SIZE_U &")] in D2D_SIZE_U l, [NativeTypeName("const D2D1_SIZE_U &")] in D2D_SIZE_U r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_SIZE_U other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_VECTOR_2F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_VECTOR_2F.Manual.cs
@@ -17,13 +17,12 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_2F l, [NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_2F r)
         {
-            return l.x == r.x && l.y == r.y;
+            return (l.x == r.x)
+                && (l.y == r.y);
         }
 
         public static bool operator !=([NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_2F l, [NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_2F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_VECTOR_2F other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_VECTOR_3F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_VECTOR_3F.Manual.cs
@@ -18,13 +18,13 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_3F l, [NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_3F r)
         {
-            return l.x == r.x && l.y == r.y && l.z == r.z;
+            return (l.x == r.x)
+                && (l.y == r.y)
+                && (l.z == r.z);
         }
 
         public static bool operator !=([NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_3F l, [NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_3F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_VECTOR_3F other) => this == other;
 

--- a/sources/Interop/Windows/um/dcommon/D2D_VECTOR_4F.Manual.cs
+++ b/sources/Interop/Windows/um/dcommon/D2D_VECTOR_4F.Manual.cs
@@ -19,13 +19,14 @@ namespace TerraFX.Interop
 
         public static bool operator ==([NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_4F l, [NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_4F r)
         {
-            return l.x == r.x && l.y == r.y && l.z == r.z && l.w == r.w;
+            return (l.x == r.x)
+                && (l.y == r.y)
+                && (l.z == r.z)
+                && (l.w == r.w);
         }
 
         public static bool operator !=([NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_4F l, [NativeTypeName("const D2D_VECTOR_2F &")] in D2D_VECTOR_4F r)
-        {
-            return !(l == r);
-        }
+            => !(l == r);
 
         public bool Equals(D2D_VECTOR_4F other) => this == other;
 

--- a/sources/Interop/Windows/um/dwrite/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/dwrite/Windows.Manual.cs
@@ -9,8 +9,8 @@ namespace TerraFX.Interop
     {
         public static uint DWRITE_MAKE_OPENTYPE_TAG(byte a, byte b, byte c, byte d) => ((uint)d << 24) | ((uint)c << 16) | ((uint)b << 8) | a;
 
-        public static int MAKE_DWRITE_HR(int severity, int code) => MAKE_HRESULT(severity, FACILITY_DWRITE, DWRITE_ERR_BASE + code);
+        public static HRESULT MAKE_DWRITE_HR(int severity, int code) => MAKE_HRESULT(severity, FACILITY_DWRITE, DWRITE_ERR_BASE + code);
 
-        public static int MAKE_DWRITE_HR_ERR(int code) => MAKE_DWRITE_HR(SEVERITY_ERROR, code);
+        public static HRESULT MAKE_DWRITE_HR_ERR(int code) => MAKE_DWRITE_HR(SEVERITY_ERROR, code);
     }
 }

--- a/sources/Interop/Windows/um/dxcore_interface/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/dxcore_interface/Windows.Manual.cs
@@ -7,9 +7,6 @@ namespace TerraFX.Interop
 {
     public static partial class Windows
     {
-        public static int MAKE_DXCORE_HRESULT(int code)
-        {
-            return MAKE_HRESULT(1, _FACDXCORE, code);
-        }
+        public static HRESULT MAKE_DXCORE_HRESULT(int code) => MAKE_HRESULT(1, _FACDXCORE, code);
     }
 }

--- a/sources/Interop/Windows/um/shellapi/APPBARDATA.Manual.cs
+++ b/sources/Interop/Windows/um/shellapi/APPBARDATA.Manual.cs
@@ -107,8 +107,7 @@ namespace TerraFX.Interop
             }
         }
 
-        [NativeTypeName("LPARAM")]
-        public ref nint lParam
+        public ref LPARAM lParam
         {
             get
             {

--- a/sources/Interop/Windows/um/shellapi/APPBARDATA32.Manual.cs
+++ b/sources/Interop/Windows/um/shellapi/APPBARDATA32.Manual.cs
@@ -21,7 +21,6 @@ namespace TerraFX.Interop
 
         public RECT rc;
 
-        [NativeTypeName("LPARAM")]
-        public nint lParam;
+        public LPARAM lParam;
     }
 }

--- a/sources/Interop/Windows/um/shellapi/APPBARDATA64.Manual.cs
+++ b/sources/Interop/Windows/um/shellapi/APPBARDATA64.Manual.cs
@@ -18,7 +18,6 @@ namespace TerraFX.Interop
 
         public RECT rc;
 
-        [NativeTypeName("LPARAM")]
-        public nint lParam;
+        public LPARAM lParam;
     }
 }

--- a/sources/Interop/Windows/um/wincred/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/wincred/Windows.Manual.cs
@@ -11,23 +11,23 @@ namespace TerraFX.Interop
         {
             return
                 ((_Status) == ERROR_LOGON_FAILURE ||
-                (_Status) == __HRESULT_FROM_WIN32(ERROR_LOGON_FAILURE) ||
+                (_Status) == HRESULT_FROM_WIN32(ERROR_LOGON_FAILURE) ||
                 (_Status) == STATUS_LOGON_FAILURE ||
-                (_Status) == __HRESULT_FROM_NT(STATUS_LOGON_FAILURE) ||
+                (_Status) == HRESULT_FROM_NT(STATUS_LOGON_FAILURE) ||
                 (_Status) == ERROR_ACCESS_DENIED ||
-                (_Status) == __HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) ||
+                (_Status) == HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) ||
                 (_Status) == STATUS_ACCESS_DENIED ||
                 (_Status) == HRESULT_FROM_NT(STATUS_ACCESS_DENIED) ||
                 (_Status) == ERROR_INVALID_PASSWORD ||
-                (_Status) == __HRESULT_FROM_WIN32(ERROR_INVALID_PASSWORD) ||
+                (_Status) == HRESULT_FROM_WIN32(ERROR_INVALID_PASSWORD) ||
                 (_Status) == STATUS_WRONG_PASSWORD ||
                 (_Status) == HRESULT_FROM_NT(STATUS_WRONG_PASSWORD) ||
                 (_Status) == STATUS_NO_SUCH_USER ||
                 (_Status) == HRESULT_FROM_NT(STATUS_NO_SUCH_USER) ||
                 (_Status) == ERROR_NO_SUCH_USER ||
-                (_Status) == __HRESULT_FROM_WIN32(ERROR_NO_SUCH_USER) ||
+                (_Status) == HRESULT_FROM_WIN32(ERROR_NO_SUCH_USER) ||
                 (_Status) == ERROR_NO_SUCH_LOGON_SESSION ||
-                (_Status) == __HRESULT_FROM_WIN32(ERROR_NO_SUCH_LOGON_SESSION) ||
+                (_Status) == HRESULT_FROM_WIN32(ERROR_NO_SUCH_LOGON_SESSION) ||
                 (_Status) == STATUS_NO_SUCH_LOGON_SESSION ||
                 (_Status) == HRESULT_FROM_NT(STATUS_NO_SUCH_LOGON_SESSION) ||
                 (_Status) == SEC_E_NO_CREDENTIALS ||
@@ -40,7 +40,7 @@ namespace TerraFX.Interop
         {
             return
                 ((_Status) == ERROR_DOWNGRADE_DETECTED ||
-                (_Status) == __HRESULT_FROM_WIN32(ERROR_DOWNGRADE_DETECTED) ||
+                (_Status) == HRESULT_FROM_WIN32(ERROR_DOWNGRADE_DETECTED) ||
                 (_Status) == STATUS_DOWNGRADE_DETECTED ||
                 (_Status) == HRESULT_FROM_NT(STATUS_DOWNGRADE_DETECTED) ||
                 (_Status) == SEC_E_DOWNGRADE_DETECTED);
@@ -50,15 +50,15 @@ namespace TerraFX.Interop
         {
             return
                 ((_Status) == ERROR_PASSWORD_EXPIRED ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_PASSWORD_EXPIRED) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_PASSWORD_EXPIRED) ||
                  (_Status) == STATUS_PASSWORD_EXPIRED ||
                  (_Status) == HRESULT_FROM_NT(STATUS_PASSWORD_EXPIRED) ||
                  (_Status) == ERROR_PASSWORD_MUST_CHANGE ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_PASSWORD_MUST_CHANGE) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_PASSWORD_MUST_CHANGE) ||
                  (_Status) == STATUS_PASSWORD_MUST_CHANGE ||
                  (_Status) == HRESULT_FROM_NT(STATUS_PASSWORD_MUST_CHANGE) ||
                  (_Status) == NERR_PasswordExpired ||
-                 (_Status) == __HRESULT_FROM_WIN32(NERR_PasswordExpired));
+                 (_Status) == HRESULT_FROM_WIN32(NERR_PasswordExpired));
         }
 
         public static bool CREDUI_IS_AUTHENTICATION_ERROR(int _Status)
@@ -73,27 +73,27 @@ namespace TerraFX.Interop
         {
             return
                 ((_Status) == ERROR_AUTHENTICATION_FIREWALL_FAILED ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_AUTHENTICATION_FIREWALL_FAILED) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_AUTHENTICATION_FIREWALL_FAILED) ||
                  (_Status) == STATUS_AUTHENTICATION_FIREWALL_FAILED ||
                  (_Status) == HRESULT_FROM_NT(STATUS_AUTHENTICATION_FIREWALL_FAILED) ||
                  (_Status) == ERROR_ACCOUNT_DISABLED ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_ACCOUNT_DISABLED) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_ACCOUNT_DISABLED) ||
                  (_Status) == STATUS_ACCOUNT_DISABLED ||
                  (_Status) == HRESULT_FROM_NT(STATUS_ACCOUNT_DISABLED) ||
                  (_Status) == ERROR_ACCOUNT_RESTRICTION ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_ACCOUNT_RESTRICTION) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_ACCOUNT_RESTRICTION) ||
                  (_Status) == STATUS_ACCOUNT_RESTRICTION ||
                  (_Status) == HRESULT_FROM_NT(STATUS_ACCOUNT_RESTRICTION) ||
                  (_Status) == ERROR_ACCOUNT_LOCKED_OUT ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_ACCOUNT_LOCKED_OUT) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_ACCOUNT_LOCKED_OUT) ||
                  (_Status) == STATUS_ACCOUNT_LOCKED_OUT ||
                  (_Status) == HRESULT_FROM_NT(STATUS_ACCOUNT_LOCKED_OUT) ||
                  (_Status) == ERROR_ACCOUNT_EXPIRED ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_ACCOUNT_EXPIRED) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_ACCOUNT_EXPIRED) ||
                  (_Status) == STATUS_ACCOUNT_EXPIRED ||
                  (_Status) == HRESULT_FROM_NT(STATUS_ACCOUNT_EXPIRED) ||
                  (_Status) == ERROR_LOGON_TYPE_NOT_GRANTED ||
-                 (_Status) == __HRESULT_FROM_WIN32(ERROR_LOGON_TYPE_NOT_GRANTED) ||
+                 (_Status) == HRESULT_FROM_WIN32(ERROR_LOGON_TYPE_NOT_GRANTED) ||
                  (_Status) == STATUS_LOGON_TYPE_NOT_GRANTED ||
                  (_Status) == HRESULT_FROM_NT(STATUS_LOGON_TYPE_NOT_GRANTED));
         }

--- a/sources/Interop/Windows/um/wincrypt/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/wincrypt/Windows.Manual.cs
@@ -8,12 +8,12 @@ namespace TerraFX.Interop
     public static unsafe partial class Windows
     {
         [NativeTypeName("#define HCCE_CURRENT_USER ((HCERTCHAINENGINE)NULL)")]
-        public static HANDLE HCCE_CURRENT_USER => ((HANDLE)(NULL));
+        public static HCERTCHAINENGINE HCCE_CURRENT_USER => ((HCERTCHAINENGINE)(NULL));
 
         [NativeTypeName("#define HCCE_LOCAL_MACHINE ((HCERTCHAINENGINE)0x1)")]
-        public static HANDLE HCCE_LOCAL_MACHINE => ((HANDLE)(0x1));
+        public static HCERTCHAINENGINE HCCE_LOCAL_MACHINE => ((HCERTCHAINENGINE)(0x1));
 
         [NativeTypeName("#define HCCE_SERIAL_LOCAL_MACHINE ((HCERTCHAINENGINE)0x2)")]
-        public static HANDLE HCCE_SERIAL_LOCAL_MACHINE => ((HANDLE)(0x2));
+        public static HCERTCHAINENGINE HCCE_SERIAL_LOCAL_MACHINE => ((HCERTCHAINENGINE)(0x2));
     }
 }

--- a/sources/Interop/Windows/um/windows.graphics.directx.direct3d11.interop/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/windows.graphics.directx.direct3d11.interop/Windows.Manual.cs
@@ -17,23 +17,23 @@ namespace TerraFX.Interop
             return inspectableSurface;
         }
 
-        public static int GetDXGIInterfaceFromObject(IInspectable* @object, Guid* iid, void** p)
+        public static HRESULT GetDXGIInterfaceFromObject(IInspectable* @object, Guid* iid, void** p)
         {
             IDirect3DDxgiInterfaceAccess* dxgiInterfaceAccess;
 
             var dxgi_iid = IID_IDirect3DDxgiInterfaceAccess;
-            int hr = @object->QueryInterface(&dxgi_iid, (void**) &dxgiInterfaceAccess);
+            HRESULT hr = @object->QueryInterface(&dxgi_iid, (void**) &dxgiInterfaceAccess);
 
             if (SUCCEEDED(hr))
             {
                 hr = dxgiInterfaceAccess->GetInterface(iid, p);
             }
 
-            dxgiInterfaceAccess->Release();
+            _ = dxgiInterfaceAccess->Release();
             return hr;
         }
 
-        public static int GetDXGIInterface<DXGI_TYPE>(IInspectable* @object, DXGI_TYPE** dxgi)
+        public static HRESULT GetDXGIInterface<DXGI_TYPE>(IInspectable* @object, DXGI_TYPE** dxgi)
             where DXGI_TYPE : unmanaged
         {
             var guid = typeof(DXGI_TYPE).GUID;

--- a/sources/Interop/Windows/um/wingdi/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/wingdi/Windows.Manual.cs
@@ -10,7 +10,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        public static IntPtr HGDI_ERROR => unchecked(((nint)((nint)(0xFFFFFFFF))));
+        public static HANDLE HGDI_ERROR => (HANDLE)(-1);
 
         public const int GDIREGISTERDDRAWPACKETVERSION = 0x1;
 
@@ -18,44 +18,40 @@ namespace TerraFX.Interop
         public static uint MAKEROP4(uint fore, uint back) => ((back << 8) & 0xFF000000) | fore;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetKValue([NativeTypeName("COLORREF")]uint cmyk) => (byte)cmyk;
+        public static byte GetKValue(COLORREF cmyk) => (byte)cmyk;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetYValue([NativeTypeName("COLORREF")]uint cmyk) => (byte)(cmyk >> 8);
+        public static byte GetYValue(COLORREF cmyk) => (byte)(cmyk >> 8);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetMValue([NativeTypeName("COLORREF")]uint cmyk) => (byte)(cmyk >> 16);
+        public static byte GetMValue(COLORREF cmyk) => (byte)(cmyk >> 16);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetCValue([NativeTypeName("COLORREF")] uint cmyk) => (byte)(cmyk >> 24);
+        public static byte GetCValue(COLORREF cmyk) => (byte)(cmyk >> 24);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("COLORREF")]
-        public static uint CMYK(byte c, byte m, byte y, byte k) => k | ((uint)y << 8) | (((uint)m) << 16) | (((uint)c) << 24);
+        public static COLORREF CMYK(byte c, byte m, byte y, byte k) => k | ((uint)y << 8) | (((uint)m) << 16) | (((uint)c) << 24);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static POINTS MAKEPOINTS(int l) => *(POINTS*)&l;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("COLORREF")]
-        public static uint RGB(byte r, byte g, byte b) => r | ((uint)g << 8) | (((uint)b) << 16);
+        public static COLORREF RGB(byte r, byte g, byte b) => r | ((uint)g << 8) | (((uint)b) << 16);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("COLORREF")]
-        public static uint PALETTERGB(byte r, byte g, byte b) => 0x02000000 | RGB(r, g, b);
+        public static COLORREF PALETTERGB(byte r, byte g, byte b) => 0x02000000 | RGB(r, g, b);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NativeTypeName("COLORREF")]
-        public static uint PALETTEINDEX(ushort i) => 0x01000000 | (uint)i;
+        public static COLORREF PALETTEINDEX(ushort i) => 0x01000000 | (uint)i;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetRValue([NativeTypeName("COLORREF")] uint rgb) => LOBYTE((ushort)rgb);
+        public static byte GetRValue(COLORREF rgb) => LOBYTE((ushort)rgb);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetGValue([NativeTypeName("COLORREF")] uint rgb) => LOBYTE((ushort)(rgb >> 8));
+        public static byte GetGValue(COLORREF rgb) => LOBYTE((ushort)(rgb >> 8));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte GetBValue([NativeTypeName("COLORREF")] uint rgb) => LOBYTE((ushort)(rgb >> 16));
+        public static byte GetBValue(COLORREF rgb) => LOBYTE((ushort)(rgb >> 16));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint GDI_WIDTHBYTES(uint bits) => ((bits + 31) & ~31u) / 8;

--- a/sources/Interop/Windows/um/winhttp/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/winhttp/Windows.Manual.cs
@@ -10,6 +10,6 @@ namespace TerraFX.Interop
     public static unsafe partial class Windows
     {
         [NativeTypeName("#define WINHTTP_INVALID_STATUS_CALLBACK ((WINHTTP_STATUS_CALLBACK)(-1L))")]
-        public static delegate* unmanaged<IntPtr, nuint, uint, void*, uint, void> WINHTTP_INVALID_STATUS_CALLBACK => ((delegate* unmanaged<IntPtr, nuint, uint, void*, uint, void>)(-1));
+        public static delegate* unmanaged<HINTERNET, nuint, uint, void*, uint, void> WINHTTP_INVALID_STATUS_CALLBACK => ((delegate* unmanaged<HINTERNET, nuint, uint, void*, uint, void>)(-1));
     }
 }

--- a/sources/Interop/Windows/um/xaudio2fx/Windows.Manual.cs
+++ b/sources/Interop/Windows/um/xaudio2fx/Windows.Manual.cs
@@ -801,7 +801,9 @@ namespace TerraFX.Interop
                 int index = (int)(-4.0 * Math.Log10(pI3DL2->DecayHFRatio));
 
                 if (index < -8)
+                {
                     index = -8;
+                }
 
                 pNative->LowEQGain = (byte)((index < 0) ? index + 8 : 8);
                 pNative->HighEQGain = 8;
@@ -812,7 +814,9 @@ namespace TerraFX.Interop
                 int index = (int)(4.0 * Math.Log10(pI3DL2->DecayHFRatio));
 
                 if (index < -8)
+                {
                     index = -8;
+                }
 
                 pNative->LowEQGain = 8;
                 pNative->HighEQGain = (byte)((index < 0) ? index + 8 : 8);

--- a/sources/Interop/Windows/winrt/roapi/Windows.Manual.cs
+++ b/sources/Interop/Windows/winrt/roapi/Windows.Manual.cs
@@ -7,13 +7,13 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Windows
     {
-        public static int ActivateInstance<T>(HSTRING activatableClassId, T** instance) 
+        public static HRESULT ActivateInstance<T>(HSTRING activatableClassId, T** instance) 
             where T : unmanaged
         {
             *instance = null;
             
             IInspectable* pInspectable;
-            int hr = RoActivateInstance(activatableClassId, &pInspectable);
+            HRESULT hr = RoActivateInstance(activatableClassId, &pInspectable);
             if (SUCCEEDED(hr))
             {
                 if (__uuidof<T>() == IID_IInspectable)
@@ -23,14 +23,14 @@ namespace TerraFX.Interop
                 else
                 {
                     hr = pInspectable->QueryInterface(__uuidof<T>(), (void**) instance);
-                    pInspectable->Release();
+                    _ = pInspectable->Release();
                 }
             }
             
             return hr;
         }
         
-        public static int GetActivationFactory<T>(HSTRING activatableClassId, T** factory)
+        public static HRESULT GetActivationFactory<T>(HSTRING activatableClassId, T** factory)
             where T : unmanaged
         {
             return RoGetActivationFactory(activatableClassId, __uuidof<T>(), (void**) factory);

--- a/sources/Interop/Windows/winrt/wrl/client/ComPtr`1.Manual.cs
+++ b/sources/Interop/Windows/winrt/wrl/client/ComPtr`1.Manual.cs
@@ -40,24 +40,20 @@ namespace TerraFX.Interop
         /// <param name="other">The raw pointer to wrap.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator ComPtr<T>(T* other)
-        {
-            return new ComPtr<T>(other);
-        }
+            => new ComPtr<T>(other);
 
         /// <summary>Unwraps a <see cref="ComPtr{T}"/> instance and returns the internal raw pointer.</summary>
         /// <param name="other">The <see cref="ComPtr{T}"/> instance to unwrap.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator T*(ComPtr<T> other)
-        {
-            return other.Get();
-        }
+            => other.Get();
 
         /// <summary>Converts the current object reference to type <typeparamref name="U"/> and assigns that to a target <see cref="ComPtr{T}"/> value.</summary>
         /// <typeparam name="U">The interface type to use to try casting the current COM object.</typeparam>
         /// <param name="p">A raw pointer to the target <see cref="ComPtr{T}"/> value to write to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
         /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="p"/>, if any.</remarks>
-        public readonly int As<U>(ComPtr<U>* p)
+        public readonly HRESULT As<U>(ComPtr<U>* p)
             where U : unmanaged
         {
             return ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)p->ReleaseAndGetAddressOf());
@@ -68,11 +64,11 @@ namespace TerraFX.Interop
         /// <param name="other">A reference to the target <see cref="ComPtr{T}"/> value to write to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
         /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="other"/>, if any.</remarks>
-        public readonly int As<U>(ref ComPtr<U> other)
+        public readonly HRESULT As<U>(ref ComPtr<U> other)
             where U : unmanaged
         {
             U* ptr;
-            int result = ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)&ptr);
+            HRESULT result = ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)&ptr);
 
             other.Attach(ptr);
             return result;
@@ -83,7 +79,7 @@ namespace TerraFX.Interop
         /// <param name="other">A raw pointer to the target <see cref="ComPtr{T}"/> value to write to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
         /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="other"/>, if any.</remarks>
-        public readonly int AsIID(Guid* riid, ComPtr<IUnknown>* other)
+        public readonly HRESULT AsIID(Guid* riid, ComPtr<IUnknown>* other)
         {
             return ((IUnknown*)ptr_)->QueryInterface(riid, (void**)other->ReleaseAndGetAddressOf());
         }
@@ -93,10 +89,10 @@ namespace TerraFX.Interop
         /// <param name="other">A reference to the target <see cref="ComPtr{T}"/> value to write to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
         /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="other"/>, if any.</remarks>
-        public readonly int AsIID(Guid* riid, ref ComPtr<IUnknown> other)
+        public readonly HRESULT AsIID(Guid* riid, ref ComPtr<IUnknown> other)
         {
             IUnknown* ptr;
-            int result = ((IUnknown*)ptr_)->QueryInterface(riid, (void**)&ptr);
+            HRESULT result = ((IUnknown*)ptr_)->QueryInterface(riid, (void**)&ptr);
 
             other.Attach(ptr);
             return result;
@@ -128,7 +124,7 @@ namespace TerraFX.Interop
         /// <summary>Increments the reference count for the current COM object, if any, and copies its address to a target raw pointer.</summary>
         /// <param name="ptr">The target raw pointer to copy the address of the current COM object to.</param>
         /// <returns>This method always returns <see cref="S_OK"/>.</returns>
-        public readonly int CopyTo(T** ptr)
+        public readonly HRESULT CopyTo(T** ptr)
         {
             InternalAddRef();
             *ptr = ptr_;
@@ -138,7 +134,7 @@ namespace TerraFX.Interop
         /// <summary>Increments the reference count for the current COM object, if any, and copies its address to a target <see cref="ComPtr{T}"/>.</summary>
         /// <param name="p">The target raw pointer to copy the address of the current COM object to.</param>
         /// <returns>This method always returns <see cref="S_OK"/>.</returns>
-        public readonly int CopyTo(ComPtr<T>* p)
+        public readonly HRESULT CopyTo(ComPtr<T>* p)
         {
             InternalAddRef();
             *p->ReleaseAndGetAddressOf() = ptr_;
@@ -148,7 +144,7 @@ namespace TerraFX.Interop
         /// <summary>Increments the reference count for the current COM object, if any, and copies its address to a target <see cref="ComPtr{T}"/>.</summary>
         /// <param name="other">The target reference to copy the address of the current COM object to.</param>
         /// <returns>This method always returns <see cref="S_OK"/>.</returns>
-        public readonly int CopyTo(ref ComPtr<T> other)
+        public readonly HRESULT CopyTo(ref ComPtr<T> other)
         {
             InternalAddRef();
             other.Attach(ptr_);
@@ -158,7 +154,7 @@ namespace TerraFX.Interop
         /// <summary>Converts the current COM object reference to a given interface type and assigns that to a target raw pointer.</summary>
         /// <param name="ptr">The target raw pointer to copy the address of the current COM object to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
-        public readonly int CopyTo<U>(U** ptr)
+        public readonly HRESULT CopyTo<U>(U** ptr)
             where U : unmanaged
         {
             return ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)ptr);
@@ -167,7 +163,7 @@ namespace TerraFX.Interop
         /// <summary>Converts the current COM object reference to a given interface type and assigns that to a target <see cref="ComPtr{T}"/>.</summary>
         /// <param name="p">The target raw pointer to copy the address of the current COM object to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
-        public readonly int CopyTo<U>(ComPtr<U>* p)
+        public readonly HRESULT CopyTo<U>(ComPtr<U>* p)
             where U : unmanaged
         {
             return ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)p->ReleaseAndGetAddressOf());
@@ -176,11 +172,11 @@ namespace TerraFX.Interop
         /// <summary>Converts the current COM object reference to a given interface type and assigns that to a target <see cref="ComPtr{T}"/>.</summary>
         /// <param name="other">The target reference to copy the address of the current COM object to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
-        public readonly int CopyTo<U>(ref ComPtr<U> other)
+        public readonly HRESULT CopyTo<U>(ref ComPtr<U> other)
             where U : unmanaged
         {
             U* ptr;
-            int result = ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)&ptr);
+            HRESULT result = ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)&ptr);
 
             other.Attach(ptr);
             return result;
@@ -190,7 +186,7 @@ namespace TerraFX.Interop
         /// <param name="riid">The IID indicating the interface type to convert the COM object reference to.</param>
         /// <param name="ptr">The target raw pointer to copy the address of the current COM object to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
-        public readonly int CopyTo(Guid* riid, void** ptr)
+        public readonly HRESULT CopyTo(Guid* riid, void** ptr)
         {
             return ((IUnknown*)ptr_)->QueryInterface(riid, ptr);
         }
@@ -199,7 +195,7 @@ namespace TerraFX.Interop
         /// <param name="riid">The IID indicating the interface type to convert the COM object reference to.</param>
         /// <param name="p">The target raw pointer to copy the address of the current COM object to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
-        public readonly int CopyTo(Guid* riid, ComPtr<IUnknown>* p)
+        public readonly HRESULT CopyTo(Guid* riid, ComPtr<IUnknown>* p)
         {
             return ((IUnknown*)ptr_)->QueryInterface(riid, (void**)p->ReleaseAndGetAddressOf());
         }
@@ -208,10 +204,10 @@ namespace TerraFX.Interop
         /// <param name="riid">The IID indicating the interface type to convert the COM object reference to.</param>
         /// <param name="other">The target reference to copy the address of the current COM object to.</param>
         /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
-        public readonly int CopyTo(Guid* riid, ref ComPtr<IUnknown> other)
+        public readonly HRESULT CopyTo(Guid* riid, ref ComPtr<IUnknown> other)
         {
             IUnknown* ptr;
-            int result = ((IUnknown*)ptr_)->QueryInterface(riid, (void**)&ptr);
+            HRESULT result = ((IUnknown*)ptr_)->QueryInterface(riid, (void**)&ptr);
 
             other.Attach(ptr);
             return result;
@@ -264,7 +260,7 @@ namespace TerraFX.Interop
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T** ReleaseAndGetAddressOf()
         {
-            InternalRelease();
+            _ = InternalRelease();
             return GetAddressOf();
         }
 
@@ -303,7 +299,7 @@ namespace TerraFX.Interop
 
             if (temp != null)
             {
-                ((IUnknown*)temp)->AddRef();
+                _ = ((IUnknown*)temp)->AddRef();
             }
         }
 


### PR DESCRIPTION
This resolves https://github.com/terrafx/terrafx.interop.windows/issues/234
This resolves https://github.com/terrafx/terrafx.interop.windows/issues/201