### PR TITLE
Add lzexpand header

### DIFF
--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -2735,6 +2735,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LsaLookup", "LsaLookup", "{
 		generation\Windows\um\LsaLookup\um-lsalookup.h = generation\Windows\um\LsaLookup\um-lsalookup.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lzexpand", "lzexpand", "{CC539B27-F7D6-44F9-9CB4-6CA9486D824D}"
+	ProjectSection(SolutionItems) = preProject
+		generation\Windows\um\lzexpand\generate.rsp = generation\Windows\um\lzexpand\generate.rsp
+		generation\Windows\um\lzexpand\header.txt = generation\Windows\um\lzexpand\header.txt
+		generation\Windows\um\lzexpand\um-lzexpand.h = generation\Windows\um\lzexpand\um-lzexpand.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -3157,6 +3164,7 @@ Global
 		{27F2C115-00D5-4152-BF08-0674EA9EF59B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{F311F39C-98D2-4DB0-938A-279CCF799089} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{1729358D-206C-4F08-AD5F-C6F2E63ECD88} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{CC539B27-F7D6-44F9-9CB4-6CA9486D824D} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/generation/Windows/um/lzexpand/generate.rsp
+++ b/generation/Windows/um/lzexpand/generate.rsp
@@ -1,0 +1,27 @@
+@../../../settings.rsp
+@../../../remap.rsp
+--file
+um-lzexpand.h
+--methodClassName
+Windows
+--namespace
+TerraFX.Interop.Windows
+--output
+../../../../sources/Interop/Windows/Windows/um/lzexpand
+--test-output
+../../../../tests/Interop/Windows/Windows/um/lzexpand
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/lzexpand.h
+--with-librarypath
+CopyLZFile=lz32
+GetExpandedNameA=lz32
+GetExpandedNameW=lz32
+LZClose=lz32
+LZCopy=lz32
+LZInit=lz32
+LZOpenFileA=lz32
+LZOpenFileW=lz32
+LZRead=lz32
+LZSeek=lz32
+LZStart=lz32
+LZDone=lz32

--- a/generation/Windows/um/lzexpand/header.txt
+++ b/generation/Windows/um/lzexpand/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/lzexpand.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/Windows/um/lzexpand/um-lzexpand.h
+++ b/generation/Windows/um/lzexpand/um-lzexpand.h
@@ -1,0 +1,2 @@
+#include "..\..\..\TerraFX.h"
+#include <lzexpand.h>

--- a/sources/Interop/Windows/Windows/um/lzexpand/Windows.cs
+++ b/sources/Interop/Windows/Windows/um/lzexpand/Windows.cs
@@ -1,0 +1,92 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/lzexpand.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows;
+
+public static unsafe partial class Windows
+{
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZStart"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int LZStart();
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZDone"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern void LZDone();
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.CopyLZFile"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    [return: NativeTypeName("LONG")]
+    public static extern int CopyLZFile(int hfSource, int hfDest);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZCopy"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    [return: NativeTypeName("LONG")]
+    public static extern int LZCopy(int hfSource, int hfDest);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZInit"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int LZInit(int hfSource);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.GetExpandedNameA"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int GetExpandedNameA([NativeTypeName("LPSTR")] sbyte* lpszSource, [NativeTypeName("LPSTR")] sbyte* lpszBuffer);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.GetExpandedNameW"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int GetExpandedNameW([NativeTypeName("LPWSTR")] ushort* lpszSource, [NativeTypeName("LPWSTR")] ushort* lpszBuffer);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZOpenFileA"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int LZOpenFileA([NativeTypeName("LPSTR")] sbyte* lpFileName, [NativeTypeName("LPOFSTRUCT")] OFSTRUCT* lpReOpenBuf, [NativeTypeName("WORD")] ushort wStyle);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZOpenFileW"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int LZOpenFileW([NativeTypeName("LPWSTR")] ushort* lpFileName, [NativeTypeName("LPOFSTRUCT")] OFSTRUCT* lpReOpenBuf, [NativeTypeName("WORD")] ushort wStyle);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZSeek"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    [return: NativeTypeName("LONG")]
+    public static extern int LZSeek(int hFile, [NativeTypeName("LONG")] int lOffset, int iOrigin);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZRead"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern int LZRead(int hFile, [NativeTypeName("CHAR *")] sbyte* lpBuffer, int cbRead);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.LZClose"]/*' />
+    [DllImport("lz32", ExactSpelling = true)]
+    public static extern void LZClose(int hFile);
+
+    [NativeTypeName("#define LZERROR_BADINHANDLE (-1)")]
+    public const int LZERROR_BADINHANDLE = (-1);
+
+    [NativeTypeName("#define LZERROR_BADOUTHANDLE (-2)")]
+    public const int LZERROR_BADOUTHANDLE = (-2);
+
+    [NativeTypeName("#define LZERROR_READ (-3)")]
+    public const int LZERROR_READ = (-3);
+
+    [NativeTypeName("#define LZERROR_WRITE (-4)")]
+    public const int LZERROR_WRITE = (-4);
+
+    [NativeTypeName("#define LZERROR_GLOBALLOC (-5)")]
+    public const int LZERROR_GLOBALLOC = (-5);
+
+    [NativeTypeName("#define LZERROR_GLOBLOCK (-6)")]
+    public const int LZERROR_GLOBLOCK = (-6);
+
+    [NativeTypeName("#define LZERROR_BADVALUE (-7)")]
+    public const int LZERROR_BADVALUE = (-7);
+
+    [NativeTypeName("#define LZERROR_UNKNOWNALG (-8)")]
+    public const int LZERROR_UNKNOWNALG = (-8);
+
+    [NativeTypeName("#define GetExpandedName GetExpandedNameW")]
+    public static delegate*<ushort*, ushort*, int> GetExpandedName => &GetExpandedNameW;
+
+    [NativeTypeName("#define LZOpenFile LZOpenFileW")]
+    public static delegate*<ushort*, OFSTRUCT*, ushort, int> LZOpenFile => &LZOpenFileW;
+}


### PR DESCRIPTION
The APIs here are necessary to expand LZX compressed files that are output by COMPRESS.EXE. These *.??_ files are common in installation media from the early 90s.