### PR TITLE
Add cabinet related headers

### DIFF
--- a/TerraFX.Interop.Windows.sln
+++ b/TerraFX.Interop.Windows.sln
@@ -2735,6 +2735,27 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LsaLookup", "LsaLookup", "{
 		generation\Windows\um\LsaLookup\um-lsalookup.h = generation\Windows\um\LsaLookup\um-lsalookup.h
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "fdi", "fdi", "{37AEBE29-9D61-4D84-A0D1-F7B748103D97}"
+	ProjectSection(SolutionItems) = preProject
+		generation\Windows\um\fdi\generate.rsp = generation\Windows\um\fdi\generate.rsp
+		generation\Windows\um\fdi\header.txt = generation\Windows\um\fdi\header.txt
+		generation\Windows\um\fdi\um-fdi.h = generation\Windows\um\fdi\um-fdi.h
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "fci", "fci", "{CBC62B75-03A4-470D-A52A-D84161773CB7}"
+	ProjectSection(SolutionItems) = preProject
+		generation\Windows\um\fci\generate.rsp = generation\Windows\um\fci\generate.rsp
+		generation\Windows\um\fci\header.txt = generation\Windows\um\fci\header.txt
+		generation\Windows\um\fci\um-fci.h = generation\Windows\um\fci\um-fci.h
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "fdi_fci_types", "fdi_fci_types", "{5FC51DA5-FF47-4100-BE74-2F3DE11EF163}"
+	ProjectSection(SolutionItems) = preProject
+		generation\Windows\um\fdi_fci_types\generate.rsp = generation\Windows\um\fdi_fci_types\generate.rsp
+		generation\Windows\um\fdi_fci_types\header.txt = generation\Windows\um\fdi_fci_types\header.txt
+		generation\Windows\um\fdi_fci_types\um-fdi_fci_types.h = generation\Windows\um\fdi_fci_types\um-fdi_fci_types.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -3157,6 +3178,9 @@ Global
 		{27F2C115-00D5-4152-BF08-0674EA9EF59B} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{F311F39C-98D2-4DB0-938A-279CCF799089} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 		{1729358D-206C-4F08-AD5F-C6F2E63ECD88} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{37AEBE29-9D61-4D84-A0D1-F7B748103D97} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{CBC62B75-03A4-470D-A52A-D84161773CB7} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
+		{5FC51DA5-FF47-4100-BE74-2F3DE11EF163} = {67311E5E-FA9C-43A6-B431-9EF10047A0CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FE36DF8-2D9C-4F20-8787-45DC74B57461}

--- a/generation/Windows/um/fci/generate.rsp
+++ b/generation/Windows/um/fci/generate.rsp
@@ -1,0 +1,20 @@
+@../../../settings.rsp
+@../../../remap.rsp
+--file
+um-fci.h
+--methodClassName
+Windows
+--namespace
+TerraFX.Interop.Windows
+--output
+../../../../sources/Interop/Windows/Windows/um/fci
+--test-output
+../../../../tests/Interop/Windows/Windows/um/fci
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fci.h
+--with-librarypath
+FCIAddFile=cabinet
+FCICreate=cabinet
+FCIDestroy=cabinet
+FCIFlushCabinet=cabinet
+FCIFlushFolder=cabinet

--- a/generation/Windows/um/fci/header.txt
+++ b/generation/Windows/um/fci/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fci.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/Windows/um/fci/um-fci.h
+++ b/generation/Windows/um/fci/um-fci.h
@@ -1,0 +1,2 @@
+#include "..\..\..\TerraFX.h"
+#include <fci.h>

--- a/generation/Windows/um/fdi/generate.rsp
+++ b/generation/Windows/um/fdi/generate.rsp
@@ -1,0 +1,23 @@
+@../../../settings.rsp
+@../../../remap.rsp
+--exclude
+_A_NAME_IS_UTF
+_A_EXEC
+--file
+um-fdi.h
+--methodClassName
+Windows
+--namespace
+TerraFX.Interop.Windows
+--output
+../../../../sources/Interop/Windows/Windows/um/fdi
+--test-output
+../../../../tests/Interop/Windows/Windows/um/fid
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fdi.h
+--with-librarypath
+FDICopy=cabinet
+FDICreate=cabinet
+FDIDestroy=cabinet
+FDIIsCabinet=cabinet
+FDITruncateCabinet=cabinet

--- a/generation/Windows/um/fdi/header.txt
+++ b/generation/Windows/um/fdi/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/Windows/um/fdi/um-fdi.h
+++ b/generation/Windows/um/fdi/um-fdi.h
@@ -1,0 +1,2 @@
+#include "..\..\..\TerraFX.h"
+#include <fdi.h>

--- a/generation/Windows/um/fdi_fci_types/generate.rsp
+++ b/generation/Windows/um/fdi_fci_types/generate.rsp
@@ -1,0 +1,14 @@
+@../../../settings.rsp
+@../../../remap.rsp
+--file
+um-fdi_fci_types.h
+--methodClassName
+Windows
+--namespace
+TerraFX.Interop.Windows
+--output
+../../../../sources/Interop/Windows/Windows/um/fdi_fci_types
+--test-output
+../../../../tests/Interop/Windows/Windows/um/fdi_fci_types
+--traverse
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fdi_fci_types.h

--- a/generation/Windows/um/fdi_fci_types/header.txt
+++ b/generation/Windows/um/fdi_fci_types/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi_fci_types.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.

--- a/generation/Windows/um/fdi_fci_types/um-fdi_fci_types.h
+++ b/generation/Windows/um/fdi_fci_types/um-fdi_fci_types.h
@@ -1,0 +1,2 @@
+#include "..\..\..\TerraFX.h"
+#include <fdi_fci_types.h>

--- a/sources/Interop/Windows/Windows/um/fci/CCAB.cs
+++ b/sources/Interop/Windows/Windows/um/fci/CCAB.cs
@@ -1,0 +1,51 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fci.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='CCAB.xml' path='doc/member[@name="CCAB"]/*' />
+public unsafe partial struct CCAB
+{
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.cb"]/*' />
+    [NativeTypeName("ULONG")]
+    public uint cb;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.cbFolderThresh"]/*' />
+    [NativeTypeName("ULONG")]
+    public uint cbFolderThresh;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.cbReserveCFHeader"]/*' />
+    public uint cbReserveCFHeader;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.cbReserveCFFolder"]/*' />
+    public uint cbReserveCFFolder;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.cbReserveCFData"]/*' />
+    public uint cbReserveCFData;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.iCab"]/*' />
+    public int iCab;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.iDisk"]/*' />
+    public int iDisk;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.fFailOnIncompressible"]/*' />
+    public int fFailOnIncompressible;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.setID"]/*' />
+    public ushort setID;
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.szDisk"]/*' />
+    [NativeTypeName("char [256]")]
+    public fixed sbyte szDisk[256];
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.szCab"]/*' />
+    [NativeTypeName("char [256]")]
+    public fixed sbyte szCab[256];
+
+    /// <include file='CCAB.xml' path='doc/member[@name="CCAB.szCabPath"]/*' />
+    [NativeTypeName("char [256]")]
+    public fixed sbyte szCabPath[256];
+}

--- a/sources/Interop/Windows/Windows/um/fci/FCIERROR.cs
+++ b/sources/Interop/Windows/Windows/um/fci/FCIERROR.cs
@@ -1,0 +1,40 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fci.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR"]/*' />
+public enum FCIERROR
+{
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_NONE"]/*' />
+    FCIERR_NONE,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_OPEN_SRC"]/*' />
+    FCIERR_OPEN_SRC,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_READ_SRC"]/*' />
+    FCIERR_READ_SRC,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_ALLOC_FAIL"]/*' />
+    FCIERR_ALLOC_FAIL,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_TEMP_FILE"]/*' />
+    FCIERR_TEMP_FILE,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_BAD_COMPR_TYPE"]/*' />
+    FCIERR_BAD_COMPR_TYPE,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_CAB_FILE"]/*' />
+    FCIERR_CAB_FILE,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_USER_ABORT"]/*' />
+    FCIERR_USER_ABORT,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_MCI_FAIL"]/*' />
+    FCIERR_MCI_FAIL,
+
+    /// <include file='FCIERROR.xml' path='doc/member[@name="FCIERROR.FCIERR_CAB_FORMAT_LIMIT"]/*' />
+    FCIERR_CAB_FORMAT_LIMIT,
+}

--- a/sources/Interop/Windows/Windows/um/fci/Windows.cs
+++ b/sources/Interop/Windows/Windows/um/fci/Windows.cs
@@ -1,0 +1,50 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fci.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows;
+
+public static unsafe partial class Windows
+{
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FCICreate"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    [return: NativeTypeName("HFCI")]
+    public static extern void* FCICreate([NativeTypeName("PERF")] ERF* perf, [NativeTypeName("PFNFCIFILEPLACED")] delegate* unmanaged<CCAB*, sbyte*, int, BOOL, void*, int> pfnfcifp, [NativeTypeName("PFNFCIALLOC")] delegate* unmanaged<uint, void*> pfna, [NativeTypeName("PFNFCIFREE")] delegate* unmanaged<void*, void> pfnf, [NativeTypeName("PFNFCIOPEN")] delegate* unmanaged<sbyte*, int, int, int*, void*, nint> pfnopen, [NativeTypeName("PFNFCIREAD")] delegate* unmanaged<nint, void*, uint, int*, void*, uint> pfnread, [NativeTypeName("PFNFCIWRITE")] delegate* unmanaged<nint, void*, uint, int*, void*, uint> pfnwrite, [NativeTypeName("PFNFCICLOSE")] delegate* unmanaged<nint, int*, void*, int> pfnclose, [NativeTypeName("PFNFCISEEK")] delegate* unmanaged<nint, int, int, int*, void*, int> pfnseek, [NativeTypeName("PFNFCIDELETE")] delegate* unmanaged<sbyte*, int*, void*, int> pfndelete, [NativeTypeName("PFNFCIGETTEMPFILE")] delegate* unmanaged<sbyte*, int, void*, BOOL> pfnfcigtf, [NativeTypeName("PCCAB")] CCAB* pccab, void* pv);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FCIAddFile"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FCIAddFile([NativeTypeName("HFCI")] void* hfci, [NativeTypeName("LPSTR")] sbyte* pszSourceFile, [NativeTypeName("LPSTR")] sbyte* pszFileName, BOOL fExecute, [NativeTypeName("PFNFCIGETNEXTCABINET")] delegate* unmanaged<CCAB*, uint, void*, BOOL> pfnfcignc, [NativeTypeName("PFNFCISTATUS")] delegate* unmanaged<uint, uint, uint, void*, int> pfnfcis, [NativeTypeName("PFNFCIGETOPENINFO")] delegate* unmanaged<sbyte*, ushort*, ushort*, ushort*, int*, void*, nint> pfnfcigoi, [NativeTypeName("TCOMP")] ushort typeCompress);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FCIFlushCabinet"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FCIFlushCabinet([NativeTypeName("HFCI")] void* hfci, BOOL fGetNextCab, [NativeTypeName("PFNFCIGETNEXTCABINET")] delegate* unmanaged<CCAB*, uint, void*, BOOL> pfnfcignc, [NativeTypeName("PFNFCISTATUS")] delegate* unmanaged<uint, uint, uint, void*, int> pfnfcis);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FCIFlushFolder"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FCIFlushFolder([NativeTypeName("HFCI")] void* hfci, [NativeTypeName("PFNFCIGETNEXTCABINET")] delegate* unmanaged<CCAB*, uint, void*, BOOL> pfnfcignc, [NativeTypeName("PFNFCISTATUS")] delegate* unmanaged<uint, uint, uint, void*, int> pfnfcis);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FCIDestroy"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FCIDestroy([NativeTypeName("HFCI")] void* hfci);
+
+    [NativeTypeName("#define INCLUDED_FCI 1")]
+    public const int INCLUDED_FCI = 1;
+
+    [NativeTypeName("#define _A_NAME_IS_UTF 0x80")]
+    public const int _A_NAME_IS_UTF = 0x80;
+
+    [NativeTypeName("#define _A_EXEC 0x40")]
+    public const int _A_EXEC = 0x40;
+
+    [NativeTypeName("#define statusFile 0")]
+    public const int statusFile = 0;
+
+    [NativeTypeName("#define statusFolder 1")]
+    public const int statusFolder = 1;
+
+    [NativeTypeName("#define statusCabinet 2")]
+    public const int statusCabinet = 2;
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDICABINETINFO.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDICABINETINFO.cs
@@ -1,0 +1,35 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO"]/*' />
+public partial struct FDICABINETINFO
+{
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.cbCabinet"]/*' />
+    [NativeTypeName("long")]
+    public int cbCabinet;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.cFolders"]/*' />
+    public ushort cFolders;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.cFiles"]/*' />
+    public ushort cFiles;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.setID"]/*' />
+    public ushort setID;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.iCabinet"]/*' />
+    public ushort iCabinet;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.fReserve"]/*' />
+    public BOOL fReserve;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.hasprev"]/*' />
+    public BOOL hasprev;
+
+    /// <include file='FDICABINETINFO.xml' path='doc/member[@name="FDICABINETINFO.hasnext"]/*' />
+    public BOOL hasnext;
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDIDECRYPT.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDIDECRYPT.cs
@@ -1,0 +1,124 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDIDECRYPT.xml' path='doc/member[@name="FDIDECRYPT"]/*' />
+public unsafe partial struct FDIDECRYPT
+{
+    /// <include file='FDIDECRYPT.xml' path='doc/member[@name="FDIDECRYPT.fdidt"]/*' />
+    public FDIDECRYPTTYPE fdidt;
+
+    /// <include file='FDIDECRYPT.xml' path='doc/member[@name="FDIDECRYPT.pvUser"]/*' />
+    public void* pvUser;
+
+    /// <include file='FDIDECRYPT.xml' path='doc/member[@name="FDIDECRYPT.Anonymous"]/*' />
+    [NativeTypeName("FDIDECRYPT::(anonymous union at C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fdi.h:416:5)")]
+    public _Anonymous_e__Union Anonymous;
+
+    /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union.cabinet"]/*' />
+    public ref _Anonymous_e__Union._cabinet_e__Struct cabinet
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.cabinet, 1));
+        }
+    }
+
+    /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union.folder"]/*' />
+    public ref _Anonymous_e__Union._folder_e__Struct folder
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.folder, 1));
+        }
+    }
+
+    /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union.decrypt"]/*' />
+    public ref _Anonymous_e__Union._decrypt_e__Struct decrypt
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.decrypt, 1));
+        }
+    }
+
+    /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union"]/*' />
+    [StructLayout(LayoutKind.Explicit)]
+    public partial struct _Anonymous_e__Union
+    {
+        /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union.cabinet"]/*' />
+        [FieldOffset(0)]
+        [NativeTypeName("struct (anonymous struct at C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fdi.h:417:9)")]
+        public _cabinet_e__Struct cabinet;
+
+        /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union.folder"]/*' />
+        [FieldOffset(0)]
+        [NativeTypeName("struct (anonymous struct at C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fdi.h:424:9)")]
+        public _folder_e__Struct folder;
+
+        /// <include file='_Anonymous_e__Union.xml' path='doc/member[@name="_Anonymous_e__Union.decrypt"]/*' />
+        [FieldOffset(0)]
+        [NativeTypeName("struct (anonymous struct at C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um/fdi.h:430:9)")]
+        public _decrypt_e__Struct decrypt;
+
+        /// <include file='_cabinet_e__Struct.xml' path='doc/member[@name="_cabinet_e__Struct"]/*' />
+        public unsafe partial struct _cabinet_e__Struct
+        {
+            /// <include file='_cabinet_e__Struct.xml' path='doc/member[@name="_cabinet_e__Struct.pHeaderReserve"]/*' />
+            public void* pHeaderReserve;
+
+            /// <include file='_cabinet_e__Struct.xml' path='doc/member[@name="_cabinet_e__Struct.cbHeaderReserve"]/*' />
+            public ushort cbHeaderReserve;
+
+            /// <include file='_cabinet_e__Struct.xml' path='doc/member[@name="_cabinet_e__Struct.setID"]/*' />
+            public ushort setID;
+
+            /// <include file='_cabinet_e__Struct.xml' path='doc/member[@name="_cabinet_e__Struct.iCabinet"]/*' />
+            public int iCabinet;
+        }
+
+        /// <include file='_folder_e__Struct.xml' path='doc/member[@name="_folder_e__Struct"]/*' />
+        public unsafe partial struct _folder_e__Struct
+        {
+            /// <include file='_folder_e__Struct.xml' path='doc/member[@name="_folder_e__Struct.pFolderReserve"]/*' />
+            public void* pFolderReserve;
+
+            /// <include file='_folder_e__Struct.xml' path='doc/member[@name="_folder_e__Struct.cbFolderReserve"]/*' />
+            public ushort cbFolderReserve;
+
+            /// <include file='_folder_e__Struct.xml' path='doc/member[@name="_folder_e__Struct.iFolder"]/*' />
+            public ushort iFolder;
+        }
+
+        /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct"]/*' />
+        public unsafe partial struct _decrypt_e__Struct
+        {
+            /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct.pDataReserve"]/*' />
+            public void* pDataReserve;
+
+            /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct.cbDataReserve"]/*' />
+            public ushort cbDataReserve;
+
+            /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct.pbData"]/*' />
+            public void* pbData;
+
+            /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct.cbData"]/*' />
+            public ushort cbData;
+
+            /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct.fSplit"]/*' />
+            public BOOL fSplit;
+
+            /// <include file='_decrypt_e__Struct.xml' path='doc/member[@name="_decrypt_e__Struct.cbPartial"]/*' />
+            public ushort cbPartial;
+        }
+    }
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDIDECRYPTTYPE.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDIDECRYPTTYPE.cs
@@ -1,0 +1,19 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDIDECRYPTTYPE.xml' path='doc/member[@name="FDIDECRYPTTYPE"]/*' />
+public enum FDIDECRYPTTYPE
+{
+    /// <include file='FDIDECRYPTTYPE.xml' path='doc/member[@name="FDIDECRYPTTYPE.fdidtNEW_CABINET"]/*' />
+    fdidtNEW_CABINET,
+
+    /// <include file='FDIDECRYPTTYPE.xml' path='doc/member[@name="FDIDECRYPTTYPE.fdidtNEW_FOLDER"]/*' />
+    fdidtNEW_FOLDER,
+
+    /// <include file='FDIDECRYPTTYPE.xml' path='doc/member[@name="FDIDECRYPTTYPE.fdidtDECRYPT"]/*' />
+    fdidtDECRYPT,
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDIERROR.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDIERROR.cs
@@ -1,0 +1,49 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR"]/*' />
+public enum FDIERROR
+{
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_NONE"]/*' />
+    FDIERROR_NONE,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_CABINET_NOT_FOUND"]/*' />
+    FDIERROR_CABINET_NOT_FOUND,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_NOT_A_CABINET"]/*' />
+    FDIERROR_NOT_A_CABINET,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_UNKNOWN_CABINET_VERSION"]/*' />
+    FDIERROR_UNKNOWN_CABINET_VERSION,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_CORRUPT_CABINET"]/*' />
+    FDIERROR_CORRUPT_CABINET,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_ALLOC_FAIL"]/*' />
+    FDIERROR_ALLOC_FAIL,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_BAD_COMPR_TYPE"]/*' />
+    FDIERROR_BAD_COMPR_TYPE,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_MDI_FAIL"]/*' />
+    FDIERROR_MDI_FAIL,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_TARGET_FILE"]/*' />
+    FDIERROR_TARGET_FILE,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_RESERVE_MISMATCH"]/*' />
+    FDIERROR_RESERVE_MISMATCH,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_WRONG_CABINET"]/*' />
+    FDIERROR_WRONG_CABINET,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_USER_ABORT"]/*' />
+    FDIERROR_USER_ABORT,
+
+    /// <include file='FDIERROR.xml' path='doc/member[@name="FDIERROR.FDIERROR_EOF"]/*' />
+    FDIERROR_EOF,
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDINOTIFICATION.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDINOTIFICATION.cs
@@ -1,0 +1,54 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION"]/*' />
+public unsafe partial struct FDINOTIFICATION
+{
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.cb"]/*' />
+    [NativeTypeName("long")]
+    public int cb;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.psz1"]/*' />
+    [NativeTypeName("char *")]
+    public sbyte* psz1;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.psz2"]/*' />
+    [NativeTypeName("char *")]
+    public sbyte* psz2;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.psz3"]/*' />
+    [NativeTypeName("char *")]
+    public sbyte* psz3;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.pv"]/*' />
+    public void* pv;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.hf"]/*' />
+    [NativeTypeName("INT_PTR")]
+    public nint hf;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.date"]/*' />
+    public ushort date;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.time"]/*' />
+    public ushort time;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.attribs"]/*' />
+    public ushort attribs;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.setID"]/*' />
+    public ushort setID;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.iCabinet"]/*' />
+    public ushort iCabinet;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.iFolder"]/*' />
+    public ushort iFolder;
+
+    /// <include file='FDINOTIFICATION.xml' path='doc/member[@name="FDINOTIFICATION.fdie"]/*' />
+    public FDIERROR fdie;
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDINOTIFICATIONTYPE.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDINOTIFICATIONTYPE.cs
@@ -1,0 +1,28 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE"]/*' />
+public enum FDINOTIFICATIONTYPE
+{
+    /// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE.fdintCABINET_INFO"]/*' />
+    fdintCABINET_INFO,
+
+    /// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE.fdintPARTIAL_FILE"]/*' />
+    fdintPARTIAL_FILE,
+
+    /// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE.fdintCOPY_FILE"]/*' />
+    fdintCOPY_FILE,
+
+    /// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE.fdintCLOSE_FILE_INFO"]/*' />
+    fdintCLOSE_FILE_INFO,
+
+    /// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE.fdintNEXT_CABINET"]/*' />
+    fdintNEXT_CABINET,
+
+    /// <include file='FDINOTIFICATIONTYPE.xml' path='doc/member[@name="FDINOTIFICATIONTYPE.fdintENUMERATE"]/*' />
+    fdintENUMERATE,
+}

--- a/sources/Interop/Windows/Windows/um/fdi/FDISPILLFILE.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/FDISPILLFILE.cs
@@ -1,0 +1,18 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='FDISPILLFILE.xml' path='doc/member[@name="FDISPILLFILE"]/*' />
+public unsafe partial struct FDISPILLFILE
+{
+    /// <include file='FDISPILLFILE.xml' path='doc/member[@name="FDISPILLFILE.ach"]/*' />
+    [NativeTypeName("char [2]")]
+    public fixed sbyte ach[2];
+
+    /// <include file='FDISPILLFILE.xml' path='doc/member[@name="FDISPILLFILE.cbFile"]/*' />
+    [NativeTypeName("long")]
+    public int cbFile;
+}

--- a/sources/Interop/Windows/Windows/um/fdi/Windows.cs
+++ b/sources/Interop/Windows/Windows/um/fdi/Windows.cs
@@ -1,0 +1,44 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows;
+
+public static unsafe partial class Windows
+{
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FDICreate"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    [return: NativeTypeName("HFDI")]
+    public static extern void* FDICreate([NativeTypeName("PFNALLOC")] delegate* unmanaged<uint, void*> pfnalloc, [NativeTypeName("PFNFREE")] delegate* unmanaged<void*, void> pfnfree, [NativeTypeName("PFNOPEN")] delegate* unmanaged<sbyte*, int, int, nint> pfnopen, [NativeTypeName("PFNREAD")] delegate* unmanaged<nint, void*, uint, uint> pfnread, [NativeTypeName("PFNWRITE")] delegate* unmanaged<nint, void*, uint, uint> pfnwrite, [NativeTypeName("PFNCLOSE")] delegate* unmanaged<nint, int> pfnclose, [NativeTypeName("PFNSEEK")] delegate* unmanaged<nint, int, int, int> pfnseek, int cpuType, [NativeTypeName("PERF")] ERF* perf);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FDIIsCabinet"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FDIIsCabinet([NativeTypeName("HFDI")] void* hfdi, [NativeTypeName("INT_PTR")] nint hf, [NativeTypeName("PFDICABINETINFO")] FDICABINETINFO* pfdici);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FDICopy"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FDICopy([NativeTypeName("HFDI")] void* hfdi, [NativeTypeName("LPSTR")] sbyte* pszCabinet, [NativeTypeName("LPSTR")] sbyte* pszCabPath, int flags, [NativeTypeName("PFNFDINOTIFY")] delegate* unmanaged<FDINOTIFICATIONTYPE, FDINOTIFICATION*, nint> pfnfdin, [NativeTypeName("PFNFDIDECRYPT")] delegate* unmanaged<FDIDECRYPT*, int> pfnfdid, void* pvUser);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FDIDestroy"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FDIDestroy([NativeTypeName("HFDI")] void* hfdi);
+
+    /// <include file='Windows.xml' path='doc/member[@name="Windows.FDITruncateCabinet"]/*' />
+    [DllImport("cabinet", ExactSpelling = true)]
+    public static extern BOOL FDITruncateCabinet([NativeTypeName("HFDI")] void* hfdi, [NativeTypeName("LPSTR")] sbyte* pszCabinetName, ushort iFolderToDelete);
+
+    [NativeTypeName("#define INCLUDED_FDI 1")]
+    public const int INCLUDED_FDI = 1;
+
+    [NativeTypeName("#define cpuUNKNOWN (-1)")]
+    public const int cpuUNKNOWN = (-1);
+
+    [NativeTypeName("#define cpu80286 (0)")]
+    public const int cpu80286 = (0);
+
+    [NativeTypeName("#define cpu80386 (1)")]
+    public const int cpu80386 = (1);
+}

--- a/sources/Interop/Windows/Windows/um/fdi_fci_types/CB.cs
+++ b/sources/Interop/Windows/Windows/um/fdi_fci_types/CB.cs
@@ -1,0 +1,27 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi_fci_types.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+public static partial class CB
+{
+    [NativeTypeName("#define CB_MAX_CHUNK 32768U")]
+    public const uint CB_MAX_CHUNK = 32768U;
+
+    [NativeTypeName("#define CB_MAX_DISK 0x7fffffffL")]
+    public const int CB_MAX_DISK = 0x7fffffff;
+
+    [NativeTypeName("#define CB_MAX_FILENAME 256")]
+    public const int CB_MAX_FILENAME = 256;
+
+    [NativeTypeName("#define CB_MAX_CABINET_NAME 256")]
+    public const int CB_MAX_CABINET_NAME = 256;
+
+    [NativeTypeName("#define CB_MAX_CAB_PATH 256")]
+    public const int CB_MAX_CAB_PATH = 256;
+
+    [NativeTypeName("#define CB_MAX_DISK_NAME 256")]
+    public const int CB_MAX_DISK_NAME = 256;
+}

--- a/sources/Interop/Windows/Windows/um/fdi_fci_types/ERF.cs
+++ b/sources/Interop/Windows/Windows/um/fdi_fci_types/ERF.cs
@@ -1,0 +1,19 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi_fci_types.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+/// <include file='ERF.xml' path='doc/member[@name="ERF"]/*' />
+public partial struct ERF
+{
+    /// <include file='ERF.xml' path='doc/member[@name="ERF.erfOper"]/*' />
+    public int erfOper;
+
+    /// <include file='ERF.xml' path='doc/member[@name="ERF.erfType"]/*' />
+    public int erfType;
+
+    /// <include file='ERF.xml' path='doc/member[@name="ERF.fError"]/*' />
+    public BOOL fError;
+}

--- a/sources/Interop/Windows/Windows/um/fdi_fci_types/Windows.cs
+++ b/sources/Interop/Windows/Windows/um/fdi_fci_types/Windows.cs
@@ -1,0 +1,69 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi_fci_types.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.Windows;
+
+public static partial class Windows
+{
+    [NativeTypeName("#define INCLUDED_TYPES_FCI_FDI 1")]
+    public const int INCLUDED_TYPES_FCI_FDI = 1;
+
+    [NativeTypeName("#define tcompMASK_TYPE 0x000F")]
+    public const int tcompMASK_TYPE = 0x000F;
+
+    [NativeTypeName("#define tcompTYPE_NONE 0x0000")]
+    public const int tcompTYPE_NONE = 0x0000;
+
+    [NativeTypeName("#define tcompTYPE_MSZIP 0x0001")]
+    public const int tcompTYPE_MSZIP = 0x0001;
+
+    [NativeTypeName("#define tcompTYPE_QUANTUM 0x0002")]
+    public const int tcompTYPE_QUANTUM = 0x0002;
+
+    [NativeTypeName("#define tcompTYPE_LZX 0x0003")]
+    public const int tcompTYPE_LZX = 0x0003;
+
+    [NativeTypeName("#define tcompBAD 0x000F")]
+    public const int tcompBAD = 0x000F;
+
+    [NativeTypeName("#define tcompMASK_LZX_WINDOW 0x1F00")]
+    public const int tcompMASK_LZX_WINDOW = 0x1F00;
+
+    [NativeTypeName("#define tcompLZX_WINDOW_LO 0x0F00")]
+    public const int tcompLZX_WINDOW_LO = 0x0F00;
+
+    [NativeTypeName("#define tcompLZX_WINDOW_HI 0x1500")]
+    public const int tcompLZX_WINDOW_HI = 0x1500;
+
+    [NativeTypeName("#define tcompSHIFT_LZX_WINDOW 8")]
+    public const int tcompSHIFT_LZX_WINDOW = 8;
+
+    [NativeTypeName("#define tcompMASK_QUANTUM_LEVEL 0x00F0")]
+    public const int tcompMASK_QUANTUM_LEVEL = 0x00F0;
+
+    [NativeTypeName("#define tcompQUANTUM_LEVEL_LO 0x0010")]
+    public const int tcompQUANTUM_LEVEL_LO = 0x0010;
+
+    [NativeTypeName("#define tcompQUANTUM_LEVEL_HI 0x0070")]
+    public const int tcompQUANTUM_LEVEL_HI = 0x0070;
+
+    [NativeTypeName("#define tcompSHIFT_QUANTUM_LEVEL 4")]
+    public const int tcompSHIFT_QUANTUM_LEVEL = 4;
+
+    [NativeTypeName("#define tcompMASK_QUANTUM_MEM 0x1F00")]
+    public const int tcompMASK_QUANTUM_MEM = 0x1F00;
+
+    [NativeTypeName("#define tcompQUANTUM_MEM_LO 0x0A00")]
+    public const int tcompQUANTUM_MEM_LO = 0x0A00;
+
+    [NativeTypeName("#define tcompQUANTUM_MEM_HI 0x1500")]
+    public const int tcompQUANTUM_MEM_HI = 0x1500;
+
+    [NativeTypeName("#define tcompSHIFT_QUANTUM_MEM 8")]
+    public const int tcompSHIFT_QUANTUM_MEM = 8;
+
+    [NativeTypeName("#define tcompMASK_RESERVED 0xE000")]
+    public const int tcompMASK_RESERVED = 0xE000;
+}

--- a/tests/Interop/Windows/Windows/um/fci/CCABTests.cs
+++ b/tests/Interop/Windows/Windows/um/fci/CCABTests.cs
@@ -1,0 +1,34 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fci.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="CCAB" /> struct.</summary>
+public static unsafe partial class CCABTests
+{
+    /// <summary>Validates that the <see cref="CCAB" /> struct is blittable.</summary>
+    [Test]
+    public static void IsBlittableTest()
+    {
+        Assert.That(Marshal.SizeOf<CCAB>(), Is.EqualTo(sizeof(CCAB)));
+    }
+
+    /// <summary>Validates that the <see cref="CCAB" /> struct has the right <see cref="LayoutKind" />.</summary>
+    [Test]
+    public static void IsLayoutSequentialTest()
+    {
+        Assert.That(typeof(CCAB).IsLayoutSequential, Is.True);
+    }
+
+    /// <summary>Validates that the <see cref="CCAB" /> struct has the correct size.</summary>
+    [Test]
+    public static void SizeOfTest()
+    {
+        Assert.That(sizeof(CCAB), Is.EqualTo(804));
+    }
+}

--- a/tests/Interop/Windows/Windows/um/fdi_fci_types/ERFTests.cs
+++ b/tests/Interop/Windows/Windows/um/fdi_fci_types/ERFTests.cs
@@ -1,0 +1,34 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi_fci_types.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="ERF" /> struct.</summary>
+public static unsafe partial class ERFTests
+{
+    /// <summary>Validates that the <see cref="ERF" /> struct is blittable.</summary>
+    [Test]
+    public static void IsBlittableTest()
+    {
+        Assert.That(Marshal.SizeOf<ERF>(), Is.EqualTo(sizeof(ERF)));
+    }
+
+    /// <summary>Validates that the <see cref="ERF" /> struct has the right <see cref="LayoutKind" />.</summary>
+    [Test]
+    public static void IsLayoutSequentialTest()
+    {
+        Assert.That(typeof(ERF).IsLayoutSequential, Is.True);
+    }
+
+    /// <summary>Validates that the <see cref="ERF" /> struct has the correct size.</summary>
+    [Test]
+    public static void SizeOfTest()
+    {
+        Assert.That(sizeof(ERF), Is.EqualTo(12));
+    }
+}

--- a/tests/Interop/Windows/Windows/um/fid/FDICABINETINFOTests.cs
+++ b/tests/Interop/Windows/Windows/um/fid/FDICABINETINFOTests.cs
@@ -1,0 +1,34 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="FDICABINETINFO" /> struct.</summary>
+public static unsafe partial class FDICABINETINFOTests
+{
+    /// <summary>Validates that the <see cref="FDICABINETINFO" /> struct is blittable.</summary>
+    [Test]
+    public static void IsBlittableTest()
+    {
+        Assert.That(Marshal.SizeOf<FDICABINETINFO>(), Is.EqualTo(sizeof(FDICABINETINFO)));
+    }
+
+    /// <summary>Validates that the <see cref="FDICABINETINFO" /> struct has the right <see cref="LayoutKind" />.</summary>
+    [Test]
+    public static void IsLayoutSequentialTest()
+    {
+        Assert.That(typeof(FDICABINETINFO).IsLayoutSequential, Is.True);
+    }
+
+    /// <summary>Validates that the <see cref="FDICABINETINFO" /> struct has the correct size.</summary>
+    [Test]
+    public static void SizeOfTest()
+    {
+        Assert.That(sizeof(FDICABINETINFO), Is.EqualTo(24));
+    }
+}

--- a/tests/Interop/Windows/Windows/um/fid/FDIDECRYPTTests.cs
+++ b/tests/Interop/Windows/Windows/um/fid/FDIDECRYPTTests.cs
@@ -1,0 +1,42 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="FDIDECRYPT" /> struct.</summary>
+public static unsafe partial class FDIDECRYPTTests
+{
+    /// <summary>Validates that the <see cref="FDIDECRYPT" /> struct is blittable.</summary>
+    [Test]
+    public static void IsBlittableTest()
+    {
+        Assert.That(Marshal.SizeOf<FDIDECRYPT>(), Is.EqualTo(sizeof(FDIDECRYPT)));
+    }
+
+    /// <summary>Validates that the <see cref="FDIDECRYPT" /> struct has the right <see cref="LayoutKind" />.</summary>
+    [Test]
+    public static void IsLayoutSequentialTest()
+    {
+        Assert.That(typeof(FDIDECRYPT).IsLayoutSequential, Is.True);
+    }
+
+    /// <summary>Validates that the <see cref="FDIDECRYPT" /> struct has the correct size.</summary>
+    [Test]
+    public static void SizeOfTest()
+    {
+        if (Environment.Is64BitProcess)
+        {
+            Assert.That(sizeof(FDIDECRYPT), Is.EqualTo(56));
+        }
+        else
+        {
+            Assert.That(sizeof(FDIDECRYPT), Is.EqualTo(32));
+        }
+    }
+}

--- a/tests/Interop/Windows/Windows/um/fid/FDINOTIFICATIONTests.cs
+++ b/tests/Interop/Windows/Windows/um/fid/FDINOTIFICATIONTests.cs
@@ -1,0 +1,42 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="FDINOTIFICATION" /> struct.</summary>
+public static unsafe partial class FDINOTIFICATIONTests
+{
+    /// <summary>Validates that the <see cref="FDINOTIFICATION" /> struct is blittable.</summary>
+    [Test]
+    public static void IsBlittableTest()
+    {
+        Assert.That(Marshal.SizeOf<FDINOTIFICATION>(), Is.EqualTo(sizeof(FDINOTIFICATION)));
+    }
+
+    /// <summary>Validates that the <see cref="FDINOTIFICATION" /> struct has the right <see cref="LayoutKind" />.</summary>
+    [Test]
+    public static void IsLayoutSequentialTest()
+    {
+        Assert.That(typeof(FDINOTIFICATION).IsLayoutSequential, Is.True);
+    }
+
+    /// <summary>Validates that the <see cref="FDINOTIFICATION" /> struct has the correct size.</summary>
+    [Test]
+    public static void SizeOfTest()
+    {
+        if (Environment.Is64BitProcess)
+        {
+            Assert.That(sizeof(FDINOTIFICATION), Is.EqualTo(64));
+        }
+        else
+        {
+            Assert.That(sizeof(FDINOTIFICATION), Is.EqualTo(40));
+        }
+    }
+}

--- a/tests/Interop/Windows/Windows/um/fid/FDISPILLFILETests.cs
+++ b/tests/Interop/Windows/Windows/um/fid/FDISPILLFILETests.cs
@@ -1,0 +1,34 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/fdi.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using NUnit.Framework;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="FDISPILLFILE" /> struct.</summary>
+public static unsafe partial class FDISPILLFILETests
+{
+    /// <summary>Validates that the <see cref="FDISPILLFILE" /> struct is blittable.</summary>
+    [Test]
+    public static void IsBlittableTest()
+    {
+        Assert.That(Marshal.SizeOf<FDISPILLFILE>(), Is.EqualTo(sizeof(FDISPILLFILE)));
+    }
+
+    /// <summary>Validates that the <see cref="FDISPILLFILE" /> struct has the right <see cref="LayoutKind" />.</summary>
+    [Test]
+    public static void IsLayoutSequentialTest()
+    {
+        Assert.That(typeof(FDISPILLFILE).IsLayoutSequential, Is.True);
+    }
+
+    /// <summary>Validates that the <see cref="FDISPILLFILE" /> struct has the correct size.</summary>
+    [Test]
+    public static void SizeOfTest()
+    {
+        Assert.That(sizeof(FDISPILLFILE), Is.EqualTo(8));
+    }
+}


### PR DESCRIPTION
The FCI (File Compression Interface) and FDI (File Decompression Interface) libraries provide the ability to create and extract files from cabinets (also known as "CAB files").