### PR TITLE
Regenerating bindings with some iterative improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
   <!-- Default settings that explicitly differ from the Sdk.props defaults  -->
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AnalysisLevel>preview</AnalysisLevel>
     <BaseIntermediateOutputPath>$(BaseArtifactsPath)obj/$(BaseArtifactsPathSuffix)/</BaseIntermediateOutputPath>
     <DebugType>embedded</DebugType>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,7 +12,7 @@
 
   <!-- Settings that append the existing setting value -->
   <PropertyGroup>
-    <NoWarn>$(NoWarn);AD0001;IL2050;NU1507;NU5105</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NU5105</NoWarn>
   </PropertyGroup>
 
   <!-- Settings that are only set for CI builds -->

--- a/generation/Windows/um/sysinfoapi/generate.rsp
+++ b/generation/Windows/um/sysinfoapi/generate.rsp
@@ -16,6 +16,7 @@ C:/Program Files (x86)/Windows Kits/10/Include/10.0.22000.0/um/sysinfoapi.h
 GetIntegratedDisplaySize=SupportedOSPlatform("windows10.0")
 GetSystemTimeAdjustmentPrecise=SupportedOSPlatform("windows10.0")
 GetSystemTimePreciseAsFileTime=SupportedOSPlatform("windows8.0")
+GetVersionEx=Obsolete
 InstallELAMCertificateInfo=SupportedOSPlatform("windows8.1")
 SetSystemTimeAdjustmentPrecise=SupportedOSPlatform("windows10.0")
 --with-librarypath

--- a/sources/Interop/Windows/DirectX/um/d2d1/ID2D1Factory.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1/ID2D1Factory.cs
@@ -68,6 +68,7 @@ public unsafe partial struct ID2D1Factory : ID2D1Factory.Interface, INativeGuid
     /// <include file='ID2D1Factory.xml' path='doc/member[@name="ID2D1Factory.GetDesktopDpi"]/*' />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -175,6 +176,7 @@ public unsafe partial struct ID2D1Factory : ID2D1Factory.Interface, INativeGuid
         HRESULT ReloadSystemMetrics();
 
         [VtblIndex(4)]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         void GetDesktopDpi(float* dpiX, float* dpiY);
 
         [VtblIndex(5)]
@@ -230,6 +232,7 @@ public unsafe partial struct ID2D1Factory : ID2D1Factory.Interface, INativeGuid
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_1/ID2D1Factory1.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_1/ID2D1Factory1.cs
@@ -80,6 +80,7 @@ public unsafe partial struct ID2D1Factory1 : ID2D1Factory1.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory1*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory1*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -304,6 +305,7 @@ public unsafe partial struct ID2D1Factory1 : ID2D1Factory1.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_2/ID2D1Factory2.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_2/ID2D1Factory2.cs
@@ -80,6 +80,7 @@ public unsafe partial struct ID2D1Factory2 : ID2D1Factory2.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory2*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory2*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -291,6 +292,7 @@ public unsafe partial struct ID2D1Factory2 : ID2D1Factory2.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory3.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory3.cs
@@ -78,6 +78,7 @@ public unsafe partial struct ID2D1Factory3 : ID2D1Factory3.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory3*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory3*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -297,6 +298,7 @@ public unsafe partial struct ID2D1Factory3 : ID2D1Factory3.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory4.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory4.cs
@@ -78,6 +78,7 @@ public unsafe partial struct ID2D1Factory4 : ID2D1Factory4.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory4*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory4*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -305,6 +306,7 @@ public unsafe partial struct ID2D1Factory4 : ID2D1Factory4.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory5.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory5.cs
@@ -78,6 +78,7 @@ public unsafe partial struct ID2D1Factory5 : ID2D1Factory5.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory5*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory5*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -313,6 +314,7 @@ public unsafe partial struct ID2D1Factory5 : ID2D1Factory5.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory6.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory6.cs
@@ -78,6 +78,7 @@ public unsafe partial struct ID2D1Factory6 : ID2D1Factory6.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory6*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory6*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -321,6 +322,7 @@ public unsafe partial struct ID2D1Factory6 : ID2D1Factory6.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory7.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_3/ID2D1Factory7.cs
@@ -78,6 +78,7 @@ public unsafe partial struct ID2D1Factory7 : ID2D1Factory7.Interface, INativeGui
     /// <inheritdoc cref="ID2D1Factory.GetDesktopDpi" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(4)]
+    [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
     public void GetDesktopDpi(float* dpiX, float* dpiY)
     {
         ((delegate* unmanaged<ID2D1Factory7*, float*, float*, void>)(lpVtbl[4]))((ID2D1Factory7*)Unsafe.AsPointer(ref this), dpiX, dpiY);
@@ -329,6 +330,7 @@ public unsafe partial struct ID2D1Factory7 : ID2D1Factory7.Interface, INativeGui
         public delegate* unmanaged<TSelf*, int> ReloadSystemMetrics;
 
         [NativeTypeName("void (FLOAT *, FLOAT *) __attribute__((nothrow)) __attribute__((stdcall))")]
+        [Obsolete("Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps")]
         public delegate* unmanaged<TSelf*, float*, float*, void> GetDesktopDpi;
 
         [NativeTypeName("HRESULT (const D2D1_RECT_F *, ID2D1RectangleGeometry **) __attribute__((nothrow)) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/Windows/other/helper-types/APARTMENT_SHUTDOWN_REGISTRATION_COOKIE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/APARTMENT_SHUTDOWN_REGISTRATION_COOKIE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct APARTMENT_SHUTDOWN_REGISTRATION_COOKIE : IComparable, IComparable<APARTMENT_SHUTDOWN_REGISTRATION_COOKIE>, IEquatable<APARTMENT_SHUTDOWN_REGISTRATION_COOKIE>, IFormattable
+public readonly unsafe partial struct APARTMENT_SHUTDOWN_REGISTRATION_COOKIE : IComparable, IComparable<APARTMENT_SHUTDOWN_REGISTRATION_COOKIE>, IEquatable<APARTMENT_SHUTDOWN_REGISTRATION_COOKIE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/ASYNCCOMPLETIONHANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/ASYNCCOMPLETIONHANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct ASYNCCOMPLETIONHANDLE : IComparable, IComparable<ASYNCCOMPLETIONHANDLE>, IEquatable<ASYNCCOMPLETIONHANDLE>, IFormattable
+public readonly unsafe partial struct ASYNCCOMPLETIONHANDLE : IComparable, IComparable<ASYNCCOMPLETIONHANDLE>, IEquatable<ASYNCCOMPLETIONHANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/BOOL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/BOOL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public partial struct BOOL : IComparable, IComparable<BOOL>, IEquatable<BOOL>, IFormattable
+public readonly partial struct BOOL : IComparable, IComparable<BOOL>, IEquatable<BOOL>, IFormattable
 {
     public readonly int Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/COLORREF.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/COLORREF.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct COLORREF : IComparable, IComparable<COLORREF>, IEquatable<COLORREF>, IFormattable
+public readonly unsafe partial struct COLORREF : IComparable, IComparable<COLORREF>, IEquatable<COLORREF>, IFormattable
 {
     public readonly uint Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/COMPRESSOR_HANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/COMPRESSOR_HANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct COMPRESSOR_HANDLE : IComparable, IComparable<COMPRESSOR_HANDLE>, IEquatable<COMPRESSOR_HANDLE>, IFormattable
+public readonly unsafe partial struct COMPRESSOR_HANDLE : IComparable, IComparable<COMPRESSOR_HANDLE>, IEquatable<COMPRESSOR_HANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/CO_DEVICE_CATALOG_COOKIE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/CO_DEVICE_CATALOG_COOKIE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct CO_DEVICE_CATALOG_COOKIE : IComparable, IComparable<CO_DEVICE_CATALOG_COOKIE>, IEquatable<CO_DEVICE_CATALOG_COOKIE>, IFormattable
+public readonly unsafe partial struct CO_DEVICE_CATALOG_COOKIE : IComparable, IComparable<CO_DEVICE_CATALOG_COOKIE>, IEquatable<CO_DEVICE_CATALOG_COOKIE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/CO_MTA_USAGE_COOKIE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/CO_MTA_USAGE_COOKIE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct CO_MTA_USAGE_COOKIE : IComparable, IComparable<CO_MTA_USAGE_COOKIE>, IEquatable<CO_MTA_USAGE_COOKIE>, IFormattable
+public readonly unsafe partial struct CO_MTA_USAGE_COOKIE : IComparable, IComparable<CO_MTA_USAGE_COOKIE>, IEquatable<CO_MTA_USAGE_COOKIE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/DPI_AWARENESS_CONTEXT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/DPI_AWARENESS_CONTEXT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct DPI_AWARENESS_CONTEXT : IComparable, IComparable<DPI_AWARENESS_CONTEXT>, IEquatable<DPI_AWARENESS_CONTEXT>, IFormattable
+public readonly unsafe partial struct DPI_AWARENESS_CONTEXT : IComparable, IComparable<DPI_AWARENESS_CONTEXT>, IEquatable<DPI_AWARENESS_CONTEXT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/EC_HANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/EC_HANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct EC_HANDLE : IComparable, IComparable<EC_HANDLE>, IEquatable<EC_HANDLE>, IFormattable
+public readonly unsafe partial struct EC_HANDLE : IComparable, IComparable<EC_HANDLE>, IEquatable<EC_HANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/EC_OBJECT_ARRAY_PROPERTY_HANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/EC_OBJECT_ARRAY_PROPERTY_HANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct EC_OBJECT_ARRAY_PROPERTY_HANDLE : IComparable, IComparable<EC_OBJECT_ARRAY_PROPERTY_HANDLE>, IEquatable<EC_OBJECT_ARRAY_PROPERTY_HANDLE>, IFormattable
+public readonly unsafe partial struct EC_OBJECT_ARRAY_PROPERTY_HANDLE : IComparable, IComparable<EC_OBJECT_ARRAY_PROPERTY_HANDLE>, IEquatable<EC_OBJECT_ARRAY_PROPERTY_HANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HACCEL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HACCEL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HACCEL : IComparable, IComparable<HACCEL>, IEquatable<HACCEL>, IFormattable
+public readonly unsafe partial struct HACCEL : IComparable, IComparable<HACCEL>, IEquatable<HACCEL>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HANDLE : IComparable, IComparable<HANDLE>, IEquatable<HANDLE>, IFormattable
+public readonly unsafe partial struct HANDLE : IComparable, IComparable<HANDLE>, IEquatable<HANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HANDLE_PTR.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HANDLE_PTR.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HANDLE_PTR : IComparable, IComparable<HANDLE_PTR>, IEquatable<HANDLE_PTR>, IFormattable
+public readonly unsafe partial struct HANDLE_PTR : IComparable, IComparable<HANDLE_PTR>, IEquatable<HANDLE_PTR>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HANIMATIONBUFFER.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HANIMATIONBUFFER.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HANIMATIONBUFFER : IComparable, IComparable<HANIMATIONBUFFER>, IEquatable<HANIMATIONBUFFER>, IFormattable
+public readonly unsafe partial struct HANIMATIONBUFFER : IComparable, IComparable<HANIMATIONBUFFER>, IEquatable<HANIMATIONBUFFER>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HBITMAP.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HBITMAP.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HBITMAP : IComparable, IComparable<HBITMAP>, IEquatable<HBITMAP>, IFormattable
+public readonly unsafe partial struct HBITMAP : IComparable, IComparable<HBITMAP>, IEquatable<HBITMAP>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HBRUSH.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HBRUSH.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HBRUSH : IComparable, IComparable<HBRUSH>, IEquatable<HBRUSH>, IFormattable
+public readonly unsafe partial struct HBRUSH : IComparable, IComparable<HBRUSH>, IEquatable<HBRUSH>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCATADMIN.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCATADMIN.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCATADMIN : IComparable, IComparable<HCATADMIN>, IEquatable<HCATADMIN>, IFormattable
+public readonly unsafe partial struct HCATADMIN : IComparable, IComparable<HCATADMIN>, IEquatable<HCATADMIN>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCERTCHAINENGINE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCERTCHAINENGINE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCERTCHAINENGINE : IComparable, IComparable<HCERTCHAINENGINE>, IEquatable<HCERTCHAINENGINE>, IFormattable
+public readonly unsafe partial struct HCERTCHAINENGINE : IComparable, IComparable<HCERTCHAINENGINE>, IEquatable<HCERTCHAINENGINE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCERTSTORE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCERTSTORE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCERTSTORE : IComparable, IComparable<HCERTSTORE>, IEquatable<HCERTSTORE>, IFormattable
+public readonly unsafe partial struct HCERTSTORE : IComparable, IComparable<HCERTSTORE>, IEquatable<HCERTSTORE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCERTSTOREPROV.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCERTSTOREPROV.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCERTSTOREPROV : IComparable, IComparable<HCERTSTOREPROV>, IEquatable<HCERTSTOREPROV>, IFormattable
+public readonly unsafe partial struct HCERTSTOREPROV : IComparable, IComparable<HCERTSTOREPROV>, IEquatable<HCERTSTOREPROV>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCERT_SERVER_OCSP_RESPONSE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCERT_SERVER_OCSP_RESPONSE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCERT_SERVER_OCSP_RESPONSE : IComparable, IComparable<HCERT_SERVER_OCSP_RESPONSE>, IEquatable<HCERT_SERVER_OCSP_RESPONSE>, IFormattable
+public readonly unsafe partial struct HCERT_SERVER_OCSP_RESPONSE : IComparable, IComparable<HCERT_SERVER_OCSP_RESPONSE>, IEquatable<HCERT_SERVER_OCSP_RESPONSE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCOLORSPACE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCOLORSPACE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCOLORSPACE : IComparable, IComparable<HCOLORSPACE>, IEquatable<HCOLORSPACE>, IFormattable
+public readonly unsafe partial struct HCOLORSPACE : IComparable, IComparable<HCOLORSPACE>, IEquatable<HCOLORSPACE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCOMDB.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCOMDB.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCOMDB : IComparable, IComparable<HCOMDB>, IEquatable<HCOMDB>, IFormattable
+public readonly unsafe partial struct HCOMDB : IComparable, IComparable<HCOMDB>, IEquatable<HCOMDB>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTASYNC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTASYNC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTASYNC : IComparable, IComparable<HCRYPTASYNC>, IEquatable<HCRYPTASYNC>, IFormattable
+public readonly unsafe partial struct HCRYPTASYNC : IComparable, IComparable<HCRYPTASYNC>, IEquatable<HCRYPTASYNC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTDEFAULTCONTEXT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTDEFAULTCONTEXT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTDEFAULTCONTEXT : IComparable, IComparable<HCRYPTDEFAULTCONTEXT>, IEquatable<HCRYPTDEFAULTCONTEXT>, IFormattable
+public readonly unsafe partial struct HCRYPTDEFAULTCONTEXT : IComparable, IComparable<HCRYPTDEFAULTCONTEXT>, IEquatable<HCRYPTDEFAULTCONTEXT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTHASH.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTHASH.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTHASH : IComparable, IComparable<HCRYPTHASH>, IEquatable<HCRYPTHASH>, IFormattable
+public readonly unsafe partial struct HCRYPTHASH : IComparable, IComparable<HCRYPTHASH>, IEquatable<HCRYPTHASH>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTKEY.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTKEY.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTKEY : IComparable, IComparable<HCRYPTKEY>, IEquatable<HCRYPTKEY>, IFormattable
+public readonly unsafe partial struct HCRYPTKEY : IComparable, IComparable<HCRYPTKEY>, IEquatable<HCRYPTKEY>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTMSG.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTMSG.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTMSG : IComparable, IComparable<HCRYPTMSG>, IEquatable<HCRYPTMSG>, IFormattable
+public readonly unsafe partial struct HCRYPTMSG : IComparable, IComparable<HCRYPTMSG>, IEquatable<HCRYPTMSG>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTOIDFUNCADDR.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTOIDFUNCADDR.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTOIDFUNCADDR : IComparable, IComparable<HCRYPTOIDFUNCADDR>, IEquatable<HCRYPTOIDFUNCADDR>, IFormattable
+public readonly unsafe partial struct HCRYPTOIDFUNCADDR : IComparable, IComparable<HCRYPTOIDFUNCADDR>, IEquatable<HCRYPTOIDFUNCADDR>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTOIDFUNCSET.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTOIDFUNCSET.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTOIDFUNCSET : IComparable, IComparable<HCRYPTOIDFUNCSET>, IEquatable<HCRYPTOIDFUNCSET>, IFormattable
+public readonly unsafe partial struct HCRYPTOIDFUNCSET : IComparable, IComparable<HCRYPTOIDFUNCSET>, IEquatable<HCRYPTOIDFUNCSET>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTPROV.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTPROV.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTPROV : IComparable, IComparable<HCRYPTPROV>, IEquatable<HCRYPTPROV>, IFormattable
+public readonly unsafe partial struct HCRYPTPROV : IComparable, IComparable<HCRYPTPROV>, IEquatable<HCRYPTPROV>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTPROV_LEGACY.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTPROV_LEGACY.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTPROV_LEGACY : IComparable, IComparable<HCRYPTPROV_LEGACY>, IEquatable<HCRYPTPROV_LEGACY>, IFormattable
+public readonly unsafe partial struct HCRYPTPROV_LEGACY : IComparable, IComparable<HCRYPTPROV_LEGACY>, IEquatable<HCRYPTPROV_LEGACY>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCRYPTPROV_OR_NCRYPT_KEY_HANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCRYPTPROV_OR_NCRYPT_KEY_HANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCRYPTPROV_OR_NCRYPT_KEY_HANDLE : IComparable, IComparable<HCRYPTPROV_OR_NCRYPT_KEY_HANDLE>, IEquatable<HCRYPTPROV_OR_NCRYPT_KEY_HANDLE>, IFormattable
+public readonly unsafe partial struct HCRYPTPROV_OR_NCRYPT_KEY_HANDLE : IComparable, IComparable<HCRYPTPROV_OR_NCRYPT_KEY_HANDLE>, IEquatable<HCRYPTPROV_OR_NCRYPT_KEY_HANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HCURSOR.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HCURSOR.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HCURSOR : IComparable, IComparable<HCURSOR>, IEquatable<HCURSOR>, IFormattable
+public readonly unsafe partial struct HCURSOR : IComparable, IComparable<HCURSOR>, IEquatable<HCURSOR>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDC : IComparable, IComparable<HDC>, IEquatable<HDC>, IFormattable
+public readonly unsafe partial struct HDC : IComparable, IComparable<HDC>, IEquatable<HDC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDESK.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDESK.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDESK : IComparable, IComparable<HDESK>, IEquatable<HDESK>, IFormattable
+public readonly unsafe partial struct HDESK : IComparable, IComparable<HDESK>, IEquatable<HDESK>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDEVINFO.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDEVINFO.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDEVINFO : IComparable, IComparable<HDEVINFO>, IEquatable<HDEVINFO>, IFormattable
+public readonly unsafe partial struct HDEVINFO : IComparable, IComparable<HDEVINFO>, IEquatable<HDEVINFO>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDEVNOTIFY.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDEVNOTIFY.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDEVNOTIFY : IComparable, IComparable<HDEVNOTIFY>, IEquatable<HDEVNOTIFY>, IFormattable
+public readonly unsafe partial struct HDEVNOTIFY : IComparable, IComparable<HDEVNOTIFY>, IEquatable<HDEVNOTIFY>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDROP.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDROP.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDROP : IComparable, IComparable<HDROP>, IEquatable<HDROP>, IFormattable
+public readonly unsafe partial struct HDROP : IComparable, IComparable<HDROP>, IEquatable<HDROP>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDSKSPC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDSKSPC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDSKSPC : IComparable, IComparable<HDSKSPC>, IEquatable<HDSKSPC>, IFormattable
+public readonly unsafe partial struct HDSKSPC : IComparable, IComparable<HDSKSPC>, IEquatable<HDSKSPC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HDWP.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HDWP.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HDWP : IComparable, IComparable<HDWP>, IEquatable<HDWP>, IFormattable
+public readonly unsafe partial struct HDWP : IComparable, IComparable<HDWP>, IEquatable<HDWP>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HENHMETAFILE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HENHMETAFILE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HENHMETAFILE : IComparable, IComparable<HENHMETAFILE>, IEquatable<HENHMETAFILE>, IFormattable
+public readonly unsafe partial struct HENHMETAFILE : IComparable, IComparable<HENHMETAFILE>, IEquatable<HENHMETAFILE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HEVENT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HEVENT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HEVENT : IComparable, IComparable<HEVENT>, IEquatable<HEVENT>, IFormattable
+public readonly unsafe partial struct HEVENT : IComparable, IComparable<HEVENT>, IEquatable<HEVENT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HFONT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HFONT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HFONT : IComparable, IComparable<HFONT>, IEquatable<HFONT>, IFormattable
+public readonly unsafe partial struct HFONT : IComparable, IComparable<HFONT>, IEquatable<HFONT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HGDIOBJ.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HGDIOBJ.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HGDIOBJ : IComparable, IComparable<HGDIOBJ>, IEquatable<HGDIOBJ>, IFormattable
+public readonly unsafe partial struct HGDIOBJ : IComparable, IComparable<HGDIOBJ>, IEquatable<HGDIOBJ>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HGESTUREINFO.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HGESTUREINFO.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HGESTUREINFO : IComparable, IComparable<HGESTUREINFO>, IEquatable<HGESTUREINFO>, IFormattable
+public readonly unsafe partial struct HGESTUREINFO : IComparable, IComparable<HGESTUREINFO>, IEquatable<HGESTUREINFO>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HGLOBAL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HGLOBAL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HGLOBAL : IComparable, IComparable<HGLOBAL>, IEquatable<HGLOBAL>, IFormattable
+public readonly unsafe partial struct HGLOBAL : IComparable, IComparable<HGLOBAL>, IEquatable<HGLOBAL>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HGLRC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HGLRC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HGLRC : IComparable, IComparable<HGLRC>, IEquatable<HGLRC>, IFormattable
+public readonly unsafe partial struct HGLRC : IComparable, IComparable<HGLRC>, IEquatable<HGLRC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HHANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HHANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HHANDLE : IComparable, IComparable<HHANDLE>, IEquatable<HHANDLE>, IFormattable
+public readonly unsafe partial struct HHANDLE : IComparable, IComparable<HHANDLE>, IEquatable<HHANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HHOOK.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HHOOK.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HHOOK : IComparable, IComparable<HHOOK>, IEquatable<HHOOK>, IFormattable
+public readonly unsafe partial struct HHOOK : IComparable, IComparable<HHOOK>, IEquatable<HHOOK>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HICON.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HICON.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HICON : IComparable, IComparable<HICON>, IEquatable<HICON>, IFormattable
+public readonly unsafe partial struct HICON : IComparable, IComparable<HICON>, IEquatable<HICON>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HIFTIMESTAMPCHANGE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HIFTIMESTAMPCHANGE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HIFTIMESTAMPCHANGE : IComparable, IComparable<HIFTIMESTAMPCHANGE>, IEquatable<HIFTIMESTAMPCHANGE>, IFormattable
+public readonly unsafe partial struct HIFTIMESTAMPCHANGE : IComparable, IComparable<HIFTIMESTAMPCHANGE>, IEquatable<HIFTIMESTAMPCHANGE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HIMAGELIST.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HIMAGELIST.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HIMAGELIST : IComparable, IComparable<HIMAGELIST>, IEquatable<HIMAGELIST>, IFormattable
+public readonly unsafe partial struct HIMAGELIST : IComparable, IComparable<HIMAGELIST>, IEquatable<HIMAGELIST>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HIMC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HIMC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HIMC : IComparable, IComparable<HIMC>, IEquatable<HIMC>, IFormattable
+public readonly unsafe partial struct HIMC : IComparable, IComparable<HIMC>, IEquatable<HIMC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HIMCC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HIMCC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HIMCC : IComparable, IComparable<HIMCC>, IEquatable<HIMCC>, IFormattable
+public readonly unsafe partial struct HIMCC : IComparable, IComparable<HIMCC>, IEquatable<HIMCC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HINF.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HINF.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HINF : IComparable, IComparable<HINF>, IEquatable<HINF>, IFormattable
+public readonly unsafe partial struct HINF : IComparable, IComparable<HINF>, IEquatable<HINF>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HINSTANCE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HINSTANCE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HINSTANCE : IComparable, IComparable<HINSTANCE>, IEquatable<HINSTANCE>, IFormattable
+public readonly unsafe partial struct HINSTANCE : IComparable, IComparable<HINSTANCE>, IEquatable<HINSTANCE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HINTERACTIONCONTEXT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HINTERACTIONCONTEXT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HINTERACTIONCONTEXT : IComparable, IComparable<HINTERACTIONCONTEXT>, IEquatable<HINTERACTIONCONTEXT>, IFormattable
+public readonly unsafe partial struct HINTERACTIONCONTEXT : IComparable, IComparable<HINTERACTIONCONTEXT>, IEquatable<HINTERACTIONCONTEXT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HINTERNET.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HINTERNET.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HINTERNET : IComparable, IComparable<HINTERNET>, IEquatable<HINTERNET>, IFormattable
+public readonly unsafe partial struct HINTERNET : IComparable, IComparable<HINTERNET>, IEquatable<HINTERNET>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HKEY.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HKEY.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HKEY : IComparable, IComparable<HKEY>, IEquatable<HKEY>, IFormattable
+public readonly unsafe partial struct HKEY : IComparable, IComparable<HKEY>, IEquatable<HKEY>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HKL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HKL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HKL : IComparable, IComparable<HKL>, IEquatable<HKL>, IFormattable
+public readonly unsafe partial struct HKL : IComparable, IComparable<HKL>, IEquatable<HKL>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HLOCAL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HLOCAL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HLOCAL : IComparable, IComparable<HLOCAL>, IEquatable<HLOCAL>, IFormattable
+public readonly unsafe partial struct HLOCAL : IComparable, IComparable<HLOCAL>, IEquatable<HLOCAL>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMENU.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMENU.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMENU : IComparable, IComparable<HMENU>, IEquatable<HMENU>, IFormattable
+public readonly unsafe partial struct HMENU : IComparable, IComparable<HMENU>, IEquatable<HMENU>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMETAFILE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMETAFILE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMETAFILE : IComparable, IComparable<HMETAFILE>, IEquatable<HMETAFILE>, IFormattable
+public readonly unsafe partial struct HMETAFILE : IComparable, IComparable<HMETAFILE>, IEquatable<HMETAFILE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMETAFILEPICT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMETAFILEPICT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMETAFILEPICT : IComparable, IComparable<HMETAFILEPICT>, IEquatable<HMETAFILEPICT>, IFormattable
+public readonly unsafe partial struct HMETAFILEPICT : IComparable, IComparable<HMETAFILEPICT>, IEquatable<HMETAFILEPICT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMIDI.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMIDI.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMIDI : IComparable, IComparable<HMIDI>, IEquatable<HMIDI>, IFormattable
+public readonly unsafe partial struct HMIDI : IComparable, IComparable<HMIDI>, IEquatable<HMIDI>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMIDIIN.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMIDIIN.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMIDIIN : IComparable, IComparable<HMIDIIN>, IEquatable<HMIDIIN>, IFormattable
+public readonly unsafe partial struct HMIDIIN : IComparable, IComparable<HMIDIIN>, IEquatable<HMIDIIN>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMIDIOUT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMIDIOUT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMIDIOUT : IComparable, IComparable<HMIDIOUT>, IEquatable<HMIDIOUT>, IFormattable
+public readonly unsafe partial struct HMIDIOUT : IComparable, IComparable<HMIDIOUT>, IEquatable<HMIDIOUT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMIDISTRM.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMIDISTRM.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMIDISTRM : IComparable, IComparable<HMIDISTRM>, IEquatable<HMIDISTRM>, IFormattable
+public readonly unsafe partial struct HMIDISTRM : IComparable, IComparable<HMIDISTRM>, IEquatable<HMIDISTRM>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMIXER.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMIXER.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMIXER : IComparable, IComparable<HMIXER>, IEquatable<HMIXER>, IFormattable
+public readonly unsafe partial struct HMIXER : IComparable, IComparable<HMIXER>, IEquatable<HMIXER>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMIXEROBJ.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMIXEROBJ.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMIXEROBJ : IComparable, IComparable<HMIXEROBJ>, IEquatable<HMIXEROBJ>, IFormattable
+public readonly unsafe partial struct HMIXEROBJ : IComparable, IComparable<HMIXEROBJ>, IEquatable<HMIXEROBJ>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMODULE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMODULE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMODULE : IComparable, IComparable<HMODULE>, IEquatable<HMODULE>, IFormattable
+public readonly unsafe partial struct HMODULE : IComparable, IComparable<HMODULE>, IEquatable<HMODULE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HMONITOR.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HMONITOR.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HMONITOR : IComparable, IComparable<HMONITOR>, IEquatable<HMONITOR>, IFormattable
+public readonly unsafe partial struct HMONITOR : IComparable, IComparable<HMONITOR>, IEquatable<HMONITOR>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPAINTBUFFER.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPAINTBUFFER.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPAINTBUFFER : IComparable, IComparable<HPAINTBUFFER>, IEquatable<HPAINTBUFFER>, IFormattable
+public readonly unsafe partial struct HPAINTBUFFER : IComparable, IComparable<HPAINTBUFFER>, IEquatable<HPAINTBUFFER>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPALETTE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPALETTE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPALETTE : IComparable, IComparable<HPALETTE>, IEquatable<HPALETTE>, IFormattable
+public readonly unsafe partial struct HPALETTE : IComparable, IComparable<HPALETTE>, IEquatable<HPALETTE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPCON.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPCON.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPCON : IComparable, IComparable<HPCON>, IEquatable<HPCON>, IFormattable
+public readonly unsafe partial struct HPCON : IComparable, IComparable<HPCON>, IEquatable<HPCON>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPEN.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPEN.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPEN : IComparable, IComparable<HPEN>, IEquatable<HPEN>, IFormattable
+public readonly unsafe partial struct HPEN : IComparable, IComparable<HPEN>, IEquatable<HPEN>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPOWERNOTIFY.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPOWERNOTIFY.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPOWERNOTIFY : IComparable, IComparable<HPOWERNOTIFY>, IEquatable<HPOWERNOTIFY>, IFormattable
+public readonly unsafe partial struct HPOWERNOTIFY : IComparable, IComparable<HPOWERNOTIFY>, IEquatable<HPOWERNOTIFY>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPROPSHEETPAGE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPROPSHEETPAGE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPROPSHEETPAGE : IComparable, IComparable<HPROPSHEETPAGE>, IEquatable<HPROPSHEETPAGE>, IFormattable
+public readonly unsafe partial struct HPROPSHEETPAGE : IComparable, IComparable<HPROPSHEETPAGE>, IEquatable<HPROPSHEETPAGE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPSS.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPSS.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPSS : IComparable, IComparable<HPSS>, IEquatable<HPSS>, IFormattable
+public readonly unsafe partial struct HPSS : IComparable, IComparable<HPSS>, IEquatable<HPSS>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPSSWALK.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPSSWALK.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPSSWALK : IComparable, IComparable<HPSSWALK>, IEquatable<HPSSWALK>, IFormattable
+public readonly unsafe partial struct HPSSWALK : IComparable, IComparable<HPSSWALK>, IEquatable<HPSSWALK>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HPSXA.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HPSXA.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HPSXA : IComparable, IComparable<HPSXA>, IEquatable<HPSXA>, IFormattable
+public readonly unsafe partial struct HPSXA : IComparable, IComparable<HPSXA>, IEquatable<HPSXA>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HRAWINPUT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HRAWINPUT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HRAWINPUT : IComparable, IComparable<HRAWINPUT>, IEquatable<HRAWINPUT>, IFormattable
+public readonly unsafe partial struct HRAWINPUT : IComparable, IComparable<HRAWINPUT>, IEquatable<HRAWINPUT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HRESULT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HRESULT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HRESULT : IComparable, IComparable<HRESULT>, IEquatable<HRESULT>, IFormattable
+public readonly unsafe partial struct HRESULT : IComparable, IComparable<HRESULT>, IEquatable<HRESULT>, IFormattable
 {
     public readonly int Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HRGN.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HRGN.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HRGN : IComparable, IComparable<HRGN>, IEquatable<HRGN>, IFormattable
+public readonly unsafe partial struct HRGN : IComparable, IComparable<HRGN>, IEquatable<HRGN>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HRSRC.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HRSRC.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HRSRC : IComparable, IComparable<HRSRC>, IEquatable<HRSRC>, IFormattable
+public readonly unsafe partial struct HRSRC : IComparable, IComparable<HRSRC>, IEquatable<HRSRC>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSEMAPHORE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSEMAPHORE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HSEMAPHORE : IComparable, IComparable<HSEMAPHORE>, IEquatable<HSEMAPHORE>, IFormattable
+public readonly unsafe partial struct HSEMAPHORE : IComparable, IComparable<HSEMAPHORE>, IEquatable<HSEMAPHORE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSPFILELOG.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSPFILELOG.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HSPFILELOG : IComparable, IComparable<HSPFILELOG>, IEquatable<HSPFILELOG>, IFormattable
+public readonly unsafe partial struct HSPFILELOG : IComparable, IComparable<HSPFILELOG>, IEquatable<HSPFILELOG>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSPFILEQ.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSPFILEQ.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HSPFILEQ : IComparable, IComparable<HSPFILEQ>, IEquatable<HSPFILEQ>, IFormattable
+public readonly unsafe partial struct HSPFILEQ : IComparable, IComparable<HSPFILEQ>, IEquatable<HSPFILEQ>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSTRING.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSTRING.cs
@@ -5,7 +5,7 @@ using TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.WinRT;
 
-public unsafe partial struct HSTRING : IComparable, IComparable<HSTRING>, IEquatable<HSTRING>, IFormattable
+public readonly unsafe partial struct HSTRING : IComparable, IComparable<HSTRING>, IEquatable<HSTRING>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSTRING_BUFFER.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSTRING_BUFFER.cs
@@ -5,7 +5,7 @@ using TerraFX.Interop.Windows;
 
 namespace TerraFX.Interop.WinRT;
 
-public unsafe partial struct HSTRING_BUFFER : IComparable, IComparable<HSTRING_BUFFER>, IEquatable<HSTRING_BUFFER>, IFormattable
+public readonly unsafe partial struct HSTRING_BUFFER : IComparable, IComparable<HSTRING_BUFFER>, IEquatable<HSTRING_BUFFER>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSWDEVICE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSWDEVICE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HSWDEVICE : IComparable, IComparable<HSWDEVICE>, IEquatable<HSWDEVICE>, IFormattable
+public readonly unsafe partial struct HSWDEVICE : IComparable, IComparable<HSWDEVICE>, IEquatable<HSWDEVICE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HSYNTHETICPOINTERDEVICE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HSYNTHETICPOINTERDEVICE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HSYNTHETICPOINTERDEVICE : IComparable, IComparable<HSYNTHETICPOINTERDEVICE>, IEquatable<HSYNTHETICPOINTERDEVICE>, IFormattable
+public readonly unsafe partial struct HSYNTHETICPOINTERDEVICE : IComparable, IComparable<HSYNTHETICPOINTERDEVICE>, IEquatable<HSYNTHETICPOINTERDEVICE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HTASK.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HTASK.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HTASK : IComparable, IComparable<HTASK>, IEquatable<HTASK>, IFormattable
+public readonly unsafe partial struct HTASK : IComparable, IComparable<HTASK>, IEquatable<HTASK>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HTHEME.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HTHEME.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HTHEME : IComparable, IComparable<HTHEME>, IEquatable<HTHEME>, IFormattable
+public readonly unsafe partial struct HTHEME : IComparable, IComparable<HTHEME>, IEquatable<HTHEME>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HTHUMBNAIL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HTHUMBNAIL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HTHUMBNAIL : IComparable, IComparable<HTHUMBNAIL>, IEquatable<HTHUMBNAIL>, IFormattable
+public readonly unsafe partial struct HTHUMBNAIL : IComparable, IComparable<HTHUMBNAIL>, IEquatable<HTHUMBNAIL>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HTOUCHINPUT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HTOUCHINPUT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HTOUCHINPUT : IComparable, IComparable<HTOUCHINPUT>, IEquatable<HTOUCHINPUT>, IFormattable
+public readonly unsafe partial struct HTOUCHINPUT : IComparable, IComparable<HTOUCHINPUT>, IEquatable<HTOUCHINPUT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HTREEITEM.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HTREEITEM.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HTREEITEM : IComparable, IComparable<HTREEITEM>, IEquatable<HTREEITEM>, IFormattable
+public readonly unsafe partial struct HTREEITEM : IComparable, IComparable<HTREEITEM>, IEquatable<HTREEITEM>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HUSKEY.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HUSKEY.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HUSKEY : IComparable, IComparable<HUSKEY>, IEquatable<HUSKEY>, IFormattable
+public readonly unsafe partial struct HUSKEY : IComparable, IComparable<HUSKEY>, IEquatable<HUSKEY>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HWAVEIN.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HWAVEIN.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HWAVEIN : IComparable, IComparable<HWAVEIN>, IEquatable<HWAVEIN>, IFormattable
+public readonly unsafe partial struct HWAVEIN : IComparable, IComparable<HWAVEIN>, IEquatable<HWAVEIN>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HWAVEOUT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HWAVEOUT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HWAVEOUT : IComparable, IComparable<HWAVEOUT>, IEquatable<HWAVEOUT>, IFormattable
+public readonly unsafe partial struct HWAVEOUT : IComparable, IComparable<HWAVEOUT>, IEquatable<HWAVEOUT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HWINEVENTHOOK.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HWINEVENTHOOK.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HWINEVENTHOOK : IComparable, IComparable<HWINEVENTHOOK>, IEquatable<HWINEVENTHOOK>, IFormattable
+public readonly unsafe partial struct HWINEVENTHOOK : IComparable, IComparable<HWINEVENTHOOK>, IEquatable<HWINEVENTHOOK>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HWINSTA.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HWINSTA.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HWINSTA : IComparable, IComparable<HWINSTA>, IEquatable<HWINSTA>, IFormattable
+public readonly unsafe partial struct HWINSTA : IComparable, IComparable<HWINSTA>, IEquatable<HWINSTA>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/HWND.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/HWND.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct HWND : IComparable, IComparable<HWND>, IEquatable<HWND>, IFormattable
+public readonly unsafe partial struct HWND : IComparable, IComparable<HWND>, IEquatable<HWND>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/InstanceHandle.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/InstanceHandle.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.WinRT;
 
-public unsafe partial struct InstanceHandle : IComparable, IComparable<InstanceHandle>, IEquatable<InstanceHandle>, IFormattable
+public readonly unsafe partial struct InstanceHandle : IComparable, IComparable<InstanceHandle>, IEquatable<InstanceHandle>, IFormattable
 {
     public readonly ulong Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/LPARAM.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/LPARAM.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct LPARAM : IComparable, IComparable<LPARAM>, IEquatable<LPARAM>, IFormattable
+public readonly unsafe partial struct LPARAM : IComparable, IComparable<LPARAM>, IEquatable<LPARAM>, IFormattable
 {
     public readonly nint Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/LPPROC_THREAD_ATTRIBUTE_LIST.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/LPPROC_THREAD_ATTRIBUTE_LIST.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct LPPROC_THREAD_ATTRIBUTE_LIST : IComparable, IComparable<LPPROC_THREAD_ATTRIBUTE_LIST>, IEquatable<LPPROC_THREAD_ATTRIBUTE_LIST>, IFormattable
+public readonly unsafe partial struct LPPROC_THREAD_ATTRIBUTE_LIST : IComparable, IComparable<LPPROC_THREAD_ATTRIBUTE_LIST>, IEquatable<LPPROC_THREAD_ATTRIBUTE_LIST>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/LRESULT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/LRESULT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public partial struct LRESULT : IComparable, IComparable<LRESULT>, IEquatable<LRESULT>, IFormattable
+public readonly partial struct LRESULT : IComparable, IComparable<LRESULT>, IEquatable<LRESULT>, IFormattable
 {
     public readonly nint Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/MSIHANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/MSIHANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct MSIHANDLE : IComparable, IComparable<MSIHANDLE>, IEquatable<MSIHANDLE>, IFormattable
+public readonly unsafe partial struct MSIHANDLE : IComparable, IComparable<MSIHANDLE>, IEquatable<MSIHANDLE>, IFormattable
 {
     public readonly uint Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/MachineGlobalObjectTableRegistrationToken.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/MachineGlobalObjectTableRegistrationToken.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct MachineGlobalObjectTableRegistrationToken : IComparable, IComparable<MachineGlobalObjectTableRegistrationToken>, IEquatable<MachineGlobalObjectTableRegistrationToken>, IFormattable
+public readonly unsafe partial struct MachineGlobalObjectTableRegistrationToken : IComparable, IComparable<MachineGlobalObjectTableRegistrationToken>, IEquatable<MachineGlobalObjectTableRegistrationToken>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/OAHWND.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/OAHWND.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct OAHWND : IComparable, IComparable<OAHWND>, IEquatable<OAHWND>, IFormattable
+public readonly unsafe partial struct OAHWND : IComparable, IComparable<OAHWND>, IEquatable<OAHWND>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PACKAGEDEPENDENCY_CONTEXT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PACKAGEDEPENDENCY_CONTEXT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PACKAGEDEPENDENCY_CONTEXT : IComparable, IComparable<PACKAGEDEPENDENCY_CONTEXT>, IEquatable<PACKAGEDEPENDENCY_CONTEXT>, IFormattable
+public readonly unsafe partial struct PACKAGEDEPENDENCY_CONTEXT : IComparable, IComparable<PACKAGEDEPENDENCY_CONTEXT>, IEquatable<PACKAGEDEPENDENCY_CONTEXT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PACKAGE_INFO_REFERENCE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PACKAGE_INFO_REFERENCE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PACKAGE_INFO_REFERENCE : IComparable, IComparable<PACKAGE_INFO_REFERENCE>, IEquatable<PACKAGE_INFO_REFERENCE>, IFormattable
+public readonly unsafe partial struct PACKAGE_INFO_REFERENCE : IComparable, IComparable<PACKAGE_INFO_REFERENCE>, IEquatable<PACKAGE_INFO_REFERENCE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PAPPCONSTRAIN_REGISTRATION.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PAPPCONSTRAIN_REGISTRATION.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PAPPCONSTRAIN_REGISTRATION : IComparable, IComparable<PAPPCONSTRAIN_REGISTRATION>, IEquatable<PAPPCONSTRAIN_REGISTRATION>, IFormattable
+public readonly unsafe partial struct PAPPCONSTRAIN_REGISTRATION : IComparable, IComparable<PAPPCONSTRAIN_REGISTRATION>, IEquatable<PAPPCONSTRAIN_REGISTRATION>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PAPPSTATE_REGISTRATION.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PAPPSTATE_REGISTRATION.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PAPPSTATE_REGISTRATION : IComparable, IComparable<PAPPSTATE_REGISTRATION>, IEquatable<PAPPSTATE_REGISTRATION>, IFormattable
+public readonly unsafe partial struct PAPPSTATE_REGISTRATION : IComparable, IComparable<PAPPSTATE_REGISTRATION>, IEquatable<PAPPSTATE_REGISTRATION>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PCUSERIALIZEDPROPSTORAGE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PCUSERIALIZEDPROPSTORAGE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PCUSERIALIZEDPROPSTORAGE : IComparable, IComparable<PCUSERIALIZEDPROPSTORAGE>, IEquatable<PCUSERIALIZEDPROPSTORAGE>, IFormattable
+public readonly unsafe partial struct PCUSERIALIZEDPROPSTORAGE : IComparable, IComparable<PCUSERIALIZEDPROPSTORAGE>, IEquatable<PCUSERIALIZEDPROPSTORAGE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PHIDP_PREPARSED_DATA.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PHIDP_PREPARSED_DATA.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PHIDP_PREPARSED_DATA : IComparable, IComparable<PHIDP_PREPARSED_DATA>, IEquatable<PHIDP_PREPARSED_DATA>, IFormattable
+public readonly unsafe partial struct PHIDP_PREPARSED_DATA : IComparable, IComparable<PHIDP_PREPARSED_DATA>, IEquatable<PHIDP_PREPARSED_DATA>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PRJ_DIR_ENTRY_BUFFER_HANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PRJ_DIR_ENTRY_BUFFER_HANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PRJ_DIR_ENTRY_BUFFER_HANDLE : IComparable, IComparable<PRJ_DIR_ENTRY_BUFFER_HANDLE>, IEquatable<PRJ_DIR_ENTRY_BUFFER_HANDLE>, IFormattable
+public readonly unsafe partial struct PRJ_DIR_ENTRY_BUFFER_HANDLE : IComparable, IComparable<PRJ_DIR_ENTRY_BUFFER_HANDLE>, IEquatable<PRJ_DIR_ENTRY_BUFFER_HANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT : IComparable, IComparable<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>, IEquatable<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>, IFormattable
+public readonly unsafe partial struct PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT : IComparable, IComparable<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>, IEquatable<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PTP_CALLBACK_INSTANCE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PTP_CALLBACK_INSTANCE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PTP_CALLBACK_INSTANCE : IComparable, IComparable<PTP_CALLBACK_INSTANCE>, IEquatable<PTP_CALLBACK_INSTANCE>, IFormattable
+public readonly unsafe partial struct PTP_CALLBACK_INSTANCE : IComparable, IComparable<PTP_CALLBACK_INSTANCE>, IEquatable<PTP_CALLBACK_INSTANCE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PTP_CLEANUP_GROUP.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PTP_CLEANUP_GROUP.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PTP_CLEANUP_GROUP : IComparable, IComparable<PTP_CLEANUP_GROUP>, IEquatable<PTP_CLEANUP_GROUP>, IFormattable
+public readonly unsafe partial struct PTP_CLEANUP_GROUP : IComparable, IComparable<PTP_CLEANUP_GROUP>, IEquatable<PTP_CLEANUP_GROUP>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/PTP_POOL.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/PTP_POOL.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct PTP_POOL : IComparable, IComparable<PTP_POOL>, IEquatable<PTP_POOL>, IFormattable
+public readonly unsafe partial struct PTP_POOL : IComparable, IComparable<PTP_POOL>, IEquatable<PTP_POOL>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/ROPARAMIIDHANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/ROPARAMIIDHANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct ROPARAMIIDHANDLE : IComparable, IComparable<ROPARAMIIDHANDLE>, IEquatable<ROPARAMIIDHANDLE>, IFormattable
+public readonly unsafe partial struct ROPARAMIIDHANDLE : IComparable, IComparable<ROPARAMIIDHANDLE>, IEquatable<ROPARAMIIDHANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/RO_REGISTRATION_COOKIE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/RO_REGISTRATION_COOKIE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct RO_REGISTRATION_COOKIE : IComparable, IComparable<RO_REGISTRATION_COOKIE>, IEquatable<RO_REGISTRATION_COOKIE>, IFormattable
+public readonly unsafe partial struct RO_REGISTRATION_COOKIE : IComparable, IComparable<RO_REGISTRATION_COOKIE>, IEquatable<RO_REGISTRATION_COOKIE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/SPSTATEHANDLE.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/SPSTATEHANDLE.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct SPSTATEHANDLE : IComparable, IComparable<SPSTATEHANDLE>, IEquatable<SPSTATEHANDLE>, IFormattable
+public readonly unsafe partial struct SPSTATEHANDLE : IComparable, IComparable<SPSTATEHANDLE>, IEquatable<SPSTATEHANDLE>, IFormattable
 {
     public readonly void* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/UI_ANIMATION_KEYFRAME.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/UI_ANIMATION_KEYFRAME.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct UI_ANIMATION_KEYFRAME : IComparable, IComparable<UI_ANIMATION_KEYFRAME>, IEquatable<UI_ANIMATION_KEYFRAME>, IFormattable
+public readonly unsafe partial struct UI_ANIMATION_KEYFRAME : IComparable, IComparable<UI_ANIMATION_KEYFRAME>, IEquatable<UI_ANIMATION_KEYFRAME>, IFormattable
 {
     public readonly int* Value;
 

--- a/sources/Interop/Windows/Windows/other/helper-types/WPARAM.cs
+++ b/sources/Interop/Windows/Windows/other/helper-types/WPARAM.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace TerraFX.Interop.Windows;
 
-public unsafe partial struct WPARAM : IComparable, IComparable<WPARAM>, IEquatable<WPARAM>, IFormattable
+public readonly unsafe partial struct WPARAM : IComparable, IComparable<WPARAM>, IEquatable<WPARAM>, IFormattable
 {
     public readonly nuint Value;
 

--- a/sources/Interop/Windows/Windows/shared/ws2def/ADDRINFOEX2A.cs
+++ b/sources/Interop/Windows/Windows/shared/ws2def/ADDRINFOEX2A.cs
@@ -10,6 +10,7 @@ namespace TerraFX.Interop.Windows;
 
 /// <include file='ADDRINFOEX2A.xml' path='doc/member[@name="ADDRINFOEX2A"]/*' />
 [SupportedOSPlatform("windows8.0")]
+[Obsolete("ADDRINFOEX2")]
 public unsafe partial struct ADDRINFOEX2A
 {
     /// <include file='ADDRINFOEX2A.xml' path='doc/member[@name="ADDRINFOEX2A.ai_flags"]/*' />

--- a/sources/Interop/Windows/Windows/shared/ws2def/ADDRINFOEXA.cs
+++ b/sources/Interop/Windows/Windows/shared/ws2def/ADDRINFOEXA.cs
@@ -8,6 +8,7 @@ using System;
 namespace TerraFX.Interop.Windows;
 
 /// <include file='ADDRINFOEXA.xml' path='doc/member[@name="ADDRINFOEXA"]/*' />
+[Obsolete("ADDRINFOEX")]
 public unsafe partial struct ADDRINFOEXA
 {
     /// <include file='ADDRINFOEXA.xml' path='doc/member[@name="ADDRINFOEXA.ai_flags"]/*' />

--- a/sources/Interop/Windows/Windows/um/ShObjIdl_core/IFolderView2.cs
+++ b/sources/Interop/Windows/Windows/um/ShObjIdl_core/IFolderView2.cs
@@ -177,6 +177,7 @@ public unsafe partial struct IFolderView2 : IFolderView2.Interface, INativeGuid
     /// <include file='IFolderView2.xml' path='doc/member[@name="IFolderView2.SetViewProperty"]/*' />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(19)]
+    [Obsolete]
     public HRESULT SetViewProperty([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("const PROPERTYKEY &")] PROPERTYKEY* propkey, [NativeTypeName("const PROPVARIANT &")] PROPVARIANT* propvar)
     {
         return ((delegate* unmanaged<IFolderView2*, ITEMIDLIST*, PROPERTYKEY*, PROPVARIANT*, int>)(lpVtbl[19]))((IFolderView2*)Unsafe.AsPointer(ref this), pidl, propkey, propvar);
@@ -185,6 +186,7 @@ public unsafe partial struct IFolderView2 : IFolderView2.Interface, INativeGuid
     /// <include file='IFolderView2.xml' path='doc/member[@name="IFolderView2.GetViewProperty"]/*' />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(20)]
+    [Obsolete]
     public HRESULT GetViewProperty([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("const PROPERTYKEY &")] PROPERTYKEY* propkey, PROPVARIANT* ppropvar)
     {
         return ((delegate* unmanaged<IFolderView2*, ITEMIDLIST*, PROPERTYKEY*, PROPVARIANT*, int>)(lpVtbl[20]))((IFolderView2*)Unsafe.AsPointer(ref this), pidl, propkey, ppropvar);
@@ -193,6 +195,7 @@ public unsafe partial struct IFolderView2 : IFolderView2.Interface, INativeGuid
     /// <include file='IFolderView2.xml' path='doc/member[@name="IFolderView2.SetTileViewProperties"]/*' />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(21)]
+    [Obsolete]
     public HRESULT SetTileViewProperties([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("LPCWSTR")] ushort* pszPropList)
     {
         return ((delegate* unmanaged<IFolderView2*, ITEMIDLIST*, ushort*, int>)(lpVtbl[21]))((IFolderView2*)Unsafe.AsPointer(ref this), pidl, pszPropList);
@@ -201,6 +204,7 @@ public unsafe partial struct IFolderView2 : IFolderView2.Interface, INativeGuid
     /// <include file='IFolderView2.xml' path='doc/member[@name="IFolderView2.SetExtendedTileViewProperties"]/*' />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(22)]
+    [Obsolete]
     public HRESULT SetExtendedTileViewProperties([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("LPCWSTR")] ushort* pszPropList)
     {
         return ((delegate* unmanaged<IFolderView2*, ITEMIDLIST*, ushort*, int>)(lpVtbl[22]))((IFolderView2*)Unsafe.AsPointer(ref this), pidl, pszPropList);
@@ -367,15 +371,19 @@ public unsafe partial struct IFolderView2 : IFolderView2.Interface, INativeGuid
         HRESULT GetGroupBy(PROPERTYKEY* pkey, BOOL* pfAscending);
 
         [VtblIndex(19)]
+        [Obsolete]
         HRESULT SetViewProperty([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("const PROPERTYKEY &")] PROPERTYKEY* propkey, [NativeTypeName("const PROPVARIANT &")] PROPVARIANT* propvar);
 
         [VtblIndex(20)]
+        [Obsolete]
         HRESULT GetViewProperty([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("const PROPERTYKEY &")] PROPERTYKEY* propkey, PROPVARIANT* ppropvar);
 
         [VtblIndex(21)]
+        [Obsolete]
         HRESULT SetTileViewProperties([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("LPCWSTR")] ushort* pszPropList);
 
         [VtblIndex(22)]
+        [Obsolete]
         HRESULT SetExtendedTileViewProperties([NativeTypeName("LPCITEMIDLIST")] ITEMIDLIST* pidl, [NativeTypeName("LPCWSTR")] ushort* pszPropList);
 
         [VtblIndex(23)]
@@ -497,15 +505,19 @@ public unsafe partial struct IFolderView2 : IFolderView2.Interface, INativeGuid
         public delegate* unmanaged<TSelf*, PROPERTYKEY*, BOOL*, int> GetGroupBy;
 
         [NativeTypeName("HRESULT (LPCITEMIDLIST, const PROPERTYKEY &, const PROPVARIANT &) __attribute__((stdcall))")]
+        [Obsolete]
         public delegate* unmanaged<TSelf*, ITEMIDLIST*, PROPERTYKEY*, PROPVARIANT*, int> SetViewProperty;
 
         [NativeTypeName("HRESULT (LPCITEMIDLIST, const PROPERTYKEY &, PROPVARIANT *) __attribute__((stdcall))")]
+        [Obsolete]
         public delegate* unmanaged<TSelf*, ITEMIDLIST*, PROPERTYKEY*, PROPVARIANT*, int> GetViewProperty;
 
         [NativeTypeName("HRESULT (LPCITEMIDLIST, LPCWSTR) __attribute__((stdcall))")]
+        [Obsolete]
         public delegate* unmanaged<TSelf*, ITEMIDLIST*, ushort*, int> SetTileViewProperties;
 
         [NativeTypeName("HRESULT (LPCITEMIDLIST, LPCWSTR) __attribute__((stdcall))")]
+        [Obsolete]
         public delegate* unmanaged<TSelf*, ITEMIDLIST*, ushort*, int> SetExtendedTileViewProperties;
 
         [NativeTypeName("HRESULT (FVTEXTTYPE, LPCWSTR) __attribute__((stdcall))")]

--- a/sources/Interop/Windows/Windows/um/sysinfoapi/Windows.cs
+++ b/sources/Interop/Windows/Windows/um/sysinfoapi/Windows.cs
@@ -3,6 +3,7 @@
 // Ported from um/sysinfoapi.h in the Windows SDK for Windows 10.0.22000.0
 // Original source is Copyright © Microsoft. All rights reserved.
 
+using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
@@ -43,6 +44,7 @@ public static unsafe partial class Windows
     /// <include file='Windows.xml' path='doc/member[@name="Windows.GetVersion"]/*' />
     [DllImport("kernel32", ExactSpelling = true)]
     [return: NativeTypeName("DWORD")]
+    [Obsolete]
     public static extern uint GetVersion();
 
     /// <include file='Windows.xml' path='doc/member[@name="Windows.SetLocalTime"]/*' />
@@ -124,11 +126,13 @@ public static unsafe partial class Windows
     /// <include file='Windows.xml' path='doc/member[@name="Windows.GetVersionExA"]/*' />
     [DllImport("kernel32", ExactSpelling = true)]
     [SetsLastSystemError]
+    [Obsolete]
     public static extern BOOL GetVersionExA([NativeTypeName("LPOSVERSIONINFOA")] OSVERSIONINFOA* lpVersionInformation);
 
     /// <include file='Windows.xml' path='doc/member[@name="Windows.GetVersionExW"]/*' />
     [DllImport("kernel32", ExactSpelling = true)]
     [SetsLastSystemError]
+    [Obsolete]
     public static extern BOOL GetVersionExW([NativeTypeName("LPOSVERSIONINFOW")] OSVERSIONINFOW* lpVersionInformation);
 
     /// <include file='Windows.xml' path='doc/member[@name="Windows.GetLogicalProcessorInformation"]/*' />
@@ -260,6 +264,7 @@ public static unsafe partial class Windows
     public static delegate*<COMPUTER_NAME_FORMAT, ushort*, BOOL> SetComputerNameEx => &SetComputerNameExW;
 
     [NativeTypeName("#define GetVersionEx GetVersionExW")]
+    [Obsolete]
     public static delegate*<OSVERSIONINFOW*, BOOL> GetVersionEx => &GetVersionExW;
 
     [NativeTypeName("#define SCEX2_ALT_NETBIOS_NAME 0x00000001")]

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -12,4 +12,9 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
+  <!-- Settings that append the existing setting value -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This resolves https://github.com/terrafx/terrafx.interop.windows/issues/313 by ensuring the `Obsolete` attribute is present where relevant.

This resolves https://github.com/terrafx/terrafx.interop.windows/issues/305 by ensuring the transparent wrapper structs are `readonly`.