### PR TITLE
Fix __uuidof<T>() not using INativeGuid

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,7 @@
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(Configuration)/</PackageOutputPath>
     <Product>TerraFX.Interop.Windows</Product>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <VersionPrefix>10.0.20348.4</VersionPrefix>
+    <VersionPrefix>10.0.20348.5</VersionPrefix>
     <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true'">rc1</VersionSuffix>
     <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">pr</VersionSuffix>
   </PropertyGroup>

--- a/sources/Interop/Windows/WinRT/winrt/roapi/WinRT.Manual.cs
+++ b/sources/Interop/Windows/WinRT/winrt/roapi/WinRT.Manual.cs
@@ -12,7 +12,7 @@ namespace TerraFX.Interop.WinRT;
 public static unsafe partial class WinRT
 {
     public static HRESULT ActivateInstance<T>(HSTRING activatableClassId, T** instance)
-        where T : unmanaged
+        where T : unmanaged, INativeGuid
     {
         *instance = null;
 
@@ -36,7 +36,7 @@ public static unsafe partial class WinRT
     }
 
     public static HRESULT GetActivationFactory<T>(HSTRING activatableClassId, T** factory)
-        where T : unmanaged
+        where T : unmanaged, INativeGuid
     {
         return RoGetActivationFactory(activatableClassId, __uuidof<T>(), (void**)factory);
     }

--- a/sources/Interop/Windows/Windows/shared/uuids/Windows.Manual.cs
+++ b/sources/Interop/Windows/Windows/shared/uuids/Windows.Manual.cs
@@ -17,9 +17,9 @@ public static partial class Windows
     /// <returns>A <see cref="UuidOfType"/> value wrapping a pointer to the GUID data for the input type. This value can be either converted to a <see cref="Guid"/> pointer, or implicitly assigned to a <see cref="Guid"/> value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe UuidOfType __uuidof<T>(T value) // for type inference similar to C++'s __uuidof
-        where T : unmanaged
+        where T : unmanaged, INativeGuid
     {
-        return new UuidOfType(UUID<T>.RIID);
+        return new UuidOfType(T.NativeGuid);
     }
 
     /// <summary>Retrieves the GUID of of a specified type.</summary>
@@ -28,9 +28,9 @@ public static partial class Windows
     /// <returns>A <see cref="UuidOfType"/> value wrapping a pointer to the GUID data for the input type. This value can be either converted to a <see cref="Guid"/> pointer, or implicitly assigned to a <see cref="Guid"/> value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe UuidOfType __uuidof<T>(T* value) // for type inference similar to C++'s __uuidof
-        where T : unmanaged
+        where T : unmanaged, INativeGuid
     {
-        return new UuidOfType(UUID<T>.RIID);
+        return new UuidOfType(T.NativeGuid);
     }
 
     /// <summary>Retrieves the GUID of of a specified type.</summary>
@@ -38,47 +38,28 @@ public static partial class Windows
     /// <returns>A <see cref="UuidOfType"/> value wrapping a pointer to the GUID data for the input type. This value can be either converted to a <see cref="Guid"/> pointer, or implicitly assigned to a <see cref="Guid"/> value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe UuidOfType __uuidof<T>()
-        where T : unmanaged
+        where T : unmanaged, INativeGuid
     {
-        return new UuidOfType(UUID<T>.RIID);
+        return new UuidOfType(T.NativeGuid);
     }
 
     /// <summary>A proxy type that wraps a pointer to GUID data. Values of this type can be implicitly converted to and assigned to <see cref="Guid"/>* or <see cref="Guid"/> parameters.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly unsafe ref struct UuidOfType
     {
-        private readonly Guid* riid;
+        private readonly Guid* _value;
 
-        internal UuidOfType(Guid* riid)
+        internal UuidOfType(Guid* value)
         {
-            this.riid = riid;
+            _value = value;
         }
 
         /// <summary>Reads a <see cref="Guid"/> value from the GUID buffer for a given <see cref="UuidOfType"/> instance.</summary>
         /// <param name="guid">The input <see cref="UuidOfType"/> instance to read data for.</param>
-        public static implicit operator Guid(UuidOfType guid) => *guid.riid;
+        public static implicit operator Guid(UuidOfType value) => *value._value;
 
         /// <summary>Returns the <see cref="Guid"/>* pointer to the GUID buffer for a given <see cref="UuidOfType"/> instance.</summary>
         /// <param name="guid">The input <see cref="UuidOfType"/> instance to read data for.</param>
-        public static implicit operator Guid*(UuidOfType guid) => guid.riid;
-    }
-
-    /// <summary>A helper type to provide static GUID buffers for specific types.</summary>
-    /// <typeparam name="T">The type to allocate a GUID buffer for.</typeparam>
-    private static unsafe class UUID<T>
-        where T : unmanaged
-    {
-        /// <summary>The pointer to the <see cref="Guid"/> value for the current type.</summary>
-        /// <remarks>The target memory area should never be written to.</remarks>
-        public static readonly Guid* RIID = CreateRIID();
-
-        /// <summary>Allocates memory for a <see cref="Guid"/> value and initializes it.</summary>
-        /// <returns>A pointer to memory holding the <see cref="Guid"/> value for the current type.</returns>
-        private static Guid* CreateRIID()
-        {
-            var p = (Guid*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(T), sizeof(Guid));
-            *p = typeof(T).GUID;
-            return p;
-        }
+        public static implicit operator Guid*(UuidOfType value) => value._value;
     }
 }


### PR DESCRIPTION
This PR updates `__uuidof<T>()` to properly use `INativeGuid` and not `Type.GUID`.