### PR TITLE
[BUG] Fix null check in SetDpiCompensatedEffectInput

### DIFF
--- a/sources/Interop/Windows/DirectX/um/d2d1_1helper/DirectX.Manual.cs
+++ b/sources/Interop/Windows/DirectX/um/d2d1_1helper/DirectX.Manual.cs
@@ -256,7 +256,7 @@ public static unsafe partial class DirectX
         HRESULT hr = S_OK;
         ID2D1Effect* dpiCompensationEffect = null;
 
-        if (inputBitmap != null)
+        if (inputBitmap == null)
         {
             effect->SetInput(inputIndex, null);
             return hr;


### PR DESCRIPTION
The `SetDpiCompensatedEffectInput` method has a simple transcription error in the `null` check.

Without this fix, both paths in the code are wrong. If `inputBitmap` is not `null`, then the `effect`'s input is set to `null` and the method returns. If `inputBitmap` _is_ `null`, the method will try to call its `GetDpi()` method resulting in an AV/crash.

Fixes #336