### PR TITLE
Update TerraFX.Interop.Windows to support trimming the `SetDllImportResolver` call

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.100",
+    "allowPrerelease": false,
+    "rollForward": "latestFeature"
+  }
+}

--- a/samples/DirectX/Shared/DXSampleHelper.cs
+++ b/samples/DirectX/Shared/DXSampleHelper.cs
@@ -3,6 +3,7 @@
 // Ported from DXSampleHelper.h in https://github.com/Microsoft/DirectX-Graphics-Samples
 // Original source is Copyright © Microsoft. All rights reserved. Licensed under the MIT License (MIT).
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -17,8 +18,7 @@ public static unsafe class DXSampleHelper
 {
     public static string GetAssetsPath()
     {
-        var entryAssembly = Assembly.GetEntryAssembly()!;
-        return Path.GetDirectoryName(entryAssembly.Location)!;
+        return Path.GetDirectoryName(AppContext.BaseDirectory)!;
     }
 
     public static byte[] ReadDataFromFile(string filename)

--- a/samples/DirectX/TerraFX.Samples.DirectX.csproj
+++ b/samples/DirectX/TerraFX.Samples.DirectX.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\..\sources\Interop\Windows\TerraFX.Interop.Windows.csproj" />
   </ItemGroup>

--- a/samples/DirectX/TerraFX.Samples.DirectX.csproj
+++ b/samples/DirectX/TerraFX.Samples.DirectX.csproj
@@ -5,9 +5,13 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\sources\Interop\Windows\TerraFX.Interop.Windows.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="TerraFX.Interop.Windows.DisableResolveLibraryHook" Value="true" Trim="true" />
   </ItemGroup>
 
 </Project>

--- a/sources/Interop/Windows/Configuration.cs
+++ b/sources/Interop/Windows/Configuration.cs
@@ -1,0 +1,30 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace TerraFX.Interop.Windows;
+
+internal static class Configuration
+{
+    private static readonly bool s_disableResolveLibraryHook = GetAppContextData("TerraFX.Interop.Windows.DisableResolveLibraryHook", defaultValue: false);
+
+    public static bool DisableResolveLibraryHook => s_disableResolveLibraryHook;
+
+    private static bool GetAppContextData(string name, bool defaultValue)
+    {
+        object? data = AppContext.GetData(name);
+
+        if (data is bool value)
+        {
+            return value;
+        }
+        else if ((data is string s) && bool.TryParse(s, out bool result))
+        {
+            return result;
+        }
+        else
+        {
+            return defaultValue;
+        }
+    }
+}

--- a/sources/Interop/Windows/ILLink.Substitutions.xml
+++ b/sources/Interop/Windows/ILLink.Substitutions.xml
@@ -1,10 +1,10 @@
 <linker>
     <assembly fullname="TerraFX.Interop.Windows">
         <type fullname="TerraFX.Interop.Windows.Configuration" feature="TerraFX.Interop.Windows.DisableResolveLibraryHook" featurevalue="true">
-            <field name="s_disableResolveLibraryHook" value="true" initialize="true" />
+            <field name="s_disableResolveLibraryHook" value="true" />
         </type>
         <type fullname="TerraFX.Interop.Windows.Configuration" feature="TerraFX.Interop.Windows.DisableResolveLibraryHook" featurevalue="false">
-            <field name="s_disableResolveLibraryHook" value="false" initialize="true" />
+            <field name="s_disableResolveLibraryHook" value="false" />
         </type>
     </assembly>
 </linker>

--- a/sources/Interop/Windows/ILLink.Substitutions.xml
+++ b/sources/Interop/Windows/ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+<linker>
+    <assembly fullname="TerraFX.Interop.Windows">
+        <type fullname="TerraFX.Interop.Windows.Configuration" feature="TerraFX.Interop.Windows.DisableResolveLibraryHook" featurevalue="true">
+            <field name="s_disableResolveLibraryHook" value="true" initialize="true" />
+        </type>
+        <type fullname="TerraFX.Interop.Windows.Configuration" feature="TerraFX.Interop.Windows.DisableResolveLibraryHook" featurevalue="false">
+            <field name="s_disableResolveLibraryHook" value="false" initialize="true" />
+        </type>
+    </assembly>
+</linker>

--- a/sources/Interop/Windows/TerraFX.Interop.Windows.csproj
+++ b/sources/Interop/Windows/TerraFX.Interop.Windows.csproj
@@ -8,6 +8,10 @@
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Additional NoWarns for the *.xml files -->
     <NoWarn>$(NoWarn);CS0419;CS1571;CS1572;CS1573;CS1574;CS1580;CS1584;CS1589;CS1658</NoWarn>

--- a/sources/Interop/Windows/Windows.cs
+++ b/sources/Interop/Windows/Windows.cs
@@ -13,7 +13,10 @@ public static unsafe partial class Windows
 
     static Windows()
     {
-        NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), OnDllImport);
+        if (!Configuration.DisableResolveLibraryHook)
+        {
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), OnDllImport);
+        }
     }
 
     /// <summary>The default <see cref="DllImportResolver"/> for TerraFX.Interop.Windows.</summary>


### PR DESCRIPTION
Notably this does not actually remove the `static constructor` as the trimmer currently leaves it as:
```csharp
static Windows()
{
  if (true)
    ;
}
```

Likewise, the field `private static readonly bool s_disableResolveLibraryHook` field cannot be consumed directly, doing so leaves the field, its initializer, and other "dead code". Accessing it through the property ends up working, however.

Attempting to remove the static constructor directly likewise does not work, we are left with:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
static Windows()
{
  // ISSUE: unable to decompile the method.
}
```