### PR TITLE
Allow disabling unused analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,4 +72,9 @@
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>
 
+  <!-- Default analyzers to remove -->
+  <ItemGroup>
+    <RemoveAnalyzer Include="Microsoft.Interop.JavaScript.JSImportGenerator" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,11 +31,22 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
-  <!-- Assembly attributes to include for every project -->
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
-      <_Parameter1>windows6.1</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+  <!-- Support for removing analyzers from the build -->
+  <PropertyGroup>
+    <RemoveAnalyzersOutputFile>$(IntermediateOutputPath)$(MSBuildProjectName).RemoveAnalyzers.cache</RemoveAnalyzersOutputFile>
+  </PropertyGroup>
+
+  <Target Name="RemoveAnalyzers"
+          BeforeTargets="BeforeCompile;CoreCompile"
+          DependsOnTargets="PrepareForBuild"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="%(RemoveAnalyzer.Identity)">
+    <PropertyGroup>
+      <RemoveAnalyzerFilename>%(RemoveAnalyzer.Identity)</RemoveAnalyzerFilename>
+    </PropertyGroup>
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer->WithMetadataValue('Filename', '$(RemoveAnalyzerFilename)'))" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/sources/Directory.Build.targets
+++ b/sources/Directory.Build.targets
@@ -36,10 +36,11 @@
           Condition="'$(Language)' == 'C#'"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(GeneratedSkipLocalsInitFile)">
-    <WriteLinesToFile Lines="$(GeneratedSkipLocalsInitFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" File="$(GeneratedSkipLocalsInitFile)" />
+    <WriteLinesToFile Lines="$(GeneratedSkipLocalsInitFileLines)" File="$(GeneratedSkipLocalsInitFile)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
       <Compile Include="$(GeneratedSkipLocalsInitFile)" />
+      <FileWrites Include="$(GeneratedSkipLocalsInitFile)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This disables `Microsoft.Interop.JavaScript.JSImportGenerator` as it is unused but adding a considerable amount of build time (33% locally).