### PR TITLE
Ensure NativeMemory.Copy passes parameters in the correct order

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,7 @@
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(Configuration)/</PackageOutputPath>
     <Product>TerraFX.Interop.Windows</Product>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <VersionPrefix>10.0.22621.5</VersionPrefix>
+    <VersionPrefix>10.0.22621.6</VersionPrefix>
     <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true'">rc1</VersionSuffix>
     <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">pr</VersionSuffix>
   </PropertyGroup>

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_core/D3D12_RT_FORMAT_ARRAY.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_core/D3D12_RT_FORMAT_ARRAY.Manual.cs
@@ -16,6 +16,10 @@ public unsafe partial struct D3D12_RT_FORMAT_ARRAY
     public D3D12_RT_FORMAT_ARRAY([NativeTypeName("const DXGI_FORMAT *")] DXGI_FORMAT* pFormats, uint NumFormats)
     {
         NumRenderTargets = NumFormats;
-        NativeMemory.Copy(Unsafe.AsPointer(ref RTFormats), pFormats, (uint)(sizeof(DXGI_FORMAT)));
+
+        fixed (DXGI_FORMAT* pRTFormats = &RTFormats[0])
+        {
+            NativeMemory.Copy(pFormats, pRTFormats, sizeof(DXGI_FORMAT));
+        }
     }
 }

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_MESH_STATE_STREAM.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_MESH_STATE_STREAM.Manual.cs
@@ -85,7 +85,7 @@ public unsafe struct CD3DX12_PIPELINE_MESH_STATE_STREAM
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM.Manual.cs
@@ -117,7 +117,7 @@ public unsafe struct CD3DX12_PIPELINE_STATE_STREAM
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM1.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM1.Manual.cs
@@ -146,7 +146,7 @@ public unsafe struct CD3DX12_PIPELINE_STATE_STREAM1
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM2.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM2.Manual.cs
@@ -152,7 +152,7 @@ public unsafe struct CD3DX12_PIPELINE_STATE_STREAM2
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM3.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM3.Manual.cs
@@ -152,7 +152,7 @@ public unsafe struct CD3DX12_PIPELINE_STATE_STREAM3
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM4.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM4.Manual.cs
@@ -151,7 +151,7 @@ public unsafe struct CD3DX12_PIPELINE_STATE_STREAM4
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM5.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_pipeline_state_stream/CD3DX12_PIPELINE_STATE_STREAM5.Manual.cs
@@ -151,7 +151,7 @@ public unsafe struct CD3DX12_PIPELINE_STATE_STREAM5
 
         fixed (DXGI_FORMAT* pFormat = &RTVFormats.pssInner.RTFormats[0])
         {
-            NativeMemory.Copy(&D.RTVFormats[0], pFormat, 8 * sizeof(DXGI_FORMAT));
+            NativeMemory.Copy(pFormat, &D.RTVFormats[0], 8 * sizeof(DXGI_FORMAT));
         }
 
         return D;

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_resource_helpers/DirectX.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_resource_helpers/DirectX.cs
@@ -20,7 +20,7 @@ public static unsafe partial class DirectX
 
             for (uint y = 0; y < NumRows; ++y)
             {
-                NativeMemory.Copy(pDestSlice + pDest->RowPitch * y, unchecked(pSrcSlice + pSrc->RowPitch * (nint)(y)), RowSizeInBytes);
+                NativeMemory.Copy(unchecked(pSrcSlice + pSrc->RowPitch * (nint)(y)), pDestSlice + pDest->RowPitch * y, RowSizeInBytes);
             }
         }
     }
@@ -35,7 +35,7 @@ public static unsafe partial class DirectX
 
             for (uint y = 0; y < NumRows; ++y)
             {
-                NativeMemory.Copy(pDestSlice + pDest->RowPitch * y, pSrcSlice + pSrc->RowPitch * (nuint)(y), RowSizeInBytes);
+                NativeMemory.Copy(pSrcSlice + pSrc->RowPitch * (nuint)(y), pDestSlice + pDest->RowPitch * y, RowSizeInBytes);
             }
         }
     }

--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_root_signature/DirectX.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_root_signature/DirectX.Manual.cs
@@ -142,7 +142,7 @@ public static unsafe partial class DirectX
                                         break;
                                     }
 
-                                    NativeMemory.Copy(pStaticSamplers + n, desc_1_2->pStaticSamplers + n, (uint)(sizeof(D3D12_STATIC_SAMPLER_DESC)));
+                                    NativeMemory.Copy(desc_1_2->pStaticSamplers + n, pStaticSamplers + n, (uint)(sizeof(D3D12_STATIC_SAMPLER_DESC)));
                                 }
                             }
                         }
@@ -216,7 +216,7 @@ public static unsafe partial class DirectX
                                         break;
                                     }
 
-                                    NativeMemory.Copy(pStaticSamplers + n, desc_1_2->pStaticSamplers + n, (uint)(sizeof(D3D12_STATIC_SAMPLER_DESC)));
+                                    NativeMemory.Copy(desc_1_2->pStaticSamplers + n, pStaticSamplers + n, (uint)(sizeof(D3D12_STATIC_SAMPLER_DESC)));
                                 }
                             }
                         }

--- a/sources/Interop/Windows/Windows/um/winioctl/Windows.cs
+++ b/sources/Interop/Windows/Windows/um/winioctl/Windows.cs
@@ -49,7 +49,7 @@ public static unsafe partial class Windows
             goto Cleanup;
         }
 
-        NativeMemory.Copy((DeviceDsmParameterBlock(Input)), (Parameters), (Input->ParameterBlockLength));
+        NativeMemory.Copy((Parameters), (DeviceDsmParameterBlock(Input)), (Input->ParameterBlockLength));
         Cleanup:
         return;
     }


### PR DESCRIPTION
`memcpy` takes its parameters as `dest, source, count`
`NativeMemory.Copy` swaps it to be `source, dest, count`