### PR TITLE
Update Win32Application.cs

### DIFF
--- a/samples/DirectX/Shared/Win32Application.cs
+++ b/samples/DirectX/Shared/Win32Application.cs
@@ -176,11 +176,8 @@ public static unsafe class Win32Application
                 pSample?.OnKeyUp((byte)wParam);
                 return 0;
             }
-
-            default:
-            {
-                return DefWindowProcW(hWnd, message, wParam, lParam);
-            }
         }
+
+        return DefWindowProcW(hWnd, message, wParam, lParam);
     }
 }


### PR DESCRIPTION
Shouldn't default: because I have tested since I clicked Titlebar than maximized and unmaximized without default: cause It crashed since you wrote default: { ... }

It fixed without default: It works as well under Windows 10 ( latest build version )

Proof: I have tested with debug and release without default: { ... } = Works fine 100 %.

Thank you for accepting my solution!