### PR TITLE
[IMPL] Add implicit conversion from RECT -> System.Drawing.Rectangle.

### DIFF
--- a/sources/Interop/Windows/Windows/shared/windef/RECT.cs
+++ b/sources/Interop/Windows/Windows/shared/windef/RECT.cs
@@ -5,6 +5,8 @@
 
 namespace TerraFX.Interop.Windows;
 
+using System.Drawing;
+
 /// <include file='RECT.xml' path='doc/member[@name="RECT"]/*' />
 public partial struct RECT
 {
@@ -23,4 +25,19 @@ public partial struct RECT
     /// <include file='RECT.xml' path='doc/member[@name="RECT.bottom"]/*' />
     [NativeTypeName("LONG")]
     public int bottom;
+
+    // type 'Rectangle' is from System.Drawing.Primitives which is from the base shared framework.
+    // as such these operators *should* be safe to include here.
+    public static implicit operator Rectangle(RECT rectangle)
+        => Rectangle.FromLTRB(rectangle.left, rectangle.top, rectangle.right, rectangle.bottom);
+
+    public static explicit operator RECT(Rectangle rectangle)
+        => new
+        {
+            // Obtained from inspecting 'Rectangle.FromLTRB(int, int, int, int)'.
+            left = rectangle.X,
+            top = rectangle.Y,
+            right = rectangle.Width + rectangle.X,
+            bottom = rectangle.Height + rectangle.Y,
+        };
 }

--- a/sources/Interop/Windows/Windows/shared/windef/RECT.cs
+++ b/sources/Interop/Windows/Windows/shared/windef/RECT.cs
@@ -28,11 +28,11 @@ public partial struct RECT
 
     // type 'Rectangle' is from System.Drawing.Primitives which is from the base shared framework.
     // as such these operators *should* be safe to include here.
-    public static implicit operator Rectangle(RECT rectangle)
+    public static explicit operator Rectangle(RECT rectangle)
         => Rectangle.FromLTRB(rectangle.left, rectangle.top, rectangle.right, rectangle.bottom);
 
     public static explicit operator RECT(Rectangle rectangle)
-        => new
+        => new RECT()
         {
             // Obtained from inspecting 'Rectangle.FromLTRB(int, int, int, int)'.
             left = rectangle.X,


### PR DESCRIPTION
## Proposal Implementation

Adds an implicit conversion operator from ``RECT`` -> ``Rectangle`` with an explicit operator from ``Rectangle`` back to ``RECT`` when the rectangle needs converted to an ``RECT`` for calls into Windows APIs that requires it. Also with operators handling these conversions programmers would worry less on if they got their conversion between ``RECT`` <-> ``Rectangle`` correct or not by eliminating all the guess work from it. Unit tests of the operators will come soon. As such I opened this pull request as a draft.

Implements/Fixes https://github.com/terrafx/terrafx.interop.windows/issues/387.