### PR TITLE
[BUG] Fix uninitialized D3D12_RESOURCE_BARRIER flags field

### DIFF
--- a/sources/Interop/Windows/DirectX/d3dx12/d3dx12_barriers/D3D12_RESOURCE_BARRIER.Manual.cs
+++ b/sources/Interop/Windows/DirectX/d3dx12/d3dx12_barriers/D3D12_RESOURCE_BARRIER.Manual.cs
@@ -36,6 +36,7 @@ public unsafe partial struct D3D12_RESOURCE_BARRIER
         Unsafe.SkipInit(out D3D12_RESOURCE_BARRIER result);
 
         result.Type = D3D12_RESOURCE_BARRIER_TYPE_ALIASING;
+        result.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
         result.Aliasing.pResourceBefore = pResourceBefore;
         result.Aliasing.pResourceAfter = pResourceAfter;
 
@@ -48,6 +49,7 @@ public unsafe partial struct D3D12_RESOURCE_BARRIER
         Unsafe.SkipInit(out D3D12_RESOURCE_BARRIER result);
 
         result.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+        result.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
         result.Anonymous.UAV.pResource = pResource;
 
         return result;


### PR DESCRIPTION
The two modified methods (`InitAliasing` and `InitUAV`) don't zero initialize the result due to `Unsafe.SkipInit()`. This makes sense due to the union field (`Aliasing`) but it means it is possible to accidentally return uninitialized stack memory -- and this is exactly what is happening with the `Flags` field.