### PR TITLE
[IMPL] Support `IDxbcConverter` from `dxilconv.dll`

### DIFF
--- a/TerraFX.Interop.Windows.slnx
+++ b/TerraFX.Interop.Windows.slnx
@@ -189,9 +189,12 @@
   </Folder>
   <Folder Name="/generation/DirectX/dxilconv/" />
   <Folder Name="/generation/DirectX/dxilconv/DxbcConverter/">
-    <File Path="generation/DirectX/dxilconv/DxbcConverter/DxbcConverter.h" />
+    <File Path="generation/DirectX/dxilconv/DxbcConverter/dxilconv-DxbcConverter.h" />
     <File Path="generation/DirectX/dxilconv/DxbcConverter/generate.rsp" />
     <File Path="generation/DirectX/dxilconv/DxbcConverter/header.txt" />
+  </Folder>
+  <Folder Name="/generation/DirectX/dxilconv/DxbcConverter/dxc/">
+    <File Path="generation/DirectX/dxilconv/DxbcConverter/dxc/dxcapi.h" />
   </Folder>
   <Folder Name="/generation/DirectX/dxtk12/" />
   <Folder Name="/generation/DirectX/dxtk12/DirectXHelpers/">
@@ -702,6 +705,9 @@
   </Folder>
   <Folder Name="/generation/include/d3dx12/">
     <File Path="generation/include/d3dx12/d3dx12.h" />
+  </Folder>
+  <Folder Name="/generation/include/dxilconv/">
+    <File Path="generation/include/dxilconv/DxbcConverter.h" />
   </Folder>
   <Folder Name="/generation/include/dxtk12/">
     <File Path="generation/include/dxtk12/DirectXHelpers.h" />

--- a/TerraFX.Interop.Windows.slnx
+++ b/TerraFX.Interop.Windows.slnx
@@ -187,6 +187,12 @@
     <File Path="generation/DirectX/d3dx12/d3dx12_state_object/generate.rsp" />
     <File Path="generation/DirectX/d3dx12/d3dx12_state_object/header.txt" />
   </Folder>
+  <Folder Name="/generation/DirectX/dxilconv/" />
+  <Folder Name="/generation/DirectX/dxilconv/DxbcConverter/">
+    <File Path="generation/DirectX/dxilconv/DxbcConverter/DxbcConverter.h" />
+    <File Path="generation/DirectX/dxilconv/DxbcConverter/generate.rsp" />
+    <File Path="generation/DirectX/dxilconv/DxbcConverter/header.txt" />
+  </Folder>
   <Folder Name="/generation/DirectX/dxtk12/" />
   <Folder Name="/generation/DirectX/dxtk12/DirectXHelpers/">
     <File Path="generation/DirectX/dxtk12/DirectXHelpers/dxtk12-DirectXHelpers.h" />

--- a/generation/DirectX/dxilconv/DxbcConverter/DxbcConverter.h
+++ b/generation/DirectX/dxilconv/DxbcConverter/DxbcConverter.h
@@ -1,0 +1,62 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxbcConverter.h                                                           //
+// Copyright (C) Microsoft. All rights reserved.                             //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Provides declarations for the DirectX DXBC to DXIL converter component.   //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef __DXBC_CONVERTER__H__
+#define __DXBC_CONVERTER__H__
+
+#include "..\..\..\TerraFX.h"
+#include <dxcapi.h>
+
+#ifndef _MSC_VER
+extern "C"
+#endif
+    DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(_In_ REFCLSID rclsid,
+                                                       _In_ REFIID riid,
+                                                       _Out_ LPVOID *ppv);
+
+#ifndef _MSC_VER
+extern "C"
+#endif
+    DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(_In_ IMalloc *pMalloc,
+                                                        _In_ REFCLSID rclsid,
+                                                        _In_ REFIID riid,
+                                                        _Out_ LPVOID *ppv);
+
+struct __declspec(uuid("5F956ED5-78D1-4B15-8247-F7187614A041")) IDxbcConverter
+    : public IUnknown {
+  /// Create DXIL container out of DXBC shader blob.
+  virtual HRESULT STDMETHODCALLTYPE Convert(
+      _In_reads_bytes_(DxbcSize) LPCVOID pDxbc, _In_ UINT32 DxbcSize,
+      _In_opt_z_ LPCWSTR pExtraOptions,
+      _Outptr_result_bytebuffer_maybenull_(*pDxilSize) LPVOID *ppDxil,
+      _Out_ UINT32 *pDxilSize, _Outptr_result_maybenull_z_ LPWSTR *ppDiag) = 0;
+
+  /// Create DXIL LLVM module out of DXBC bytecode and DDI I/O signatures.
+  /// This is for driver consumption only.
+  virtual HRESULT STDMETHODCALLTYPE ConvertInDriver(
+      _In_reads_bytes_(pBytecode[1]) const UINT32 *pBytecode,
+      _In_opt_z_ LPCVOID pInputSignature, _In_ UINT32 NumInputSignatureElements,
+      _In_opt_z_ LPCVOID pOutputSignature,
+      _In_ UINT32 NumOutputSignatureElements,
+      _In_opt_z_ LPCVOID pPatchConstantSignature,
+      _In_ UINT32 NumPatchConstantSignatureElements,
+      _In_opt_z_ LPCWSTR pExtraOptions, _Out_ IDxcBlob **ppDxilModule,
+      _Outptr_result_maybenull_z_ LPWSTR *ppDiag) = 0;
+};
+
+__declspec(selectany) extern const CLSID
+    CLSID_DxbcConverter = {/* 4900391E-B752-4EDD-A885-6FB76E25ADDB */
+                           0x4900391e,
+                           0xb752,
+                           0x4edd,
+                           {0xa8, 0x85, 0x6f, 0xb7, 0x6e, 0x25, 0xad, 0xdb}};
+
+#endif

--- a/generation/DirectX/dxilconv/DxbcConverter/dxc/dxcapi.h
+++ b/generation/DirectX/dxilconv/DxbcConverter/dxc/dxcapi.h
@@ -1,0 +1,2 @@
+// DxbcConverter.h includes "dxc/dxcapi.h", so we created this forwarding header to avoid modifying DxbcConverter.h.
+#include <dxcapi.h>

--- a/generation/DirectX/dxilconv/DxbcConverter/dxilconv-DxbcConverter.h
+++ b/generation/DirectX/dxilconv/DxbcConverter/dxilconv-DxbcConverter.h
@@ -1,0 +1,4 @@
+// Disable the non-portable search warning for our "dxc/dxcapi.h" forwarding header
+#pragma clang diagnostic ignored "-Wmicrosoft-include"
+#include "..\..\..\TerraFX.h"
+#include <DxbcConverter.h>

--- a/generation/DirectX/dxilconv/DxbcConverter/generate.rsp
+++ b/generation/DirectX/dxilconv/DxbcConverter/generate.rsp
@@ -1,7 +1,7 @@
 @../../../settings.rsp
 @../../../remap.rsp
 --file
-DxbcConverter.h
+dxilconv-DxbcConverter.h
 --methodClassName
 DxilConv
 --namespace
@@ -10,5 +10,7 @@ TerraFX.Interop.DirectX
 ../../../../sources/Interop/Windows/DirectX/dxilconv/DxbcConverter
 --test-output
 ../../../../tests/Interop/Windows/DirectX/dxilconv/DxbcConverter
+--traverse
+../../../include/dxilconv/DxbcConverter.h
 --with-librarypath
 *=dxilconv

--- a/generation/DirectX/dxilconv/DxbcConverter/generate.rsp
+++ b/generation/DirectX/dxilconv/DxbcConverter/generate.rsp
@@ -10,7 +10,5 @@ TerraFX.Interop.DirectX
 ../../../../sources/Interop/Windows/DirectX/dxilconv/DxbcConverter
 --test-output
 ../../../../tests/Interop/Windows/DirectX/dxilconv/DxbcConverter
---include-directory
-C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/um
 --with-librarypath
 *=dxilconv

--- a/generation/DirectX/dxilconv/DxbcConverter/generate.rsp
+++ b/generation/DirectX/dxilconv/DxbcConverter/generate.rsp
@@ -1,0 +1,16 @@
+@../../../settings.rsp
+@../../../remap.rsp
+--file
+DxbcConverter.h
+--methodClassName
+DxilConv
+--namespace
+TerraFX.Interop.DirectX
+--output
+../../../../sources/Interop/Windows/DirectX/dxilconv/DxbcConverter
+--test-output
+../../../../tests/Interop/Windows/DirectX/dxilconv/DxbcConverter
+--include-directory
+C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/um
+--with-librarypath
+*=dxilconv

--- a/generation/DirectX/dxilconv/DxbcConverter/header.txt
+++ b/generation/DirectX/dxilconv/DxbcConverter/header.txt
@@ -1,0 +1,4 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.

--- a/generation/include/dxilconv/DxbcConverter.h
+++ b/generation/include/dxilconv/DxbcConverter.h
@@ -12,8 +12,7 @@
 #ifndef __DXBC_CONVERTER__H__
 #define __DXBC_CONVERTER__H__
 
-#include "..\..\..\TerraFX.h"
-#include <dxcapi.h>
+#include "dxc/dxcapi.h"
 
 #ifndef _MSC_VER
 extern "C"

--- a/generation/settings.rsp
+++ b/generation/settings.rsp
@@ -46,6 +46,7 @@ header.txt
 ../../../include/d3d12
 ../../../include/d3d12on7
 ../../../include/d3dx12
+../../../include/dxilconv
 ../../../include/dxtk12
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.28000.0/shared
 C:/Program Files (x86)/Windows Kits/10/Include/10.0.28000.0/ucrt

--- a/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/CLSID.cs
+++ b/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/CLSID.cs
@@ -1,0 +1,40 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop.DirectX;
+
+namespace TerraFX.Interop.Windows;
+
+public static partial class CLSID
+{
+    [NativeTypeName("const CLSID")]
+    public static ref readonly Guid CLSID_DxbcConverter
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data = [
+                0x1E, 0x39, 0x00, 0x49,
+                0x52, 0xB7,
+                0xDD, 0x4E,
+                0xA8,
+                0x85,
+                0x6F,
+                0xB7,
+                0x6E,
+                0x25,
+                0xAD,
+                0xDB
+            ];
+
+            Debug.Assert(data.Length == Unsafe.SizeOf<Guid>());
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+}

--- a/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/DxilConv.cs
+++ b/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/DxilConv.cs
@@ -1,0 +1,21 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
+
+using System;
+using System.Runtime.InteropServices;
+using TerraFX.Interop.Windows;
+
+namespace TerraFX.Interop.DirectX;
+
+public static unsafe partial class DxilConv
+{
+    /// <include file='DxilConv.xml' path='doc/member[@name="DxilConv.DxcCreateInstance"]/*' />
+    [DllImport("dxilconv", ExactSpelling = true)]
+    public static extern HRESULT DxcCreateInstance([NativeTypeName("const IID &")] Guid* rclsid, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("LPVOID *")] void** ppv);
+
+    /// <include file='DxilConv.xml' path='doc/member[@name="DxilConv.DxcCreateInstance2"]/*' />
+    [DllImport("dxilconv", ExactSpelling = true)]
+    public static extern HRESULT DxcCreateInstance2(IMalloc* pMalloc, [NativeTypeName("const IID &")] Guid* rclsid, [NativeTypeName("const IID &")] Guid* riid, [NativeTypeName("LPVOID *")] void** ppv);
+}

--- a/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/IDxbcConverter.cs
+++ b/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/IDxbcConverter.cs
@@ -1,0 +1,93 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop.Windows;
+using static TerraFX.Interop.Windows.IID;
+
+namespace TerraFX.Interop.DirectX;
+
+/// <include file='IDxbcConverter.xml' path='doc/member[@name="IDxbcConverter"]/*' />
+[Guid("5F956ED5-78D1-4B15-8247-F7187614A041")]
+[NativeTypeName("struct IDxbcConverter : IUnknown")]
+[NativeInheritance("IUnknown")]
+public unsafe partial struct IDxbcConverter : IDxbcConverter.Interface, INativeGuid
+{
+    static Guid* INativeGuid.NativeGuid => (Guid*)Unsafe.AsPointer(in IID_IDxbcConverter);
+
+    public void** lpVtbl;
+
+    /// <inheritdoc cref="IUnknown.QueryInterface" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(0)]
+    public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
+    {
+        return ((delegate* unmanaged[MemberFunction]<IDxbcConverter*, Guid*, void**, int>)(lpVtbl[0]))((IDxbcConverter*)Unsafe.AsPointer(ref this), riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="IUnknown.AddRef" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(1)]
+    [return: NativeTypeName("ULONG")]
+    public uint AddRef()
+    {
+        return ((delegate* unmanaged[MemberFunction]<IDxbcConverter*, uint>)(lpVtbl[1]))((IDxbcConverter*)Unsafe.AsPointer(ref this));
+    }
+
+    /// <inheritdoc cref="IUnknown.Release" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(2)]
+    [return: NativeTypeName("ULONG")]
+    public uint Release()
+    {
+        return ((delegate* unmanaged[MemberFunction]<IDxbcConverter*, uint>)(lpVtbl[2]))((IDxbcConverter*)Unsafe.AsPointer(ref this));
+    }
+
+    /// <include file='IDxbcConverter.xml' path='doc/member[@name="IDxbcConverter.Convert"]/*' />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(3)]
+    public HRESULT Convert([NativeTypeName("LPCVOID")] void* pDxbc, [NativeTypeName("UINT32")] uint DxbcSize, [NativeTypeName("LPCWSTR")] char* pExtraOptions, [NativeTypeName("LPVOID *")] void** ppDxil, [NativeTypeName("UINT32 *")] uint* pDxilSize, [NativeTypeName("LPWSTR *")] char** ppDiag)
+    {
+        return ((delegate* unmanaged[MemberFunction]<IDxbcConverter*, void*, uint, char*, void**, uint*, char**, int>)(lpVtbl[3]))((IDxbcConverter*)Unsafe.AsPointer(ref this), pDxbc, DxbcSize, pExtraOptions, ppDxil, pDxilSize, ppDiag);
+    }
+
+    /// <include file='IDxbcConverter.xml' path='doc/member[@name="IDxbcConverter.ConvertInDriver"]/*' />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(4)]
+    public HRESULT ConvertInDriver([NativeTypeName("const UINT32 *")] uint* pBytecode, [NativeTypeName("LPCVOID")] void* pInputSignature, [NativeTypeName("UINT32")] uint NumInputSignatureElements, [NativeTypeName("LPCVOID")] void* pOutputSignature, [NativeTypeName("UINT32")] uint NumOutputSignatureElements, [NativeTypeName("LPCVOID")] void* pPatchConstantSignature, [NativeTypeName("UINT32")] uint NumPatchConstantSignatureElements, [NativeTypeName("LPCWSTR")] char* pExtraOptions, IDxcBlob** ppDxilModule, [NativeTypeName("LPWSTR *")] char** ppDiag)
+    {
+        return ((delegate* unmanaged[MemberFunction]<IDxbcConverter*, uint*, void*, uint, void*, uint, void*, uint, char*, IDxcBlob**, char**, int>)(lpVtbl[4]))((IDxbcConverter*)Unsafe.AsPointer(ref this), pBytecode, pInputSignature, NumInputSignatureElements, pOutputSignature, NumOutputSignatureElements, pPatchConstantSignature, NumPatchConstantSignatureElements, pExtraOptions, ppDxilModule, ppDiag);
+    }
+
+    public interface Interface : IUnknown.Interface
+    {
+        [VtblIndex(3)]
+        HRESULT Convert([NativeTypeName("LPCVOID")] void* pDxbc, [NativeTypeName("UINT32")] uint DxbcSize, [NativeTypeName("LPCWSTR")] char* pExtraOptions, [NativeTypeName("LPVOID *")] void** ppDxil, [NativeTypeName("UINT32 *")] uint* pDxilSize, [NativeTypeName("LPWSTR *")] char** ppDiag);
+
+        [VtblIndex(4)]
+        HRESULT ConvertInDriver([NativeTypeName("const UINT32 *")] uint* pBytecode, [NativeTypeName("LPCVOID")] void* pInputSignature, [NativeTypeName("UINT32")] uint NumInputSignatureElements, [NativeTypeName("LPCVOID")] void* pOutputSignature, [NativeTypeName("UINT32")] uint NumOutputSignatureElements, [NativeTypeName("LPCVOID")] void* pPatchConstantSignature, [NativeTypeName("UINT32")] uint NumPatchConstantSignatureElements, [NativeTypeName("LPCWSTR")] char* pExtraOptions, IDxcBlob** ppDxilModule, [NativeTypeName("LPWSTR *")] char** ppDiag);
+    }
+
+    public partial struct Vtbl<TSelf>
+        where TSelf : unmanaged, Interface
+    {
+        [NativeTypeName("HRESULT (const IID &, void **) __attribute__((stdcall))")]
+        public delegate* unmanaged[MemberFunction]<TSelf*, Guid*, void**, int> QueryInterface;
+
+        [NativeTypeName("ULONG () __attribute__((stdcall))")]
+        public delegate* unmanaged[MemberFunction]<TSelf*, uint> AddRef;
+
+        [NativeTypeName("ULONG () __attribute__((stdcall))")]
+        public delegate* unmanaged[MemberFunction]<TSelf*, uint> Release;
+
+        [NativeTypeName("HRESULT (LPCVOID, UINT32, LPCWSTR, LPVOID *, UINT32 *, LPWSTR *) __attribute__((stdcall))")]
+        public delegate* unmanaged[MemberFunction]<TSelf*, void*, uint, char*, void**, uint*, char**, int> Convert;
+
+        [NativeTypeName("HRESULT (const UINT32 *, LPCVOID, UINT32, LPCVOID, UINT32, LPCVOID, UINT32, LPCWSTR, IDxcBlob **, LPWSTR *) __attribute__((stdcall))")]
+        public delegate* unmanaged[MemberFunction]<TSelf*, uint*, void*, uint, void*, uint, void*, uint, char*, IDxcBlob**, char**, int> ConvertInDriver;
+    }
+}

--- a/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/IID.cs
+++ b/sources/Interop/Windows/DirectX/dxilconv/DxbcConverter/IID.cs
@@ -1,0 +1,38 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop.Windows;
+
+public static partial class IID
+{
+    public static ref readonly Guid IID_IDxbcConverter
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data = [
+                0xD5, 0x6E, 0x95, 0x5F,
+                0xD1, 0x78,
+                0x15, 0x4B,
+                0x82,
+                0x47,
+                0xF7,
+                0x18,
+                0x76,
+                0x14,
+                0xA0,
+                0x41
+            ];
+
+            Debug.Assert(data.Length == Unsafe.SizeOf<Guid>());
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+}

--- a/tests/Interop/Windows/DirectX/dxilconv/DxbcConverter/CLSIDTests.cs
+++ b/tests/Interop/Windows/DirectX/dxilconv/DxbcConverter/CLSIDTests.cs
@@ -1,0 +1,21 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
+
+using NUnit.Framework;
+using System;
+using static TerraFX.Interop.Windows.CLSID;
+
+namespace TerraFX.Interop.Windows.UnitTests;
+
+/// <summary>Provides validation of the <see cref="CLSID" /> class.</summary>
+public static partial class CLSIDTests
+{
+    /// <summary>Validates that the value of the <see cref="CLSID_DxbcConverter" /> property is correct.</summary>
+    [Test]
+    public static void CLSID_DxbcConverterTest()
+    {
+        Assert.That(CLSID_DxbcConverter, Is.EqualTo(new Guid(0x4900391e, 0xb752, 0x4edd, 0xa8, 0x85, 0x6f, 0xb7, 0x6e, 0x25, 0xad, 0xdb)));
+    }
+}

--- a/tests/Interop/Windows/DirectX/dxilconv/DxbcConverter/IDxbcConverterTests.cs
+++ b/tests/Interop/Windows/DirectX/dxilconv/DxbcConverter/IDxbcConverterTests.cs
@@ -1,0 +1,22 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from https://github.com/microsoft/DirectXShaderCompiler/blob/main/projects/dxilconv/include/DxbcConverter.h
+// Original source is Copyright © Microsoft. All rights reserved. Licensed under the University of Illinois Open Source License.
+
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static TerraFX.Interop.Windows.IID;
+
+namespace TerraFX.Interop.DirectX.UnitTests;
+
+/// <summary>Provides validation of the <see cref="IDxbcConverter" /> struct.</summary>
+public static unsafe partial class IDxbcConverterTests
+{
+    /// <summary>Validates that the <see cref="Guid" /> of the <see cref="IDxbcConverter" /> struct is correct.</summary>
+    [Test]
+    public static void GuidOfTest()
+    {
+        Assert.That(typeof(IDxbcConverter).GUID, Is.EqualTo(IID_IDxbcConverter));
+    }
+}


### PR DESCRIPTION
This implements support for `IDxbcConverter` from `dxilconv.dll` in `C:\Windows\System32` using the header from [DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler).

* I created a new class `DxilConv` so that `DxcCreateInstance` and `DxcCreateInstance2` wouldn't conflict with the ones in `DirectX` for `dxcompiler.dll`. Should I have renamed them to `DxilConvCreateInstance` / `DxilConvCreateInstance2` and put them in the `DirectX` class?
* Generated with ClangSharpPInvokeGenerator 20.1.8.2

Resolves #416
